### PR TITLE
아크 오류 일부 수정, 인피니티 수정, 시그너스의 축복 작성

### DIFF
--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -82,6 +82,8 @@ class JobGenerator(ck.JobGenerator):
         PlainBuff = core.BuffSkill("플레인 버프", 0, 60 * 1000, cooltime = -1).wrap(core.BuffSkillWrapper)
         
         ScarletChargeDrive = core.DamageSkill("스칼렛 차지 드라이브", 540, 350, 6, cooltime = 3000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        ScarletChargeDrive_After = core.DamageSkill("스칼렛 차지 드라이브(후속타)", 0, 350, 6).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        
         ScarletSpell = core.DamageSkill("스칼렛 스펠", 0, 220, 5).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         ScarletSpell_Infinity = core.DamageSkill("스칼렛 스펠(인피니티)", 0, 220, 5 * 5, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
@@ -98,6 +100,10 @@ class JobGenerator(ck.JobGenerator):
         CrawlingFear = core.DamageSkill("기어다니는 공포", 690, 1390, 12, cooltime = 60*1000).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
         AbyssChargeDrive = core.DamageSkill("어비스 차지 드라이브", 630, 340, 4, cooltime = 9000).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        AbyssChargeDrive_After = core.DamageSkill("어비스 차지 드라이브(후속타)", 0, 410, 6).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        
+        # 어비스 스펠: 70%로 2번 공격하는 장판, 10초동안 13번
+        # SummonSkill로 변경 필요
         AbyssSpell = core.DamageSkill("어비스 스펠", 0, 410, 6).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         AbyssSpell_Infinity = core.DamageSkill("어비스 스펠(인피니티)", 0, 410, 6 * 5, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         
@@ -105,10 +111,12 @@ class JobGenerator(ck.JobGenerator):
         
         AbyssBuff = core.BuffSkill("어비스 버프", 0, 60*1000, cooltime = -1, pdamage = 20, boss_pdamage = 30, armor_ignore = 20).wrap(core.BuffSkillWrapper)
         
-        RaptRestriction = core.DamageSkill("황홀한 구속", 690, 500, 6, cooltime = 180 * 1000).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        RaptRestrictionSummon = core.SummonSkill("황홀한 구속(소환)", 0, 300, 400, 3, 9000, cooltime = -1).setV(vEhc, 7, 2, False).wrap(core.SummonSkillWrapper)  #임의주기 300ms, DPM 미사용.
+        RaptRestriction = core.DamageSkill("황홀한 구속", 690, 600, 6, cooltime = 180 * 1000).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        RaptRestrictionSummon = core.SummonSkill("황홀한 구속(소환)", 0, 450, 400, 3, 9000, cooltime = -1).setV(vEhc, 7, 2, False).wrap(core.SummonSkillWrapper)  #임의주기 300ms, DPM 미사용.
         RaptRestrictionEnd = core.DamageSkill("황홀한 구속(종결)", 0, 1000, 8, cooltime = -1).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
+        # TODO: 딜레이 추가, 5차 강화 정보 갱신, 딜사이클 등록, 2회 발동기능 추가
+        UnstoppableImpulse = core.DamageSkill("멈출 수 없는 충동", 0, 435, 5, cooltime = 6000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
         ##### 스펙터 상태일 때 #####
         UpcomingDeath = core.DamageSkill("다가오는 죽음", 0, 450, 2).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
@@ -119,22 +127,24 @@ class JobGenerator(ck.JobGenerator):
         
         EndlessBadDream = core.DamageSkill("끝나지 않는 흉몽", 540, 445, 6).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) # 끝나지 않는 악몽 변형
         
-        UnfulfilledHunger = core.DamageSkill("채워지지 않는 굶주림", 750, 320, 7, cooltime = 5000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)  #거스트 차지 드라이브 변형
+        UnfulfilledHunger = core.DamageSkill("채워지지 않는 굶주림", 750, 510, 7, cooltime = 5000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)  #거스트 차지 드라이브 변형
         UnfulfilledHunger_Link = core.DamageSkill("채워지지 않는 굶주림(연계)", 750 - 240 - 240, 320, 7, cooltime = 5000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
         UncontrollableChaos = core.DamageSkill("겉잡을 수 없는 혼돈", 810, 440, 12, cooltime = 9000).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper) #어비스 차지 드라이브 변형
         UncontrollableChaos_Link = core.DamageSkill("겉잡을 수 없는 혼돈(연계)", 810 - 240 - 240, 440, 12, cooltime = 9000).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         
+        # TODO: 딜레이 추가, 5차 강화 정보 갱신, 딜사이클 등록, 2회 발동기능 추가
+        TenaciousInstinct = core.DamageSkill("멈출 수 없는 본능", 0, 460, 6, cooltime = 6000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
         
-        
-        # 하이처
-        ChargeSpellAmplification = core.BuffSkill("차지 스펠 엠플리피케이션", 720, 60000, att = 30, crit = 20, pdamage = 20, armor_ignore = 20, boss_pdamage = 20, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
+        # 하이퍼
+        ChargeSpellAmplification = core.BuffSkill("차지 스펠 엠플리피케이션", 720, 60000, att = 30, crit = 20, pdamage = 20, armor_ignore = 20, boss_pdamage = 30, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
         
         
         EndlessPainTick = core.DamageSkill("끝없는 고통(틱)", 200,  300, 3).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)   #15타
         EndlessPain = core.DamageSkill("끝없는 고통", 0, 0, 0, cooltime = 60 * 1000).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper) # onTick==> 다가오는 죽음
-        EndlessPainEnd = core.DamageSkill("끝없는 고통(종결)", 0, 700*2, 12).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        # 딜레이 : 1200ms 또는 1050ms(이후 연계 시). 일단 1200으로.
+        EndlessPainEnd = core.DamageSkill("끝없는 고통(종결)", 1200, 700*2, 12).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
         WraithOfGod = core.BuffSkill("레이스 오브 갓", 0, 60*1000, pdamage = 10, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
         
@@ -156,16 +166,16 @@ class JobGenerator(ck.JobGenerator):
         
         MemoryOfSource = core.DamageSkill("근원의 기억", 0, 0, 0, cooltime = 200 * 1000).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         MemoryOfSourceTick = core.DamageSkill("근원의 기억(틱)", 250, 400 + 16 * vEhc.getV(1,1), 6).wrap(core.DamageSkillWrapper)    # 43타
-        MemoryOfSourceEnd = core.DamageSkill("근원의 기억(종결)", 0, 120 + 24 * vEhc.getV(1,1), 12 * 6).wrap(core.DamageSkillWrapper)
+        MemoryOfSourceEnd = core.DamageSkill("근원의 기억(종결)", 0, 1200 + 48 * vEhc.getV(1,1), 12 * 6).wrap(core.DamageSkillWrapper)
         MemoryOfSourceBuff = core.BuffSkill("근원의 기억(버프)", 0, 30 * 1000, cooltime = -1).wrap(core.BuffSkillWrapper) #정신력 소모되지 않음
         
         
-        InfinitySpell = core.BuffSkill("인피니티 스펠", 720, (40 + vEhc.getV(0,0)) * 1000, cooltime = 240 * 1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        InfinitySpell = core.BuffSkill("인피니티 스펠", 720, (40 + 2*vEhc.getV(0,0)) * 1000, cooltime = 240 * 1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         #스펠이 남은 수많큼 차지됨
         #심연의 기운은 세개씩 추가 생성됨
         
         EvanescentNightmare = core.DamageSkill("새어나오는 악몽", 0, 500 + 20*vEhc.getV(2,2), 9, cooltime = 10 * 1000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
-        EvanescentBadDream = core.DamageSkill("새어나오는 흉몽", 0, 500 + 20*vEhc.getV(2,2), 9, cooltime = 10 * 1000).wrap(core.DamageSkillWrapper)
+        EvanescentBadDream = core.DamageSkill("새어나오는 흉몽", 0, 600 + 24*vEhc.getV(2,2), 9, cooltime = 10 * 1000).wrap(core.DamageSkillWrapper)
         
         EvanescentNightmareTimer = core.BuffSkill("새어나오는 악몽(타이머)", 0, 10000, cooltime = -1).wrap(core.BuffSkillWrapper)
         EvanescentBadDreamTimer = core.BuffSkill("새어나오는 흉몽(타이머)", 0, 10000 - 1000 - 1000, cooltime = -1).wrap(core.BuffSkillWrapper)   #악몽만 사용 가정
@@ -195,6 +205,8 @@ class JobGenerator(ck.JobGenerator):
         ScarletChargeDrive_Link.onBefore(PlainChargeDrive)
         ScarletSpell_Connected.onAfter(ScarletBuff)
         
+        ScarletChargeDrive.onAfter(ScarletChargeDrive_After)
+
         GustSpell_Connected = core.OptionalElement(InfinitySpell.is_active, GustSpell_Infinity, GustSpell)
         GustChargeDrive.onAfter(GustSpell_Connected)
         GustChargeDrive_Link.onAfter(GustSpell_Connected)
@@ -205,6 +217,8 @@ class JobGenerator(ck.JobGenerator):
         AbyssChargeDrive.onAfter(AbyssSpell_Connected)
         AbyssChargeDrive_Link.onAfter(AbyssSpell_Connected)
         AbyssChargeDrive_Link.onBefore(PlainChargeDrive)
+
+        AbyssChargeDrive.onAfter(AbyssChargeDrive_After)
         
         RaptRestriction.onAfter(RaptRestrictionSummon)
         RaptRestriction.onAfter(RaptRestrictionEnd)

--- a/dpmModule/jobs/jobbranch/pirates.py
+++ b/dpmModule/jobs/jobbranch/pirates.py
@@ -10,6 +10,13 @@ class OverdriveWrapper:
         self.Overdrive = core.BuffSkill("오버드라이브", 540, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
         self.OverdrivePenalty = core.BuffSkill("오버드라이브(페널티)", 0, (40 - 0.2*vEhc.getV(num1, num2))*1000, cooltime = -1, att = -0.15 * WEAPON_ATT).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
 
+# 오버드라이브 함수 버전 (테스트 아직 안함)
+def OverdirveWrapper2(vEhc, num1, num2, WEAPON_ATT):
+    Overdrive = core.BuffSkill("오버드라이브", 540, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
+    OverdrivePenalty = core.BuffSkill("오버드라이브(페널티)", 0, (40 - 0.2*vEhc.getV(num1, num2))*1000, cooltime = -1, att = -0.15 * WEAPON_ATT).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
+    Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
+    return Overdrive
+
 def LoadedDicePassiveWrapper(vEhc, num1, num2):
     LoadedDicePassive = core.InformedCharacterModifier("로디드 다이스(패시브)", att = vEhc.getV(num1, num2) + 10)
     return LoadedDicePassive

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -1,20 +1,13 @@
 from ...kernel import core
 from ...kernel.core import VSkillModifier as V
 from ...character import characterKernel as ck
-# 모험가 공용 5차스킬 통합코드
+# 모험가 및 모험가 직업 공용 5차스킬 통합코드
 
-#TODO: 얼닼사, 블리츠실드, 이볼브, 파이렛 플래그
-'''
-class MapleHero2:
-    #vEhc.getV(var1,var2)
-    def __init__(self, vEhc):
-        return
-    def mapleHero2(var1, var2):
-        return core.BuffSkill("메이플월드 여신의 축복")
-'''
+#TODO: 얼닼사
+
 # 모험가 법사
 # 3% 증가로 알고있는데... 확인필요
-# TODO : 재사용 대기시간 초기화 미적용으로 변경
+
 class InfinityWrapper(core.BuffSkillWrapper):
     def __init__(self, serverlag = 3):
         skill = core.BuffSkill("인피니티", 960, 40000, cooltime = 180 * 1000, rem = True, red = False)
@@ -38,6 +31,8 @@ class InfinityWrapper(core.BuffSkillWrapper):
         return super(InfinityWrapper, self)._use(rem = rem, red = red)
 
 # 이하 모든 코드 테스트 필요
+
+# 레지스탕스도 이 코드를 사용
 def MapleHeroes2Wrapper(vEhc, num1, num2, level):
     MapleHeroes2 = core.BuffSkill("메이플월드 여신의 축복", 450, 60*1000, stat_main = 0.01 * (100 + 10 * vEhc.getV(num1, num2)) * (25 + level * 5), pdamage = 5 + vEhc.getV(num1, num2) // 2, cooltime = 180*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     return MapleHeroes2
@@ -49,10 +44,10 @@ def PirateFlagWrapper(vEhc, num1, num2, level):
 # 작성중, 2초 후 폭발 가정
 def BlitzShieldWrappers(vEhc, num1, num2):
     # 딜레이 추가 필요
-    BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 0, 2000, cooltime = 15000).wrap(core.BuffSkillWrapper)
+    BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 600, 2000, cooltime = 15000).wrap(core.BuffSkillWrapper)
     BlitzShield = core.DamageSkill("블리츠 실드", 2000, vEhc.getV(num1, num2)*20+500, 5).wrap(core.DamageSkillWrapper)
-    #BlitzShieldDummy.onAfter(BlitzShield)
-    return BlitzShieldDummy, BlitzShield
+    BlitzShieldDummy.onAfter(BlitzShield)
+    return BlitzShieldDummy
 
 # 아직 사용하지 말것! 연계 설정 추가 필요
 def EvolveWrapper(vEhc, num1, num2):

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -48,19 +48,18 @@ def PirateFlagWrapper(vEhc, num1, num2, level):
 
 # 작성중, 2초 후 폭발 가정
 def BlitzShieldWrappers(vEhc, num1, num2):
-    BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 0, 2000, cooltime = -1).wrap(core.BuffSkillWrapper)
-    BlitzShield = core.DamageSkill("블리츠 실드", 0, vEhc.getV(num1, num2)*20+500, 5, cooltime = 15000).isV(vEhc, num1, num2).wrap(core.DamageSkillWrapper)
+    # 딜레이 추가 필요
+    BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 0, 2000, cooltime = 15000).wrap(core.BuffSkillWrapper)
+    BlitzShield = core.DamageSkill("블리츠 실드", 2000, vEhc.getV(num1, num2)*20+500, 5).wrap(core.DamageSkillWrapper)
+    #BlitzShieldDummy.onAfter(BlitzShield)
+    return BlitzShieldDummy, BlitzShield
+
+# 아직 사용하지 말것! 연계 설정 추가 필요
+def EvolveWrapper(vEhc, num1, num2):
+    Evolve = core.BuffSkill("이볼브", 600, 3330, 450+vEhc.getV(num1, num2)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(num1, num2)))*1000).isV(vEhc,num1, num2).wrap(core.SummonSkillWrapper)
+    return Evolve
+
 '''
-블리츠 실드
-HP 5% 소비, 최대 HP의 20%의[23] 피해를 막아주는 보호막을 5초간 생성
-보호막의 지속시간이 끝나거나 스킬을 다시 사용하면 보호막이 폭발하여 최대 12명의 적을 1000%의[(스킬 레벨*20+500)%의 데미지] 데미지로 5번 공격
-보호막이 생성된 후 2초가 지나야 스킬을 다시 사용하여 수동 폭발 가능
-재사용 대기시간 15초
-
-이볼브
-MP 800 소비, 40초 동안 강화되어 최대 10명의 적을 825%[(스킬 레벨*15+450)%의 데미지] 데미지로 7번 공격
-재사용 대기시간 108초[(121-스킬 레벨*0.5)초. 소숫점은 버린다.]
-
 얼티밋 다크 사이트
 MP 850 소비, 30초 동안 다크 사이트 중 공격 및 스킬 사용 시 은신이 해제되지 않음
 다크 사이트 중 공격 시 최종 데미지 15%[기본 10%에서 5레벨마다 1% 증가한다.] 증가, 어드밴스드 다크 사이트의 최종 데미지 증가와 합적용

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -17,7 +17,7 @@ class MapleHero2:
 # TODO : 재사용 대기시간 초기화 미적용으로 변경
 class InfinityWrapper(core.BuffSkillWrapper):
     def __init__(self, serverlag = 3):
-        skill = core.BuffSkill("인피니티", 960, 40000, cooltime = 180 * 1000, rem = True, red = True)
+        skill = core.BuffSkill("인피니티", 960, 40000, cooltime = 180 * 1000, rem = True, red = False)
         super(InfinityWrapper, self).__init__(skill)
         self.passedTime = 0
         self.serverlag = serverlag
@@ -29,7 +29,7 @@ class InfinityWrapper(core.BuffSkillWrapper):
             
     def get_modifier(self):
         if self.onoff:
-            return core.CharacterModifier(pdamage_indep = (70 + 4 * (self.passedTime // ((4+self.serverlag)*1000))) )
+            return core.CharacterModifier(pdamage_indep = (70 + 3 * (self.passedTime // ((4+self.serverlag)*1000))) )
         else:
             return core.CharacterModifier()
         

--- a/dpmModule/jobs/jobclass/cygnus.py
+++ b/dpmModule/jobs/jobclass/cygnus.py
@@ -8,14 +8,43 @@ def PhalanxChargeWrapper(vEhc, num1, num2):
     PhalanxCharge = core.DamageSkill("시그너스 팔랑크스", 780, 450 + 18*vEhc.getV(num1, num2), 40 + vEhc.getV(num1, num2), cooltime = 30 * 1000).isV(vEhc, num1, num2).wrap(core.DamageSkillWrapper)
     return PhalanxCharge
 
-# 인피니티와 유사한 매커니즘이므로 별도의 클래스 작성 필요
-#세부값 확인해서 변경필요
-#MP 500 소비, 45초 동안 데미지 25% 증가, 일정 시간마다 HP 4%씩 회복 및 데미지 3% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 90%까지 증가
-#MP 500 소비, 45초 동안 데미지 25% 증가 및 최대 HP의 일정 비율로 피해를 입히는 공격을 포함한 피격 데미지 5% 감소, 일정 시간마다 HP 7%씩 회복 및 데미지 5% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 120%까지 증가
+class CygnusBlessWrapper(core.BuffSkillWrapper):
+    def __init__(self, enhancer, skill_importance, enhance_importance, serverlag = 3, level = 230):
+        self.isUpgraded = (level >= 245) 
+        self.enhancer = enhancer
+        self.skill_importance = skill_importance
+        self.enhance_importance = enhance_importance
+        
+        # 스킬 딜레이, 쿨타임 확인 필요
+        skill = core.BuffSkill("초월자 시그너스의 축복" if isUpgraded else "여제 시그너스의 축복" , 450, 45000, cooltime = 240*1000).wrap(core.BuffSkillWrapper)
+        super(CygnusBlessWrapper, self).__init__(skill)
 
-def CygnusBlessWrapper(vEhc, num1, num2, LEVEL):
-    if LEVEL < 245:
-        CygnusBless = core.BuffSkill("여제 시그너스의 축복", 450, (30+vEhc.getV(num1, num2)//2)*1000, pdamage = (30+vEhc.getV(num1, num2)//5) *1.2 + 20, cooltime = 240*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
-    else:
-        CygnusBless = core.BuffSkill("초월자 시그너스의 축복", 450, (30+vEhc.getV(num1, num2)//2)*1000, pdamage = (30+vEhc.getV(num1, num2)//5) *1.2 + 20, cooltime = 240*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
-    return CygnusBless
+        self.passedTime = 0
+        self.serverlag = serverlag
+
+    def spend_time(self, time):
+        if self.onoff:
+            self.passedTime += time
+        super(CygnusBlessWrapper, self).spend_time(time)
+    
+    #세부값 확인해서 변경필요
+    #MP 500 소비, 45초 동안 데미지 25% 증가, 일정 시간마다 HP 4%씩 회복 및 데미지 3% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 90%까지 증가
+    #MP 500 소비, 45초 동안 데미지 25% 증가 및 최대 HP의 일정 비율로 피해를 입히는 공격을 포함한 피격 데미지 5% 감소, 일정 시간마다 HP 7%씩 회복 및 데미지 5% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 120%까지 증가
+
+    def calc_damage(self):
+        interval = 4
+        if self.isUpgraded:
+            pd_value = min(25 + 5 * (self.passedTime // ((interval + self.serverlag) * 1000)), 120)
+        else:
+            pd_value = min(25 + 3 * (self.passedTime // ((interval + self.serverlag) * 1000)), 90)
+        return pd_value
+
+    def get_modifier(self):
+        if self.onoff:
+            return core.CharacterModifier(pdamage = self.calc_damage())
+        else:
+            return core.CharacterModifier()
+        
+    def _use(self, rem = 0, red = 0):
+        self.passedTime = 0
+        return super(CygnusBlessWrapper, self)._use(rem = rem, red = red)

--- a/dpmModule/jobs/jobclass/cygnus.py
+++ b/dpmModule/jobs/jobclass/cygnus.py
@@ -15,10 +15,19 @@ class CygnusBlessWrapper(core.BuffSkillWrapper):
         self.skill_importance = skill_importance
         self.enhance_importance = enhance_importance
         
-        # 스킬 딜레이, 쿨타임 확인 필요
-        skill = core.BuffSkill("초월자 시그너스의 축복" if isUpgraded else "여제 시그너스의 축복" , 450, 45000, cooltime = 240*1000).wrap(core.BuffSkillWrapper)
+        skill = core.BuffSkill("초월자 시그너스의 축복" if isUpgraded else "여제 시그너스의 축복" , 630, 45000, cooltime = 240*1000).wrap(core.BuffSkillWrapper)
         super(CygnusBlessWrapper, self).__init__(skill)
 
+        self.damage_point = 4 + (enhancer.getV(self.skill_importance, self.enhance_importance))//15
+        self.damage_limit = 90
+        #interval: 데미지 증가 주기 (모름)
+        self.interval = 4
+        
+        # 업그레이드 상태일경우 해당 스펙 적용
+        if self.isUpgraded:
+            self.damage_point += 2
+            self.damage_limit += 30
+            
         self.passedTime = 0
         self.serverlag = serverlag
 
@@ -26,22 +35,11 @@ class CygnusBlessWrapper(core.BuffSkillWrapper):
         if self.onoff:
             self.passedTime += time
         super(CygnusBlessWrapper, self).spend_time(time)
-    
-    #세부값 확인해서 변경필요
-    #MP 500 소비, 45초 동안 데미지 25% 증가, 일정 시간마다 HP 4%씩 회복 및 데미지 3% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 90%까지 증가
-    #MP 500 소비, 45초 동안 데미지 25% 증가 및 최대 HP의 일정 비율로 피해를 입히는 공격을 포함한 피격 데미지 5% 감소, 일정 시간마다 HP 7%씩 회복 및 데미지 5% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 120%까지 증가
-
-    def calc_damage(self):
-        interval = 4
-        if self.isUpgraded:
-            pd_value = min(25 + 5 * (self.passedTime // ((interval + self.serverlag) * 1000)), 120)
-        else:
-            pd_value = min(25 + 3 * (self.passedTime // ((interval + self.serverlag) * 1000)), 90)
-        return pd_value
 
     def get_modifier(self):
+        
         if self.onoff:
-            return core.CharacterModifier(pdamage = self.calc_damage())
+            return core.CharacterModifier(pdamage = min(enhancer.getV(self.skill_importance, self.enhance_importance) + self.damage_point * (self.passedTime // ((self.interval + self.serverlag) * 1000)), self.damage_limit))
         else:
             return core.CharacterModifier()
         

--- a/dpmModule/jobs/jobclass/demon.py
+++ b/dpmModule/jobs/jobclass/demon.py
@@ -11,6 +11,13 @@ from functools import partial
 
 '''
 
+class AnotherWorldGoddessWrapper(core.BuffSkillWrapper):
+    def __init__(self, vEhc, num1, num2):
+        self.vlevel = vEhc.getV(num1, num2)
+        vlevel = self.vlevel
+        super(AnotherWorldGoddessWrapper, self).__init__(skill = core.BuffSkill("이계 여신의 축복", num1, num2, pdamage_indep=6+(vlevel-1)//5).isV(vEhc, num1, num2))
+        self.skillList = [core.BuffSkill("회복의 축복"), core.BuffSkill("방패의 축복"), core.BuffSkill("보호의 축복"), core.BuffSkill(("이계의 공허"))]
+
 '''
 최대 HP의 5% 소비, 40초 동안 최종 데미지 [1레벨에서 6%, 6, 11, 16, 21, 26레벨에서 1%씩 증가] 증가, 일정 시간마다 각종 축복 및 공격을 시전, 축복 시전 시 이전 축복이 남아있다면 소멸
 회복의 축복: DF/PP/HP 중 자신이 사용하는 쪽을 최대치의 27%[(15 + 스킬레벨/2)%, 소수점은 버린다.] 회복, 특정한 회복 불가 상황에도 회복 가능

--- a/dpmModule/jobs/jobclass/nova.py
+++ b/dpmModule/jobs/jobclass/nova.py
@@ -4,9 +4,10 @@ from ...kernel.core import CharacterModifier as MDF
 from ...character import characterKernel as ck
 from functools import partial
 
-#TODO: 판테온 추가 4000%[(스킬 레벨*80+2000)%] 데미지로 10번 공격, 쿨타임 1200초
-
 def NovaGoddessBlessWrapper(vEhc, num1, num2):
     #TODO: (40+0.5*스킬레벨)%, 소수점 아래로 버림. 확률로 재사용 대기시간 미적용, 최대 5회까지만 미적용 가능
     NovaGoddessBless = core.BuffSkill("그란디스 여신의 축복(노바)", 450, 40*1000, pdamage = 5+vEhc.getV(num1, num2), cooltime = 240*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     return NovaGoddessBless
+
+def PantheonWrapper(vEhc, num1, num2):
+    Pantheon = core.DamageSkill("판테온", 510, 2000 + 80 * vEhc.getV(num1, num2), 10, cooltime = 1200*1000).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/readme.md
+++ b/dpmModule/jobs/readme.md
@@ -107,3 +107,24 @@ jobs.py
     - `SkillNum` : 사용하는 5차 스킬의 개수입니다.
     - `vEnhanceNum` : 가능한 5차 강화스킬의 가짓수입니다.
     - `passiveSkillList` : 패시브 스킬 효과를 담고 있는 리스트 입니다. generate 전까지는 계산되지 않습니다.
+
+하위 모듈
+-------------
+jobs의 하위 모듈로는 `jobbranch`와 `jobclass`가 존재합니다. 여기에는 각각 직업 계열과 직업군별 공용 스킬이 저장되어 있습니다.
+
+단일 직업군의 스킬은 해당 직업의 스크립트에 포함되어 있습니다. (제로, 키네시스)
+
+- jobbranch 모듈은 다음을 포함합니다.
+  - `warriors.py` : 전사 공용 스킬입니다.
+  - `magicians.py` : 마법사 공용 스킬입니다.
+  - `bowmen.py` : 궁수 공용 스킬입니다.
+  - `thieves.py` : 도적 공용 스킬입니다.
+  - `pirates.py` : 해적 공용 스킬입니다.
+- jobclass 모듈은 다음을 포함합니다.
+  - `adventurer.py` : 모험가 공용 스킬입니다.
+  - `cygnus.py` : 시그너스 기사단 공용 스킬입니다.
+  - `heroes.py` : 영웅 공용 스킬입니다.
+  - `resistance.py` : 레지스탕스(데몬 제외) 공용 스킬입니다.
+  - `demon.py` : 데몬 공용 스킬입니다.
+  - `nova.py` : 노바 공용 스킬입니다.
+  - `flora.py` : 레프 공용 스킬입니다.

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -10,6 +10,35 @@ from .jobbranch import warriors
 
 # 제로 메용은 쓸컴뱃을 적용받지 않음
 
+# 현재로는 계산 알고리즘 작성 구문에서 연산과정에 접근을 할 수 없도록 캡슐화되어 있으므로 사용 불가능
+'''
+class LimitBreakNew():
+    def __init__(self, enhancer, skill_importance, enhance_importance):
+        self.damage_start = 0
+        self.damage_end = 0
+        self.analytics = core.Analytics()
+        self.vLevel = enhancer.getV(skill_importance, enhance_importance)
+
+        self.LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*self.vLevel, 5).isV(enhancer, skill_importance, enhance_importance).wrap(core.DamageSkillWrapper)
+        self.LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+self.vLevel//2)*1000, pdamage_indep = (30+self.vLevel//5) * 1.2 + 20, cooltime = 240*1000).isV(enhancer, skill_importance, enhance_importance).wrap(core.BuffSkillWrapper)
+        self.LimitBreak.onAfter(self.LimitBreakAttack)
+        
+    def LimitBreakStart(self):
+        self.damage_start = self.analytics.total_damage
+        return LimitBreak
+
+    def LimitBreakEnd(self):
+        self.damage_end = self.analytics.total_damage - self.damage_start
+        # 지속시간 동안 가한 데미지의 20% / 15
+        # 퍼뎀이 아니라 고정값으로 뜨게 수정해야 함
+        return core.DamageSkill("리미트 브레이크(막타)", 0, damage_end / 75, 15).wrap(core.DamageSkillWrapper)
+    def get_buff(self):
+        return self.LimitBreak
+
+# LimitBreakSet = LimitBreakNew(vEhc, 0, 0)
+# LimitBreak = LimitBreakSet.get_buff()
+'''
+
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()


### PR DESCRIPTION
* 스칼렛 차지드라이브, 어비스 차지드라이브 후속타 추가
* 채워지지 않는 굶주림, 황홀한 구속, 황홀한 구속(소환), 끝없는 고통(종결), 인피니티 스펠, 근원의 기억(종결), 새어나오는 흉몽, 차지 스펠 앰플리피케이션 수정
* 인피니티 데미지값과 재사용 수치 변경
* 시그너스의 축복 일부 값 제외하고 작성
* `dpmModule/jobs/readme.md` : 하위 모듈 설명 추가

딜사이클 변경은 건드릴 자신이 없어서 일단 빼고 했습니다. 시그너스의 축복은 스킬 레벨당 변경값을 몰라서 세부값을 못 넣었습니다.