### PR TITLE
1.2.332 패치 일부 적용

### DIFF
--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -93,9 +93,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = 154
-        OverdriveBuff = pirates.OverdriveWrapper(vEhc, WEAPON_ATT, 3, 3)
-        Overdrive = OverdriveBuff.Overdrive
-        OverdrivePenalty = OverdriveBuff.OverdrivePenalty
+        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 3, 3, WEAPON_ATT)
     
         EnergyBurst = core.DamageSkill("에너지 버스트", 900, (600+20*vEhc.getV(4,4)) * 3, 12, red = True, cooltime = 120 * 1000).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
         
@@ -126,7 +124,6 @@ class JobGenerator(ck.JobGenerator):
         
         SuperNova.onTick(SoulSeeker)
         #SuperNova.onConstraint(core.ConstraintElement("익절트와 함께", SoulExult, SoulExult.is_active))
-        Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
         
     
         return (Trinity_1,

--- a/dpmModule/jobs/aran.py
+++ b/dpmModule/jobs/aran.py
@@ -22,7 +22,7 @@ class JobGenerator(ck.JobGenerator):
         self.preEmptiveSkills = 2
         
     def get_passive_skill_list(self):
-        RetrievedMemory = core.InformedCharacterModifier("되찾은 기억", att=10)
+        RetrievedMemory = core.InformedCharacterModifier("되찾은 기억", patt=5)
         SnowChargePassive = core.InformedCharacterModifier("스노우 차지(패시브)", pdamage=10+10)
         PhisicalTraining = core.InformedCharacterModifier("피지컬 드레이닝",stat_main = 30, stat_sub = 30)
         AdvancedComboAbilityPassive = core.InformedCharacterModifier("어드밴스드 콤보 어빌리티", att=10, crit=20, crit_damage=10)
@@ -53,14 +53,14 @@ class JobGenerator(ck.JobGenerator):
 
         SmashSwing = core.DamageSkill("스매시 스윙", 90, 800, 2).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         SmashSwingIncr = core.BuffSkill("스매시 스윙(최종데미지)", 0, 5000+3000, pdamage_indep=15, pdamage=20, cooltime=-1).wrap(core.BuffSkillWrapper)
-        SmashSwingIllusion = core.DamageSkill("스매시 스윙(잔상)", 0, 350, 4).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        SmashSwingIllusion = core.DamageSkill("스매시 스윙(잔상)", 0, 280, 5).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
 
         FinalBlow = core.DamageSkill("파이널 블로우", 600, 445, 5, modifier=core.CharacterModifier(armor_ignore=15)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
 
         Booster = core.BuffSkill("부스터", 0, 180*1000, rem = True).wrap(core.BuffSkillWrapper)
         SnowCharge = core.BuffSkill("스노우 차지", 0, 200*1000, pdamage=10).wrap(core.BuffSkillWrapper) # 펫버프
 
-        FinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 250, 0.6).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        FinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 85, 3*0.6).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
 
         AdvancedComboAbility = core.BuffSkill("어드밴스드 콤보 어빌리티", 0, 9999*9999, att=2*10, crit=3*10).wrap(core.BuffSkillWrapper)
         Judgement = core.DamageSkill("저지먼트", JUDGEMENT_DELAY, 380, 4).wrap(core.DamageSkillWrapper)
@@ -84,7 +84,7 @@ class JobGenerator(ck.JobGenerator):
         AdrenalineBeyonderThird = core.DamageSkill("비욘더(3타)(아드레날린)", 410, 565, 8, modifier=core.CharacterModifier(pdamage=20+79.1, armor_ignore=20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         AdrenalineBeyonderWave = core.DamageSkill("비욘더(파동)", 0, 400, 5).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
 
-        BoostEndHuntersTargeting = core.DamageSkill("부스트엔드-헌터즈타겟팅", BOOST_END_HUNTERS_TARGETING_DELAY, 1500+500, 15, cooltime=-1).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        BoostEndHuntersTargeting = core.DamageSkill("부스트엔드-헌터즈타겟팅", BOOST_END_HUNTERS_TARGETING_DELAY, 1500+500, 15*5, cooltime=-1).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
 
         AdrenalineGenerator = core.BuffSkill("아드레날린 제네레이터", ADRENALINE_GENERATOR_DELAY, 0, cooltime=240*1000).wrap(core.BuffSkillWrapper)
         MahaRegion = core.SummonSkill("마하의 영역", 1710, 1000, 500, 3, 10*1000, cooltime=150*1000).wrap(core.SummonSkillWrapper)
@@ -98,7 +98,7 @@ class JobGenerator(ck.JobGenerator):
         InstallMahaBlizzard = core.SummonSkill("인스톨 마하(눈보라)", 0, 3000, 650+10*vEhc.getV(1,1), 5, 60*1000, cooltime=-1).wrap(core.SummonSkillWrapper)
         #스택+100
 
-        BrandishMaha = core.DamageSkill('브랜디쉬 마하', 1170, 900+vEhc.getV(2,2)*36, 10*2, cooltime=20*1000, modifier=core.CharacterModifier(boss_pdamage=20)).wrap(core.DamageSkillWrapper)
+        BrandishMaha = core.DamageSkill('브랜디쉬 마하', 1170, 600+vEhc.getV(2,2)*24, 15*2, cooltime=20*1000, modifier=core.CharacterModifier(boss_pdamage=20)).wrap(core.DamageSkillWrapper)
         #인스톨마하상태에서 쿨타임 10초 감소
 
         PenrilCrash = core.DamageSkill('펜릴 크래시', 450, 100+500+vEhc.getV(3,3)*5, 7, modifier=core.CharacterModifier(crit=100, armor_ignore=60,pdamage=20+69.6)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -106,21 +106,21 @@ class JobGenerator(ck.JobGenerator):
         OverloadMana = OverloadMana = magicians.OverloadManaWrapper(vEhc, 1, 2)
         
         #Damage Skills
-        ChainLightening = core.DamageSkill("체인 라이트닝", 600, 230 + 2*combat, 9, modifier = core.CharacterModifier(crit = 25, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        ChainLightening = core.DamageSkill("체인 라이트닝", 600, 185 + 2*combat, 10+1, modifier = core.CharacterModifier(crit = 25, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
-        FrozenOrbEjac = core.SummonSkill("프로즌 오브", 450, 100, 200+4*combat, 1, 1999, cooltime = -1, modifier = core.CharacterModifier(pdamage = 10)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
+        FrozenOrbEjac = core.SummonSkill("프로즌 오브", 690, 100, 200+4*combat, 1, 1999, cooltime = -1, modifier = core.CharacterModifier(pdamage = 10)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
     
         LighteningSpear = core.DamageSkill("라이트닝 스피어", 0, 0, 1, cooltime = 75 * 1000).wrap(core.DamageSkillWrapper)
         LighteningSpearSingle = core.DamageSkill("라이트닝 스피어(단일)", 250, 200, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         LighteningSpearFinalizer = core.DamageSkill("라이트닝 스피어 막타", 0, 1500, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         IceAgeHolder = core.DamageSkill("아이스 에이지 개시스킬", 870, 500 + vEhc.getV(2,3)*20, 10, cooltime = 60 * 1000, red = True).isV(vEhc,2,3).wrap(core.DamageSkillWrapper)
-        IceAge = core.EjaculateSkill("아이스 에이지 사출기", 870, 375 + vEhc.getV(2,3)*15, 1, 15 * 1000).isV(vEhc,2,3).wrap(core.SummonSkillWrapper) #소환처리 해야함 ;; TODO
+        IceAge = core.EjaculateSkill("아이스 에이지 사출기", 870, 125 + vEhc.getV(2,3)*5, 3, 15 * 1000).isV(vEhc,2,3).wrap(core.SummonSkillWrapper) #소환처리 해야함 ;; TODO
         
-        Blizzard = core.DamageSkill("블리자드", 870, 900+10*combat, 4, cooltime = 45 * 1000, red = True).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
+        Blizzard = core.DamageSkill("블리자드", 720, 450+10*combat, 8, cooltime = 45 * 1000, red = True).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
         
         # 중첩당 감소량 5%
-        ThunderBrake = core.DamageSkill("썬더브레이크 개시스킬", 0, 0, 1, red = True, cooltime = 45 * 1000).wrap(core.DamageSkillWrapper) #Awesome! -> Tandem 사출처리 해야함...Later. 690을 일단 급한대로 분배해서 사용.
+        ThunderBrake = core.DamageSkill("썬더브레이크 개시스킬", 0, 0, 1, red = True, cooltime = 40 * 1000).wrap(core.DamageSkillWrapper) #Awesome! -> Tandem 사출처리 해야함...Later. 690을 일단 급한대로 분배해서 사용.
         ThunderBrake1 = core.DamageSkill("썬더브레이크", 100, (750 + vEhc.getV(0,0)*30), 8).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         ThunderBrake2 = core.DamageSkill("썬더브레이크(1)", 100, (750 + vEhc.getV(0,0)*30)*0.95, 8).wrap(core.DamageSkillWrapper)
         ThunderBrake3 = core.DamageSkill("썬더브레이크(2)", 100, (750 + vEhc.getV(0,0)*30)*0.9, 8).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -82,6 +82,8 @@ class JobGenerator(ck.JobGenerator):
         PlainBuff = core.BuffSkill("플레인 버프", 0, 60 * 1000, cooltime = -1).wrap(core.BuffSkillWrapper)
         
         ScarletChargeDrive = core.DamageSkill("스칼렛 차지 드라이브", 540, 350, 6, cooltime = 3000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        ScarletChargeDrive_After = core.DamageSkill("스칼렛 차지 드라이브(후속타)", 0, 350, 6).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        
         ScarletSpell = core.DamageSkill("스칼렛 스펠", 0, 220, 5).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         ScarletSpell_Infinity = core.DamageSkill("스칼렛 스펠(인피니티)", 0, 220, 5 * 5, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
@@ -98,6 +100,10 @@ class JobGenerator(ck.JobGenerator):
         CrawlingFear = core.DamageSkill("기어다니는 공포", 690, 1390, 12, cooltime = 60*1000).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
         AbyssChargeDrive = core.DamageSkill("어비스 차지 드라이브", 630, 340, 4, cooltime = 9000).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        AbyssChargeDrive_After = core.DamageSkill("어비스 차지 드라이브(후속타)", 0, 410, 6).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        
+        # 어비스 스펠: 70%로 2번 공격하는 장판, 10초동안 13번
+        # SummonSkill로 변경 필요
         AbyssSpell = core.DamageSkill("어비스 스펠", 0, 410, 6).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         AbyssSpell_Infinity = core.DamageSkill("어비스 스펠(인피니티)", 0, 410, 6 * 5, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         
@@ -105,10 +111,12 @@ class JobGenerator(ck.JobGenerator):
         
         AbyssBuff = core.BuffSkill("어비스 버프", 0, 60*1000, cooltime = -1, pdamage = 20, boss_pdamage = 30, armor_ignore = 20).wrap(core.BuffSkillWrapper)
         
-        RaptRestriction = core.DamageSkill("황홀한 구속", 690, 500, 6, cooltime = 180 * 1000).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        RaptRestrictionSummon = core.SummonSkill("황홀한 구속(소환)", 0, 300, 400, 3, 9000, cooltime = -1).setV(vEhc, 7, 2, False).wrap(core.SummonSkillWrapper)  #임의주기 300ms, DPM 미사용.
+        RaptRestriction = core.DamageSkill("황홀한 구속", 690, 600, 6, cooltime = 180 * 1000).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        RaptRestrictionSummon = core.SummonSkill("황홀한 구속(소환)", 0, 450, 400, 3, 9000, cooltime = -1).setV(vEhc, 7, 2, False).wrap(core.SummonSkillWrapper)  #임의주기 300ms, DPM 미사용.
         RaptRestrictionEnd = core.DamageSkill("황홀한 구속(종결)", 0, 1000, 8, cooltime = -1).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
+        # TODO: 딜레이 추가, 5차 강화 정보 갱신, 딜사이클 등록, 2회 발동기능 추가
+        UnstoppableImpulse = core.DamageSkill("멈출 수 없는 충동", 0, 435, 5, cooltime = 6000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
         ##### 스펙터 상태일 때 #####
         UpcomingDeath = core.DamageSkill("다가오는 죽음", 0, 450, 2).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
@@ -119,22 +127,24 @@ class JobGenerator(ck.JobGenerator):
         
         EndlessBadDream = core.DamageSkill("끝나지 않는 흉몽", 540, 445, 6).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) # 끝나지 않는 악몽 변형
         
-        UnfulfilledHunger = core.DamageSkill("채워지지 않는 굶주림", 750, 320, 7, cooltime = 5000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)  #거스트 차지 드라이브 변형
+        UnfulfilledHunger = core.DamageSkill("채워지지 않는 굶주림", 750, 510, 7, cooltime = 5000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)  #거스트 차지 드라이브 변형
         UnfulfilledHunger_Link = core.DamageSkill("채워지지 않는 굶주림(연계)", 750 - 240 - 240, 320, 7, cooltime = 5000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
         UncontrollableChaos = core.DamageSkill("겉잡을 수 없는 혼돈", 810, 440, 12, cooltime = 9000).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper) #어비스 차지 드라이브 변형
         UncontrollableChaos_Link = core.DamageSkill("겉잡을 수 없는 혼돈(연계)", 810 - 240 - 240, 440, 12, cooltime = 9000).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         
+        # TODO: 딜레이 추가, 5차 강화 정보 갱신, 딜사이클 등록, 2회 발동기능 추가
+        TenaciousInstinct = core.DamageSkill("멈출 수 없는 본능", 0, 460, 6, cooltime = 6000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
         
-        
-        # 하이처
-        ChargeSpellAmplification = core.BuffSkill("차지 스펠 엠플리피케이션", 720, 60000, att = 30, crit = 20, pdamage = 20, armor_ignore = 20, boss_pdamage = 20, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
+        # 하이퍼
+        ChargeSpellAmplification = core.BuffSkill("차지 스펠 엠플리피케이션", 720, 60000, att = 30, crit = 20, pdamage = 20, armor_ignore = 20, boss_pdamage = 30, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
         
         
         EndlessPainTick = core.DamageSkill("끝없는 고통(틱)", 200,  300, 3).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)   #15타
         EndlessPain = core.DamageSkill("끝없는 고통", 0, 0, 0, cooltime = 60 * 1000).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper) # onTick==> 다가오는 죽음
-        EndlessPainEnd = core.DamageSkill("끝없는 고통(종결)", 0, 700*2, 12).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        # 딜레이 : 1200ms 또는 1050ms(이후 연계 시). 일단 1200으로.
+        EndlessPainEnd = core.DamageSkill("끝없는 고통(종결)", 1200, 700*2, 12).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
         WraithOfGod = core.BuffSkill("레이스 오브 갓", 0, 60*1000, pdamage = 10, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
         
@@ -156,16 +166,16 @@ class JobGenerator(ck.JobGenerator):
         
         MemoryOfSource = core.DamageSkill("근원의 기억", 0, 0, 0, cooltime = 200 * 1000).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         MemoryOfSourceTick = core.DamageSkill("근원의 기억(틱)", 250, 400 + 16 * vEhc.getV(1,1), 6).wrap(core.DamageSkillWrapper)    # 43타
-        MemoryOfSourceEnd = core.DamageSkill("근원의 기억(종결)", 0, 120 + 24 * vEhc.getV(1,1), 12 * 6).wrap(core.DamageSkillWrapper)
+        MemoryOfSourceEnd = core.DamageSkill("근원의 기억(종결)", 0, 1200 + 48 * vEhc.getV(1,1), 12 * 6).wrap(core.DamageSkillWrapper)
         MemoryOfSourceBuff = core.BuffSkill("근원의 기억(버프)", 0, 30 * 1000, cooltime = -1).wrap(core.BuffSkillWrapper) #정신력 소모되지 않음
         
         
-        InfinitySpell = core.BuffSkill("인피니티 스펠", 720, (40 + vEhc.getV(0,0)) * 1000, cooltime = 240 * 1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        InfinitySpell = core.BuffSkill("인피니티 스펠", 720, (40 + 2*vEhc.getV(0,0)) * 1000, cooltime = 240 * 1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         #스펠이 남은 수많큼 차지됨
         #심연의 기운은 세개씩 추가 생성됨
         
         EvanescentNightmare = core.DamageSkill("새어나오는 악몽", 0, 500 + 20*vEhc.getV(2,2), 9, cooltime = 10 * 1000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
-        EvanescentBadDream = core.DamageSkill("새어나오는 흉몽", 0, 500 + 20*vEhc.getV(2,2), 9, cooltime = 10 * 1000).wrap(core.DamageSkillWrapper)
+        EvanescentBadDream = core.DamageSkill("새어나오는 흉몽", 0, 600 + 24*vEhc.getV(2,2), 9, cooltime = 10 * 1000).wrap(core.DamageSkillWrapper)
         
         EvanescentNightmareTimer = core.BuffSkill("새어나오는 악몽(타이머)", 0, 10000, cooltime = -1).wrap(core.BuffSkillWrapper)
         EvanescentBadDreamTimer = core.BuffSkill("새어나오는 흉몽(타이머)", 0, 10000 - 1000 - 1000, cooltime = -1).wrap(core.BuffSkillWrapper)   #악몽만 사용 가정
@@ -195,6 +205,8 @@ class JobGenerator(ck.JobGenerator):
         ScarletChargeDrive_Link.onBefore(PlainChargeDrive)
         ScarletSpell_Connected.onAfter(ScarletBuff)
         
+        ScarletChargeDrive.onAfter(ScarletChargeDrive_After)
+
         GustSpell_Connected = core.OptionalElement(InfinitySpell.is_active, GustSpell_Infinity, GustSpell)
         GustChargeDrive.onAfter(GustSpell_Connected)
         GustChargeDrive_Link.onAfter(GustSpell_Connected)
@@ -205,6 +217,8 @@ class JobGenerator(ck.JobGenerator):
         AbyssChargeDrive.onAfter(AbyssSpell_Connected)
         AbyssChargeDrive_Link.onAfter(AbyssSpell_Connected)
         AbyssChargeDrive_Link.onBefore(PlainChargeDrive)
+
+        AbyssChargeDrive.onAfter(AbyssChargeDrive_After)
         
         RaptRestriction.onAfter(RaptRestrictionSummon)
         RaptRestriction.onAfter(RaptRestrictionEnd)

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -156,9 +156,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = 154
-        OverdriveBuff = pirates.OverdriveWrapper(vEhc, WEAPON_ATT, 5, 5)
-        Overdrive = OverdriveBuff.Overdrive
-        OverdrivePenalty = OverdriveBuff.OverdrivePenalty
+        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         MagicCircuitFullDrive = core.BuffSkill("매직서킷 풀드라이브", 720, (30+vEhc.getV(4,4))*1000, pdamage = (20 + vEhc.getV(3,2)), cooltime = 200*1000).isV(vEhc,4,4).wrap(core.BuffSkillWrapper)
         MagicCircuitFullDriveStorm = core.SummonSkill("매직서킷 풀드라이브(마력 폭풍)", 0, 4000, 500+20*vEhc.getV(4,4), 3, (30+vEhc.getV(4,4))*1000, cooltime = -1).wrap(core.SummonSkillWrapper)
@@ -230,7 +228,6 @@ class JobGenerator(ck.JobGenerator):
         MemoryOfSource.onAfter(MemoryOfSourceEnd)
         MemoryOfSource.onAfter(MemoryOfSourceBuff)
         
-        Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
         MagicCircuitFullDrive.onAfter(MagicCircuitFullDriveStorm)
         
         # 스펙터 상태 파이널어택류 연계

--- a/dpmModule/jobs/battlemage.py
+++ b/dpmModule/jobs/battlemage.py
@@ -9,6 +9,8 @@ from .jobclass import resistance
 from .jobbranch import magicians
 # TODO: 오버로드 마나를 정말 안쓰는 것인지 확인필요
 
+# TODO: [블랙 매직 알터] : 제단이 설치되어 있지 않을 때 아래 방향키와 함께 사용하면 자신의 위치와 전방에 총 2개의 제단이 한번에 설치되는 기능이 추가됩니다. 설치 개수가 2개를 초과했을 때 초과한 개수에 비례해 저주의 이동속도가 증가하는 기능이 공격 횟수가 증가하는 기능으로 변경됩니다.
+
 ######   Passive Skill   ######
 
 class JobGenerator(ck.JobGenerator):
@@ -32,7 +34,7 @@ class JobGenerator(ck.JobGenerator):
         ArtOfStaff = core.InformedCharacterModifier("아트 오브 스태프",att = 20, crit = 15)
         StaffMastery = core.InformedCharacterModifier("스태프 마스터리",att = 30, crit = 20)
         HighWisdom =  core.InformedCharacterModifier("하이 위즈덤",stat_main = 40)
-        BattleMastery = core.InformedCharacterModifier("배틀 마스터리",pdamage_indep = 10, crit_damage = 20)
+        BattleMastery = core.InformedCharacterModifier("배틀 마스터리",pdamage_indep = 15, crit_damage = 20)
         DarkAuraPassive = core.InformedCharacterModifier("다크 오라(패시브)", patt=15)
         
         #택 1
@@ -131,10 +133,11 @@ class JobGenerator(ck.JobGenerator):
 
         # DeathAfterMOD는 처음에 비활성화됨
         DeathAfterMOD.set_disabled_and_time_left(-1)
-        
+
+        # 쓸윈 제거 ([너브 스티뮬레이션] : 공격 속도가 1단계 증가하는 기능이 추가됩니다.)
         return(FinishBlowEndpoint,
                 [Booster, WillOfLiberty, MasterOfDeath, UnionAura,
-                globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), #globalSkill.useful_wind_booster(),
                 globalSkill.soul_contract()] +\
                 [DarkGenesis, BattlekingBar] +\
                 [RegistanceLineInfantry, Death, DeathAfterMOD, BlackMagicAlter, GrimReaper] +\

--- a/dpmModule/jobs/bishop.py
+++ b/dpmModule/jobs/bishop.py
@@ -109,9 +109,9 @@ class JobGenerator(ck.JobGenerator):
         Pray = core.BuffSkill("프레이", 810, 1000 * (30 + 0.5 * vEhc.getV(2,2)), cooltime = 180 * 1000, red = True, pdamage_indep = (5 + (charMainStat // 2500))).isV(vEhc, 2,2).wrap(core.BuffSkillWrapper)
         
         #Damage Skills
-        AngelRay = core.DamageSkill("엔젤레이", 630, 315 + 6*combat, 10).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #벤전스 사용 가정
-        AngelRay_25 = core.DamageSkill("엔젤레이(25)", 630, 315 + 6*combat, 10, modifier = core.CharacterModifier(pdamage_indep = 25)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #벤전스 사용 가정
-        AngelRay_50 = core.DamageSkill("엔젤레이(50)", 630, 315 + 6*combat, 10, modifier = core.CharacterModifier(pdamage_indep = 50)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #벤전스 사용 가정
+        AngelRay = core.DamageSkill("엔젤레이", 630, 225 + 5*combat, 14).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #벤전스 사용 가정
+        AngelRay_25 = core.DamageSkill("엔젤레이(25)", 630, 225 + 5*combat, 14, modifier = core.CharacterModifier(pdamage_indep = 25)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #벤전스 사용 가정
+        AngelRay_50 = core.DamageSkill("엔젤레이(50)", 630, 225 + 5*combat, 14, modifier = core.CharacterModifier(pdamage_indep = 50)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #벤전스 사용 가정
         
         HeavensDoor = core.DamageSkill("헤븐즈도어", 1080, 1000, 8, cooltime = 180 * 1000).wrap(core.DamageSkillWrapper)   #사용하지 않는다--> 일단 Wrapper 제작 안할 것.
         PeaceMaker = core.DamageSkill("피스메이커", 750, 350 + 14*vEhc.getV(0,0), 12, cooltime = 10 * 1000, red = True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) #풀스택시 미발동..

--- a/dpmModule/jobs/blaster.py
+++ b/dpmModule/jobs/blaster.py
@@ -31,14 +31,14 @@ class JobGenerator(ck.JobGenerator):
         ChargeMastery= core.InformedCharacterModifier("차지 마스터리", pdamage = 20)
         GuntletExpert = core.InformedCharacterModifier("건틀렛 엑스퍼트", crit_damage = 15, boss_pdamage = 15)
         AdvancedChargeMastery= core.InformedCharacterModifier("어드밴스드 차지 마스터리", armor_ignore = 35)
-        CombinationTraining = core.InformedCharacterModifier("콤비네이션 트레이닝II", att = 40)	#패시브스킬+1, 오더스+1
+        CombinationTraining = core.InformedCharacterModifier("콤비네이션 트레이닝II", att = 44)	#패시브스킬+1, 오더스+1
         return [GuntletMastery, PhisicalTraining, ChargeMastery, 
                         GuntletExpert, AdvancedChargeMastery, CombinationTraining]
 
     def get_not_implied_skill_list(self):
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 70)
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
-        CombinationTraining = core.InformedCharacterModifier("콤비네이션 트레이닝II", pdamage_indep = 60, crit = 40)	#패시브스킬+1, 오더스+1
+        CombinationTraining = core.InformedCharacterModifier("콤비네이션 트레이닝II", pdamage_indep = 70, crit = 40)	#패시브스킬+1, 오더스+1
         
 
         return [WeaponConstant, Mastery, CombinationTraining]

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -74,8 +74,9 @@ class JobGenerator(ck.JobGenerator):
         #GrittyGust = core.DamageSkill("윈드 오브 프레이", ?, 500, 81, cooltime = 15 * 1000, red = true).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         #GrittyGustDOT = core.SummonSkill("윈드 오브 프레이(도트)", 0, 1000, 200, 1, 10*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         #TODO : 애로우 레인(조건부 파이널어택)
-        ArrowRainBuff = core.BuffSkill("애로우 레인(버프)", 720, (40+vEhc.getV(0,0))*1000, cooltime = 120 * 1000, red = True, pdamage = 15+(0.5*vEhc.getV(0,0))).isV(vEhc,0,0).wrap(core.BuffSkillWrapper) #딜레이 모름
-        ArrowRain = core.SummonSkill("애로우 레인", 0, 840, 500+vEhc.getV(0,0)*24, 5, (40+vEhc.getV(0,0))*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        # 최신 패치내용과 일치하는지 재확인 필요
+        ArrowRainBuff = core.BuffSkill("애로우 레인(버프)", 720, (40+vEhc.getV(0,0))*1000, cooltime = 120 * 1000, red = True, pdamage = 15+(vEhc.getV(0,0)//2)).isV(vEhc,0,0).wrap(core.BuffSkillWrapper) #딜레이 모름
+        ArrowRain = core.SummonSkill("애로우 레인", 0, 840, 600+vEhc.getV(0,0)*24, 8, (40+vEhc.getV(0,0))*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         
         #Summon Skills
         Pheonix = core.SummonSkill("피닉스", 900, 2670, 390, 1, 220 * 1000).setV(vEhc, 5, 3, True).wrap(core.SummonSkillWrapper)

--- a/dpmModule/jobs/cadena.py
+++ b/dpmModule/jobs/cadena.py
@@ -159,8 +159,8 @@ class JobGenerator(ck.JobGenerator):
         ChainArts_Fury_Damage = core.DamageSkill("체인아츠:퓨리(공격)", 0, 250+10*vEhc.getV(0,0), 6).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         ChainArts_Fury_Dummy = core.BuffSkill("체인아츠:퓨리(재사용대기)", 0, 600, cooltime = -1).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         
-        AD_Odnunce = core.SummonSkill("A.D 오드넌스", 450, 330, 145+6*vEhc.getV(1,1), 4, 10000, cooltime = 25000, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)
-        AD_Odnunce_Final = core.DamageSkill("A.D 오드넌스(막타)", 0, 735+29*vEhc.getV(1,1), 8, cooltime = -1, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        AD_Odnunce = core.SummonSkill("A.D 오드넌스", 450, 330, 225+9*vEhc.getV(1,1), 5, 10000, cooltime = 25000, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)
+        AD_Odnunce_Final = core.DamageSkill("A.D 오드넌스(막타)", 0, 750+30*vEhc.getV(1,1), 8, cooltime = -1, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         
         ChainArts_maelstorm = core.SummonSkill("체인아츠:메일스트롬", 720, 240, 300+12*vEhc.getV(3,2), 4, 4000, cooltime = -1).isV(vEhc,3,2).wrap(core.SummonSkillWrapper)
         ChainArts_maelstorm_slow = core.BuffSkill("체인아츠:메일스트롬(중독)", 0, 14000, crit=2, crit_damage = 10, cooltime = -1).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -80,8 +80,12 @@ class JobGenerator(ck.JobGenerator):
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         PirateFlag = PirateFlag = adventurer.PirateFlagWrapper(vEhc, 4, 3, chtr.level)
-    
-        BFGCannonball = core.SummonSkill("빅 휴즈 기간틱 캐논볼", 600, 210, (450+15*vEhc.getV(0,0)) * 0.45, 4 * 3, COCOBALLHIT, cooltime = 25000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+
+        # 쿨타임마다 사용
+        # 1.2.332 패치 반영 (50회 제한)
+        BFGCannonball = core.SummonSkill("빅 휴즈 기간틱 캐논볼", 600, 210, (450+15*vEhc.getV(0,0)) * 0.45, 4 * 3, 210*50, cooltime = 25000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+
+
         ICBM = core.DamageSkill("ICBM", 1190, (1200+48*vEhc.getV(1,1)) * 0.45, 5*ICBMHIT * 3, cooltime = 30000).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         ICBMDOT = core.SummonSkill("ICBM(장판)", 0, 15000/27, (500+20*vEhc.getV(1,1)) * 0.45, 1 * 3, 15000, cooltime = -1).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) #27타
     

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -77,9 +77,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = 210
-        OverdriveBuff = pirates.OverdriveWrapper(vEhc, WEAPON_ATT, 5, 5)
-        Overdrive = OverdriveBuff.Overdrive
-        OverdrivePenalty = OverdriveBuff.OverdrivePenalty
+        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         PirateFlag = PirateFlag = adventurer.PirateFlagWrapper(vEhc, 4, 3, chtr.level)
     
@@ -102,8 +100,6 @@ class JobGenerator(ck.JobGenerator):
         ICBM.onAfter(ICBMDOT)
     
         SpecialMonkeyEscort_Canon.onAfter(SpecialMonkeyEscort_Boom)
-    
-        Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
     
         return(CanonBuster,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),

--- a/dpmModule/jobs/captain.py
+++ b/dpmModule/jobs/captain.py
@@ -76,7 +76,9 @@ class JobGenerator(ck.JobGenerator):
         OctaQuaterdeck = core.SummonSkill("옥타 쿼터덱", 630, 60000/110, 300, 1, 30000, rem = True, cooltime = 10000).setV(vEhc, 5, 2, True).wrap(core.SummonSkillWrapper)
         RapidFire = core.DamageSkill("래피드 파이어", 120, 325, 1, modifier = core.CharacterModifier(pdamage = 30, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         
-        BattleshipBomber = core.DamageSkill("배틀쉽 봄버", 0,0,0, red = True, cooltime = 30000).wrap(core.DamageSkillWrapper)
+        # TODO : 지속시간 30초 -> 60초, 쿨타임 60초 -> 30초
+        # 소환수 데미지 변경 계산 필요
+        BattleshipBomber = core.DamageSkill("배틀쉽 봄버", 0,0,0, red = True, cooltime = 60000).wrap(core.DamageSkillWrapper)
         BattleshipBomber_1_ON = core.BuffSkill("배틀쉽봄버-1", 0, 30000, rem = True, cooltime = -1).wrap(core.BuffSkillWrapper)
         BattleshipBomber_2_ON = core.BuffSkill("배틀쉽봄버-2", 0, 30000, rem = True, cooltime = -1).wrap(core.BuffSkillWrapper)
         BattleshipBomber_1 = core.SummonSkill("배틀쉽 봄버(소환,1)", 300, 600, 249, 3, 30000, rem = True, cooltime = -1).setV(vEhc, 4, 2, True).wrap(core.SummonSkillWrapper)
@@ -88,8 +90,16 @@ class JobGenerator(ck.JobGenerator):
         조나단 : 235 보통   12/20 타수3 600
         평균 데미지 600ms당 249
         '''
+        '''
+        돈틀레스 : 330 보통 13/22 타수3 600
+        블랙바크 : 445 느림 15/18 타수3 810
+        슈린츠 : 200 빠름   15/27 타수3 570
+        조나단 : 320 보통   12/20 타수3 600
+        평균 데미지 600ms당 ?
+        '''
+        
 
-        Headshot = core.DamageSkill("헤드 샷", 660, 525, 12+1, cooltime = 5000, modifier = core.CharacterModifier(crit=100, armor_ignore=60, pdamage = 20)).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        Headshot = core.DamageSkill("헤드 샷", 420, 525, 12+1, cooltime = 5000, modifier = core.CharacterModifier(crit=100, armor_ignore=60, pdamage = 20)).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
         
         Nautilus = core.DamageSkill("노틸러스", 690, 440+130, 7, red = True, cooltime = 30000).setV(vEhc, 8, 2, True).wrap(core.DamageSkillWrapper)
         PirateStyle = core.BuffSkill("파이렛 스타일", 0, 180000, rem = True, patt = 20).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/captain.py
+++ b/dpmModule/jobs/captain.py
@@ -112,9 +112,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = 150
-        OverdriveBuff = pirates.OverdriveWrapper(vEhc, WEAPON_ATT, 4, 4)
-        Overdrive = OverdriveBuff.Overdrive
-        OverdrivePenalty = OverdriveBuff.OverdrivePenalty
+        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 4, 4, WEAPON_ATT)
         
         BulletParty = core.DamageSkill("불릿 파티", 0, 0, 0, cooltime = 75000).wrap(core.DamageSkillWrapper)
         BulletPartyTick = core.DamageSkill("불릿 파티(틱)", BULLET_PARTY_TICK, 230+9*vEhc.getV(5,5), 5).isV(vEhc,5,5).wrap(core.DamageSkillWrapper) #12초간 지속 -> 50회 시전
@@ -146,8 +144,6 @@ class JobGenerator(ck.JobGenerator):
             end.onAfter(QuickDrawShutdownTrigger)
         #디그니티는 노틸러스 쿨을 반영    
         CaptainDignitiy = core.OptionalElement(Nautilus.is_usable, CaptainDignitiyNormal, CaptainDignitiyEnhance)
-        #오버드라이브 연계
-        Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
         #노틸러스 어썰트는 2개로 분리되어 잇음
         NautillusAssult.onAfter(NautillusAssult_2)
         #디그니티

--- a/dpmModule/jobs/darknight.py
+++ b/dpmModule/jobs/darknight.py
@@ -56,9 +56,9 @@ class JobGenerator(ck.JobGenerator):
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 180*1000, rem = True).wrap(core.BuffSkillWrapper)
         CrossoverChain = core.BuffSkill("크로스 오버 체인", 0, 200*1000, pdamage_indep = 80).wrap(core.BuffSkillWrapper)
-        FinalAttack = core.DamageSkill("파이널 어택", 0, 150, 0.4).setV(vEhc, 3, 4, True).wrap(core.DamageSkillWrapper)
+        FinalAttack = core.DamageSkill("파이널 어택", 0, 80, 2*0.4).setV(vEhc, 3, 4, True).wrap(core.DamageSkillWrapper)
         BiholderDominant = core.SummonSkill("비홀더 도미넌트", 0, 10000, 210, 1, 99999*10000, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).wrap(core.SummonSkillWrapper)
-        BiholderShock = core.DamageSkill("비홀더 쇼크", 0, 640, 2, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).wrap(core.DamageSkillWrapper)
+        BiholderShock = core.DamageSkill("비홀더 쇼크", 0, 215, 6, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).wrap(core.DamageSkillWrapper)
         
         DarkImpail = core.DamageSkill("다크 임페일", 630, 280, 6).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         GoungnilDescentNoCooltime = core.DamageSkill("궁그닐 디센트(무한)", 600, 225, 12, modifier = core.CharacterModifier(armor_ignore = 30+20, pdamage = 20, boss_pdamage = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)    
@@ -72,7 +72,7 @@ class JobGenerator(ck.JobGenerator):
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
         DarkSpear = core.DamageSkill("다크 스피어", 990, 350+10*vEhc.getV(1,0), 7 * 8, cooltime = 10000, red = True, modifier = core.CharacterModifier(crit=100, armor_ignore=50)).isV(vEhc,1,0).wrap(core.DamageSkillWrapper)
-        BiholderImpact = core.SummonSkill("비홀더 임팩트", 0, 300, 300+3*vEhc.getV(0,2), 2, 3001, cooltime = 20000, red = True, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).isV(vEhc,0,2).wrap(core.SummonSkillWrapper)#onTick으로 0.3초씩
+        BiholderImpact = core.SummonSkill("비홀더 임팩트", 0, 300, 100+vEhc.getV(0,2), 6, 3001, cooltime = 20000, red = True, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).isV(vEhc,0,2).wrap(core.SummonSkillWrapper)#onTick으로 0.3초씩
         PierceCyclone = core.DamageSkill("피어스 사이클론(더미)", 90, 0, 0, cooltime = 180*1000).wrap(core.DamageSkillWrapper)
         PierceCycloneTick = core.DamageSkill("피어스 사이클론", 9000/22, 400+16*vEhc.getV(3,3), 12, modifier = core.CharacterModifier(crit=100, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper) #22타
         PierceCycloneEnd = core.DamageSkill("피어스 사이클론(종료)", 0, 1500+60*vEhc.getV(3,3), 15, modifier = core.CharacterModifier(crit=100, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -55,7 +55,7 @@ class JobGenerator(ck.JobGenerator):
         Booster = core.BuffSkill("부스터", 0, 180000, rem = True).wrap(core.BuffSkillWrapper)
         MirrorImaging = core.BuffSkill("미러 이미징", 0, 200000, rem = True, pdamage_indep = 70).wrap(core.BuffSkillWrapper)
         
-        DarkSight = core.BuffSkill("다크 사이트", 0, 1, cooltime = -1, pdamage_indep = 20 + 10 + int(0.2*vEhc.getV(3,3))).wrap(core.BuffSkillWrapper)
+        DarkSight = core.BuffSkill("다크 사이트", 0, 1, cooltime = -1).wrap(core.BuffSkillWrapper)#, pdamage_indep = 20 + 10 + int(0.2*vEhc.getV(3,3))).wrap(core.BuffSkillWrapper)
         
         PhantomBlow = core.DamageSkill("팬텀 블로우", 540, 315, 6+1, modifier = core.CharacterModifier(armor_ignore = 30+20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         SuddenRaid = core.DamageSkill("써든 레이드", 900, 1150, 3, cooltime = 30000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)    #파컷의 남은 쿨타임 20% 감소
@@ -76,7 +76,8 @@ class JobGenerator(ck.JobGenerator):
         Asura = core.DamageSkill("아수라", 0, 0, 0, cooltime = 60000).wrap(core.DamageSkillWrapper)
         AsuraTick = core.DamageSkill("아수라(틱)", 300, 420, 4, modifier =core.CharacterModifier(armor_ignore = 100)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)  #41타
         
-        UltimateDarksight = core.BuffSkill("얼티밋 다크사이트", 750, 30000, red = True, cooltime = (220-vEhc.getV(3,3))*1000).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
+        UltimateDarksight = thieves.UltimateDarkSightWrapper(vEhc, 3, 3, 20)
+        #UltimateDarksight = core.BuffSkill("얼티밋 다크사이트", 750, 30000, red = True, cooltime = (220-vEhc.getV(3,3))*1000).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc,1,1)
         
         BladeStorm = core.DamageSkill("블레이드 스톰", 660, 580+23*vEhc.getV(0,0), 7, red = True, cooltime = 90000, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -70,6 +70,7 @@ class JobGenerator(ck.JobGenerator):
         FlashBangDebuff = core.BuffSkill("플래시 뱅(디버프)", 0, 50000/2, cooltime = -1, pdamage = 10 * 0.9).wrap(core.BuffSkillWrapper)
         Venom = core.DotSkill("페이탈 베놈", 160*3/1.7, 8000).wrap(core.SummonSkillWrapper)
         
+        # TODO: 버프 시전 딜레이 적용
         HiddenBladeBuff = core.BuffSkill("히든 블레이드(버프)", 0, 60000, cooltime = 90000, pdamage = 10).wrap(core.BuffSkillWrapper)
         HiddenBlade = core.DamageSkill("히든 블레이드", 0, 140 / 1.7, 2).setV(vEhc, 5, 2, True).wrap(core.DamageSkillWrapper)    #미러 이미징에 의해 추가타 2개, 최종뎀 1.7배 무시
         

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -102,9 +102,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = 154
-        OverdriveBuff = pirates.OverdriveWrapper(vEhc, WEAPON_ATT, 5, 5)
-        Overdrive = OverdriveBuff.Overdrive
-        OverdrivePenalty = OverdriveBuff.OverdrivePenalty
+        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
         
         SoulConcentrate = core.BuffSkill("정령 집속", 960, (30+vEhc.getV(2,1))*1000, cooltime = 120*1000, pdamage_indep = (5+vEhc.getV(2,1)//2)).isV(vEhc,2,1).wrap(core.BuffSkillWrapper)
         SoulConcentrateSummon = core.SummonSkill("정령 집속(무작위)", 0, 2000, 1742, 1, (30+vEhc.getV(2,1))*1000, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
@@ -128,8 +126,6 @@ class JobGenerator(ck.JobGenerator):
         EnhanceSpiritLink.onAfters([EnhanceSpiritLinkSummon_S, EnhanceSpiritLinkSummon_J_Init])
         EnhanceSpiritLinkSummon_J_Init.onTick(EnhanceSpiritLinkSummon_J)
         EnhanceSpiritLinkSummon_J.onAfter( core.RepeatElement(EnhanceSpiritLinkSummon_J_Damage, 32) )
-        
-        Overdrive.onAfter(OverdrivePenalty.controller(30000))
         
         #정령 집속
         SoulConcentrate.onAfter(DoubleBody.controller(1.0, 'reduce_cooltime_p'))

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -73,9 +73,9 @@ class JobGenerator(ck.JobGenerator):
         ######   Skill   ######
         #Buff skills
     
-        FoxSoul = core.DamageSkill("여우령", 0, 200, 3 * (0.2+0.1)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        FoxSoul = core.DamageSkill("여우령", 0, 200, 3 * (0.25+0.1)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
 
-        SoulAttack = core.DamageSkill("귀참", 600, 380, 8+1, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        SoulAttack = core.DamageSkill("귀참", 600, 265, 12+1, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         DoubleBodyAttack = core.DamageSkill("분혼 격참(공격)", 0, 2000, 1).wrap(core.DamageSkillWrapper)
         DoubleBody = core.BuffSkill("분혼 격참", 1000, 10000, cooltime = 180000, red = True, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
     
@@ -110,7 +110,7 @@ class JobGenerator(ck.JobGenerator):
         SoulTrap = core.SummonSkill("귀문진", 1000, 930, 600+24*vEhc.getV(3,2), 3, 40000, cooltime = (120-vEhc.getV(3,2))*1000).isV(vEhc,3,2).wrap(core.SummonSkillWrapper)
         SoulTrapBuff = core.BuffSkill("귀문진(버프)", 0, 40000, cooltime = -1).wrap(SoulTrapBuffWrapper)
 
-        RealSoulAttack = core.DamageSkill("진 귀참", 600, 800+8*vEhc.getV(1,3), 8 + 1, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20) + core.CharacterModifier(armor_ignore=50)).setV(vEhc, 0, 2, False).isV(vEhc,1,3).wrap(core.DamageSkillWrapper)
+        RealSoulAttack = core.DamageSkill("진 귀참", 600, 540+6*vEhc.getV(1,3), 12 + 1, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20) + core.CharacterModifier(armor_ignore=50)).setV(vEhc, 0, 2, False).isV(vEhc,1,3).wrap(core.DamageSkillWrapper)
         RealSoulAttackCounter = core.BuffSkill("진 귀참(딜레이)", 0, 6000, cooltime = -1).wrap(core.BuffSkillWrapper)
         
         DoubleBodyRegistance = core.BuffSkill("분혼 격참(저항)", 0, 90000, cooltime = -1).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/flamewizard.py
+++ b/dpmModule/jobs/flamewizard.py
@@ -61,7 +61,7 @@ class JobGenerator(ck.JobGenerator):
         
         OverloadMana = OverloadMana = magicians.OverloadManaWrapper(vEhc, 1, 2)
         #Damage Skills
-        InfernoRize = core.DamageSkill("인페르노 라이즈", 720, 285, 5, cooltime = 30*1000, modifier = core.CharacterModifier(pdamage = 90)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)    #임의딜레이 720
+        InfernoRize = core.DamageSkill("인페르노 라이즈", 720, 350, 10, cooltime = 30*1000, modifier = core.CharacterModifier(pdamage = 90)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)    #임의딜레이 720
         
         #Full speed, No Combat Orders
         OrbitalFlame = core.DamageSkill("오비탈 플레임", flamewizardDefaultSpeed, 215, 3 * 2, modifier = core.CharacterModifier(armor_ignore = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -25,9 +25,12 @@ def useful_wind_booster():
     UsefulWindBooster = core.BuffSkill("쓸만한 윈드 부스터", 1080, 183*1000, rem = False).wrap(core.BuffSkillWrapper)
     return UsefulWindBooster
 
-# 235레벨 이상만 사용가능
-class SpiderInMirrorBuilder():
-    def __init__(self, enhancer, skill_importance, enhance_importance):
-        self.MirrorBreak = core.DamageSkill("스파이더 인 미러(공간 붕괴)", 0, 750+30*enhancer.getV(skill_importance, enhance_importance), 12, cooltime = 250*1000).wrap(core.DamageSkillWrapper)
-        # 50초 동안 지속되며 일정 시간 마다 공격 상태에 돌입, 공격 상태 동안 385%의 데미지로 8번 공격하는 거미 다리를 10회 사용, 거미 다리가 한명의 적을 5번 연속 공격할 경우 공격 상태 즉시 종료, 공격 상태 종료 후 재돌입 대기시간 3초
-        self.MirrorSpider = core.SummonSkill("스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+17*enhancer.getV(skill_importance, enhance_importance), 8, 50*1000).wrap(core.SummonSkillWrapper)
+def SpiderInMirrorWrapper(enhancer, skill_importance, enhance_importance, LEVEL):
+    MirrorBreak = core.DamageSkill("스파이더 인 미러(공간 붕괴)", 960, 750+30*enhancer.getV(skill_importance, enhance_importance), 12, cooltime = 250*1000).wrap(core.DamageSkillWrapper)
+    # 5번 연속 공격 후 종료, 재돌입 대기시간 3초
+    MirrorSpider = core.SummonSkill("스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+17*enhancer.getV(skill_importance, enhance_importance), 8, 15*1000).wrap(core.SummonSkillWrapper)
+    MirrorBreak.onAfter(MirrorSpider)
+    # 235레벨 이상만 사용가능
+    SpiderInMirror = core.OptionalElement(lambda : (LEVEL >= 235), MirrorBreak)
+
+    return SpiderInMirror

--- a/dpmModule/jobs/hero.py
+++ b/dpmModule/jobs/hero.py
@@ -100,15 +100,18 @@ class JobGenerator(ck.JobGenerator):
         Panic = core.DamageSkill("패닉", 1080, 1150, 1, cooltime = 40000).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         PanicBuff = core.BuffSkill("패닉(디버프)", 0, 40000, cooltime = -1, pdamage_indep = 25, rem = False).wrap(core.BuffSkillWrapper)
         
-        RaisingBlow = core.DamageSkill("레이징 블로우", 600, 268, 6, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-        RaisingBlowInrage = core.DamageSkill("레이징 블로우(인레이지)", 600, 285, 4, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)  #이걸 사용함.
-        RaisingBlowInrageFinalizer = core.DamageSkill("레이징 블로우(인레이지)(최종타)", 0, 285, 2, modifier = core.CharacterModifier(pdamage = 20, crit = 100)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)  #이걸 사용함. 둘을 연결해야 함.
+        RaisingBlow = core.DamageSkill("레이징 블로우", 600, 200, 8, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        RaisingBlowInrage = core.DamageSkill("레이징 블로우(인레이지)", 570, 215, 6, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)  #이걸 사용함.
+        RaisingBlowInrageFinalizer = core.DamageSkill("레이징 블로우(인레이지)(최종타)", 0, 215, 2, modifier = core.CharacterModifier(pdamage = 20, crit = 100)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)  #이걸 사용함. 둘을 연결해야 함.
         
         Insizing = core.DamageSkill("인사이징", 660, 576, 4, cooltime = 30 * 1000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)    #870->640 오더스 적용 필요함. 도트뎀 (30초간 2초당 165%), 크리율에따른 뎀증 반영필요.
         InsizingBuff = core.BuffSkill("인사이징(버프)", 0, 30 * 1000, cooltime = -1, pdamage = 25).wrap(core.BuffSkillWrapper)
     
-        AdvancedFinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 250, 2 * 0.75).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-    
+        AdvancedFinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 170, 3 * 0.75).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+
+        # 현재 딜사이클 미포함 상태, 코어강화 수치 확인 필요
+        RisingRage = core.DamageSkill("레이지 업라이징", 750, 500, 8, cooltime = 10*1000).setV(vEhc, 0, 0, False).wrap(core.DamageSkillWrapper)
+
         Valhalla = core.BuffSkill("발할라", 840, 30 * 1000, cooltime = 150 * 1000, crit = 30, att = 50).wrap(core.BuffSkillWrapper)  #임의 배정된 공격속도.
         SwordOfBurningSoul = core.SummonSkill("소드 오브 버닝 소울", 820, 1000, (315+12*vEhc.getV(0,0)), 6, (60+0.5*vEhc.getV(0,0)) * 1000, cooltime = 120 * 1000, modifier = core.CharacterModifier(crit = 50)).isV(vEhc, 0, 0).wrap(core.SummonSkillWrapper)       #시전 딜레이 모름.
         

--- a/dpmModule/jobs/jobbranch/pirates.py
+++ b/dpmModule/jobs/jobbranch/pirates.py
@@ -10,6 +10,13 @@ class OverdriveWrapper:
         self.Overdrive = core.BuffSkill("오버드라이브", 540, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
         self.OverdrivePenalty = core.BuffSkill("오버드라이브(페널티)", 0, (40 - 0.2*vEhc.getV(num1, num2))*1000, cooltime = -1, att = -0.15 * WEAPON_ATT).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
 
+# 오버드라이브 함수 버전 (테스트 아직 안함)
+def OverdirveWrapper2(vEhc, num1, num2, WEAPON_ATT):
+    Overdrive = core.BuffSkill("오버드라이브", 540, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
+    OverdrivePenalty = core.BuffSkill("오버드라이브(페널티)", 0, (40 - 0.2*vEhc.getV(num1, num2))*1000, cooltime = -1, att = -0.15 * WEAPON_ATT).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
+    Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
+    return Overdrive
+
 def LoadedDicePassiveWrapper(vEhc, num1, num2):
     LoadedDicePassive = core.InformedCharacterModifier("로디드 다이스(패시브)", att = vEhc.getV(num1, num2) + 10)
     return LoadedDicePassive

--- a/dpmModule/jobs/jobbranch/pirates.py
+++ b/dpmModule/jobs/jobbranch/pirates.py
@@ -4,18 +4,14 @@ from ...kernel.core import CharacterModifier as MDF
 from ...character import characterKernel as ck
 from functools import partial
 
-
-class OverdriveWrapper:
-    def __init__(self, vEhc, WEAPON_ATT, num1, num2):
-        self.Overdrive = core.BuffSkill("오버드라이브", 540, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
-        self.OverdrivePenalty = core.BuffSkill("오버드라이브(페널티)", 0, (40 - 0.2*vEhc.getV(num1, num2))*1000, cooltime = -1, att = -0.15 * WEAPON_ATT).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
-
-# 오버드라이브 함수 버전 (테스트 아직 안함)
-def OverdirveWrapper2(vEhc, num1, num2, WEAPON_ATT):
+# 오버드라이브 함수 버전
+# 직업 소스에서 chtr.itemlist["weapon"].att 으로 무기 공격력 접근이 가능하나 강화 후 공격력이 나옴
+def OverdriveWrapper(vEhc, num1, num2, WEAPON_ATT):
     Overdrive = core.BuffSkill("오버드라이브", 540, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     OverdrivePenalty = core.BuffSkill("오버드라이브(페널티)", 0, (40 - 0.2*vEhc.getV(num1, num2))*1000, cooltime = -1, att = -0.15 * WEAPON_ATT).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
-    return Overdrive
+    OverdrivePenalty.set_disabled_and_time_left(-1)
+    return Overdrive, OverdrivePenalty
 
 def LoadedDicePassiveWrapper(vEhc, num1, num2):
     LoadedDicePassive = core.InformedCharacterModifier("로디드 다이스(패시브)", att = vEhc.getV(num1, num2) + 10)

--- a/dpmModule/jobs/jobbranch/thieves.py
+++ b/dpmModule/jobs/jobbranch/thieves.py
@@ -14,3 +14,9 @@ def ReadyToDieWrapper(vEhc, num1, num2):
 def ReadyToDiePassiveWrapper(vEhc, num1, num2):
     ReadyToDiePassive = core.InformedCharacterModifier("레디 투 다이(패시브)",att = vEhc.getV(num1, num2))
     return ReadyToDiePassive
+
+# 3개 직업의 코드가 통일이 안되어 있으므로 아직 쓰면 안됨
+# aDS = 어드밴스드 다크사이트 최종뎀값
+def UltimateDarkSightWrapper(vEhc, num1, num2, aDS = 0):
+    UltimateDarkSight = core.BuffSkill("얼티밋 다크사이트", 750, 30000, cooltime = (220-vEhc.getV(num1, num2))*1000, pdamage_indep= (10 + (vEhc.getV(num1, num2))//5)/(1+0.01*aDS)).wrap(core.BuffSkillWrapper)
+    return UltimateDarkSight

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -1,20 +1,13 @@
 from ...kernel import core
 from ...kernel.core import VSkillModifier as V
 from ...character import characterKernel as ck
-# 모험가 공용 5차스킬 통합코드
+# 모험가 및 모험가 직업 공용 5차스킬 통합코드
 
-#TODO: 얼닼사, 블리츠실드, 이볼브, 파이렛 플래그
-'''
-class MapleHero2:
-    #vEhc.getV(var1,var2)
-    def __init__(self, vEhc):
-        return
-    def mapleHero2(var1, var2):
-        return core.BuffSkill("메이플월드 여신의 축복")
-'''
+#TODO: 얼닼사
+
 # 모험가 법사
 # 3% 증가로 알고있는데... 확인필요
-# TODO : 재사용 대기시간 초기화 미적용으로 변경
+
 class InfinityWrapper(core.BuffSkillWrapper):
     def __init__(self, serverlag = 3):
         skill = core.BuffSkill("인피니티", 960, 40000, cooltime = 180 * 1000, rem = True, red = False)
@@ -38,6 +31,8 @@ class InfinityWrapper(core.BuffSkillWrapper):
         return super(InfinityWrapper, self)._use(rem = rem, red = red)
 
 # 이하 모든 코드 테스트 필요
+
+# 레지스탕스도 이 코드를 사용
 def MapleHeroes2Wrapper(vEhc, num1, num2, level):
     MapleHeroes2 = core.BuffSkill("메이플월드 여신의 축복", 450, 60*1000, stat_main = 0.01 * (100 + 10 * vEhc.getV(num1, num2)) * (25 + level * 5), pdamage = 5 + vEhc.getV(num1, num2) // 2, cooltime = 180*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     return MapleHeroes2
@@ -49,10 +44,10 @@ def PirateFlagWrapper(vEhc, num1, num2, level):
 # 작성중, 2초 후 폭발 가정
 def BlitzShieldWrappers(vEhc, num1, num2):
     # 딜레이 추가 필요
-    BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 0, 2000, cooltime = 15000).wrap(core.BuffSkillWrapper)
+    BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 600, 2000, cooltime = 15000).wrap(core.BuffSkillWrapper)
     BlitzShield = core.DamageSkill("블리츠 실드", 2000, vEhc.getV(num1, num2)*20+500, 5).wrap(core.DamageSkillWrapper)
-    #BlitzShieldDummy.onAfter(BlitzShield)
-    return BlitzShieldDummy, BlitzShield
+    BlitzShieldDummy.onAfter(BlitzShield)
+    return BlitzShieldDummy
 
 # 아직 사용하지 말것! 연계 설정 추가 필요
 def EvolveWrapper(vEhc, num1, num2):

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -48,19 +48,18 @@ def PirateFlagWrapper(vEhc, num1, num2, level):
 
 # 작성중, 2초 후 폭발 가정
 def BlitzShieldWrappers(vEhc, num1, num2):
-    BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 0, 2000, cooltime = -1).wrap(core.BuffSkillWrapper)
-    BlitzShield = core.DamageSkill("블리츠 실드", 0, vEhc.getV(num1, num2)*20+500, 5, cooltime = 15000).isV(vEhc, num1, num2).wrap(core.DamageSkillWrapper)
+    # 딜레이 추가 필요
+    BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 0, 2000, cooltime = 15000).wrap(core.BuffSkillWrapper)
+    BlitzShield = core.DamageSkill("블리츠 실드", 2000, vEhc.getV(num1, num2)*20+500, 5).wrap(core.DamageSkillWrapper)
+    #BlitzShieldDummy.onAfter(BlitzShield)
+    return BlitzShieldDummy, BlitzShield
+
+# 아직 사용하지 말것! 연계 설정 추가 필요
+def EvolveWrapper(vEhc, num1, num2):
+    Evolve = core.BuffSkill("이볼브", 600, 3330, 450+vEhc.getV(num1, num2)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(num1, num2)))*1000).isV(vEhc,num1, num2).wrap(core.SummonSkillWrapper)
+    return Evolve
+
 '''
-블리츠 실드
-HP 5% 소비, 최대 HP의 20%의[23] 피해를 막아주는 보호막을 5초간 생성
-보호막의 지속시간이 끝나거나 스킬을 다시 사용하면 보호막이 폭발하여 최대 12명의 적을 1000%의[(스킬 레벨*20+500)%의 데미지] 데미지로 5번 공격
-보호막이 생성된 후 2초가 지나야 스킬을 다시 사용하여 수동 폭발 가능
-재사용 대기시간 15초
-
-이볼브
-MP 800 소비, 40초 동안 강화되어 최대 10명의 적을 825%[(스킬 레벨*15+450)%의 데미지] 데미지로 7번 공격
-재사용 대기시간 108초[(121-스킬 레벨*0.5)초. 소숫점은 버린다.]
-
 얼티밋 다크 사이트
 MP 850 소비, 30초 동안 다크 사이트 중 공격 및 스킬 사용 시 은신이 해제되지 않음
 다크 사이트 중 공격 시 최종 데미지 15%[기본 10%에서 5레벨마다 1% 증가한다.] 증가, 어드밴스드 다크 사이트의 최종 데미지 증가와 합적용

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -17,7 +17,7 @@ class MapleHero2:
 # TODO : 재사용 대기시간 초기화 미적용으로 변경
 class InfinityWrapper(core.BuffSkillWrapper):
     def __init__(self, serverlag = 3):
-        skill = core.BuffSkill("인피니티", 960, 40000, cooltime = 180 * 1000, rem = True, red = True)
+        skill = core.BuffSkill("인피니티", 960, 40000, cooltime = 180 * 1000, rem = True, red = False)
         super(InfinityWrapper, self).__init__(skill)
         self.passedTime = 0
         self.serverlag = serverlag
@@ -29,7 +29,7 @@ class InfinityWrapper(core.BuffSkillWrapper):
             
     def get_modifier(self):
         if self.onoff:
-            return core.CharacterModifier(pdamage_indep = (70 + 4 * (self.passedTime // ((4+self.serverlag)*1000))) )
+            return core.CharacterModifier(pdamage_indep = (70 + 3 * (self.passedTime // ((4+self.serverlag)*1000))) )
         else:
             return core.CharacterModifier()
         

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -47,7 +47,7 @@ def BlitzShieldWrappers(vEhc, num1, num2):
     BlitzShieldDummy = core.BuffSkill("블리츠 실드 (더미)", 600, 2000, cooltime = 15000).wrap(core.BuffSkillWrapper)
     BlitzShield = core.DamageSkill("블리츠 실드", 2000, vEhc.getV(num1, num2)*20+500, 5).wrap(core.DamageSkillWrapper)
     BlitzShieldDummy.onAfter(BlitzShield)
-    return BlitzShieldDummy
+    return BlitzShieldDummy, BlitzShield
 
 # 아직 사용하지 말것! 연계 설정 추가 필요
 def EvolveWrapper(vEhc, num1, num2):

--- a/dpmModule/jobs/jobclass/cygnus.py
+++ b/dpmModule/jobs/jobclass/cygnus.py
@@ -8,14 +8,43 @@ def PhalanxChargeWrapper(vEhc, num1, num2):
     PhalanxCharge = core.DamageSkill("시그너스 팔랑크스", 780, 450 + 18*vEhc.getV(num1, num2), 40 + vEhc.getV(num1, num2), cooltime = 30 * 1000).isV(vEhc, num1, num2).wrap(core.DamageSkillWrapper)
     return PhalanxCharge
 
-# 인피니티와 유사한 매커니즘이므로 별도의 클래스 작성 필요
-#세부값 확인해서 변경필요
-#MP 500 소비, 45초 동안 데미지 25% 증가, 일정 시간마다 HP 4%씩 회복 및 데미지 3% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 90%까지 증가
-#MP 500 소비, 45초 동안 데미지 25% 증가 및 최대 HP의 일정 비율로 피해를 입히는 공격을 포함한 피격 데미지 5% 감소, 일정 시간마다 HP 7%씩 회복 및 데미지 5% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 120%까지 증가
+class CygnusBlessWrapper(core.BuffSkillWrapper):
+    def __init__(self, enhancer, skill_importance, enhance_importance, serverlag = 3, level = 230):
+        self.isUpgraded = (level >= 245) 
+        self.enhancer = enhancer
+        self.skill_importance = skill_importance
+        self.enhance_importance = enhance_importance
+        
+        # 스킬 딜레이, 쿨타임 확인 필요
+        skill = core.BuffSkill("초월자 시그너스의 축복" if isUpgraded else "여제 시그너스의 축복" , 450, 45000, cooltime = 240*1000).wrap(core.BuffSkillWrapper)
+        super(CygnusBlessWrapper, self).__init__(skill)
 
-def CygnusBlessWrapper(vEhc, num1, num2, LEVEL):
-    if LEVEL < 245:
-        CygnusBless = core.BuffSkill("여제 시그너스의 축복", 450, (30+vEhc.getV(num1, num2)//2)*1000, pdamage = (30+vEhc.getV(num1, num2)//5) *1.2 + 20, cooltime = 240*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
-    else:
-        CygnusBless = core.BuffSkill("초월자 시그너스의 축복", 450, (30+vEhc.getV(num1, num2)//2)*1000, pdamage = (30+vEhc.getV(num1, num2)//5) *1.2 + 20, cooltime = 240*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
-    return CygnusBless
+        self.passedTime = 0
+        self.serverlag = serverlag
+
+    def spend_time(self, time):
+        if self.onoff:
+            self.passedTime += time
+        super(CygnusBlessWrapper, self).spend_time(time)
+    
+    #세부값 확인해서 변경필요
+    #MP 500 소비, 45초 동안 데미지 25% 증가, 일정 시간마다 HP 4%씩 회복 및 데미지 3% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 90%까지 증가
+    #MP 500 소비, 45초 동안 데미지 25% 증가 및 최대 HP의 일정 비율로 피해를 입히는 공격을 포함한 피격 데미지 5% 감소, 일정 시간마다 HP 7%씩 회복 및 데미지 5% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 120%까지 증가
+
+    def calc_damage(self):
+        interval = 4
+        if self.isUpgraded:
+            pd_value = min(25 + 5 * (self.passedTime // ((interval + self.serverlag) * 1000)), 120)
+        else:
+            pd_value = min(25 + 3 * (self.passedTime // ((interval + self.serverlag) * 1000)), 90)
+        return pd_value
+
+    def get_modifier(self):
+        if self.onoff:
+            return core.CharacterModifier(pdamage = self.calc_damage())
+        else:
+            return core.CharacterModifier()
+        
+    def _use(self, rem = 0, red = 0):
+        self.passedTime = 0
+        return super(CygnusBlessWrapper, self)._use(rem = rem, red = red)

--- a/dpmModule/jobs/jobclass/cygnus.py
+++ b/dpmModule/jobs/jobclass/cygnus.py
@@ -15,10 +15,19 @@ class CygnusBlessWrapper(core.BuffSkillWrapper):
         self.skill_importance = skill_importance
         self.enhance_importance = enhance_importance
         
-        # 스킬 딜레이, 쿨타임 확인 필요
-        skill = core.BuffSkill("초월자 시그너스의 축복" if isUpgraded else "여제 시그너스의 축복" , 450, 45000, cooltime = 240*1000).wrap(core.BuffSkillWrapper)
+        skill = core.BuffSkill("초월자 시그너스의 축복" if isUpgraded else "여제 시그너스의 축복" , 630, 45000, cooltime = 240*1000).wrap(core.BuffSkillWrapper)
         super(CygnusBlessWrapper, self).__init__(skill)
 
+        self.damage_point = 4 + (enhancer.getV(self.skill_importance, self.enhance_importance))//15
+        self.damage_limit = 90
+        #interval: 데미지 증가 주기 (모름)
+        self.interval = 4
+        
+        # 업그레이드 상태일경우 해당 스펙 적용
+        if self.isUpgraded:
+            self.damage_point += 2
+            self.damage_limit += 30
+            
         self.passedTime = 0
         self.serverlag = serverlag
 
@@ -26,22 +35,11 @@ class CygnusBlessWrapper(core.BuffSkillWrapper):
         if self.onoff:
             self.passedTime += time
         super(CygnusBlessWrapper, self).spend_time(time)
-    
-    #세부값 확인해서 변경필요
-    #MP 500 소비, 45초 동안 데미지 25% 증가, 일정 시간마다 HP 4%씩 회복 및 데미지 3% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 90%까지 증가
-    #MP 500 소비, 45초 동안 데미지 25% 증가 및 최대 HP의 일정 비율로 피해를 입히는 공격을 포함한 피격 데미지 5% 감소, 일정 시간마다 HP 7%씩 회복 및 데미지 5% 추가 증가, 시그너스의 축복으로 증가하는 데미지는 합 적용이며 최대 120%까지 증가
-
-    def calc_damage(self):
-        interval = 4
-        if self.isUpgraded:
-            pd_value = min(25 + 5 * (self.passedTime // ((interval + self.serverlag) * 1000)), 120)
-        else:
-            pd_value = min(25 + 3 * (self.passedTime // ((interval + self.serverlag) * 1000)), 90)
-        return pd_value
 
     def get_modifier(self):
+        
         if self.onoff:
-            return core.CharacterModifier(pdamage = self.calc_damage())
+            return core.CharacterModifier(pdamage = min(enhancer.getV(self.skill_importance, self.enhance_importance) + self.damage_point * (self.passedTime // ((self.interval + self.serverlag) * 1000)), self.damage_limit))
         else:
             return core.CharacterModifier()
         

--- a/dpmModule/jobs/jobclass/cygnus.py
+++ b/dpmModule/jobs/jobclass/cygnus.py
@@ -9,21 +9,24 @@ def PhalanxChargeWrapper(vEhc, num1, num2):
     return PhalanxCharge
 
 class CygnusBlessWrapper(core.BuffSkillWrapper):
+    # 코드 정리 필요
     def __init__(self, enhancer, skill_importance, enhance_importance, serverlag = 3, level = 230):
-        self.isUpgraded = (level >= 245) 
+        skill = core.BuffSkill("초월자 시그너스의 축복" if level >= 245 else "여제 시그너스의 축복" , 630, 45000, cooltime = 240*1000).wrap(core.BuffSkillWrapper)
+        super(CygnusBlessWrapper, self).__init__(skill)
+
+        self.isUpgraded = (level >= 245)
+
         self.enhancer = enhancer
         self.skill_importance = skill_importance
         self.enhance_importance = enhance_importance
-        
-        skill = core.BuffSkill("초월자 시그너스의 축복" if isUpgraded else "여제 시그너스의 축복" , 630, 45000, cooltime = 240*1000).wrap(core.BuffSkillWrapper)
-        super(CygnusBlessWrapper, self).__init__(skill)
 
         self.damage_point = 4 + (enhancer.getV(self.skill_importance, self.enhance_importance))//15
         self.damage_limit = 90
-        #interval: 데미지 증가 주기 (모름)
+        
+        #interval: 데미지 증가 주기 (확인 필요)
         self.interval = 4
         
-        # 업그레이드 상태일경우 해당 스펙 적용
+        # 업그레이드 상태일경우 스펙 증가치 적용
         if self.isUpgraded:
             self.damage_point += 2
             self.damage_limit += 30

--- a/dpmModule/jobs/jobclass/demon.py
+++ b/dpmModule/jobs/jobclass/demon.py
@@ -4,12 +4,13 @@ from ...kernel.core import CharacterModifier as MDF
 from ...character import characterKernel as ck
 from functools import partial
 
-'''
-최대 HP의 20% 소비, 55초[(스킬 레벨+30)초] 동안 마스테마 소환, 재사용 대기시간 150초, 소환된 마스테마는 스스로의 판단으로 아래의 스킬을 시전
-마스테마 클로우: 최대 8명의 적을 1000%[(스킬 레벨*20+500)%의 데미지]의 데미지로 8번 공격, 재사용 대기시간 5초
-러블리 테리토리: 6초 동안 최대 HP의 일정 비율로 피해를 입히는 공격을 포함한 피격 데미지 22%를 2회 감소시키는 버프를 시전, 지속시간이 끝나거나 감소 횟수를 모두 소비하면 버프 소멸, 재사용 대기시간 8초
+# 마스테마 클로우를 쿨타임마다 시전한다고 가정
+def CallMastemaWrapper(vEhc, num1, num2):
+    CallMastema = core.BuffSkill("콜 마스테마(버프)", 690, (30 + vEhc.getV(num1, num2))*1000, cooltime = 150*1000).wrap(core.BuffSkillWrapper)
+    MastemaClaw_Attack = core.DamageSkill("마스테마 클로우", 0, 500 + 20 *vEhc.getV(num1, num2), 8, cooltime=4000).wrap(core.DamageSkillWrapper)
+    MastemaClaw = core.OptionalElement(CallMastema.is_active(), MastemaClaw_Attack)
+    return CallMastema, MastemaClaw
 
-'''
 
 class AnotherWorldGoddessWrapper(core.BuffSkillWrapper):
     def __init__(self, vEhc, num1, num2):

--- a/dpmModule/jobs/jobclass/demon.py
+++ b/dpmModule/jobs/jobclass/demon.py
@@ -11,6 +11,13 @@ from functools import partial
 
 '''
 
+class AnotherWorldGoddessWrapper(core.BuffSkillWrapper):
+    def __init__(self, vEhc, num1, num2):
+        self.vlevel = vEhc.getV(num1, num2)
+        vlevel = self.vlevel
+        super(AnotherWorldGoddessWrapper, self).__init__(skill = core.BuffSkill("이계 여신의 축복", num1, num2, pdamage_indep=6+(vlevel-1)//5).isV(vEhc, num1, num2))
+        self.skillList = [core.BuffSkill("회복의 축복"), core.BuffSkill("방패의 축복"), core.BuffSkill("보호의 축복"), core.BuffSkill(("이계의 공허"))]
+
 '''
 최대 HP의 5% 소비, 40초 동안 최종 데미지 [1레벨에서 6%, 6, 11, 16, 21, 26레벨에서 1%씩 증가] 증가, 일정 시간마다 각종 축복 및 공격을 시전, 축복 시전 시 이전 축복이 남아있다면 소멸
 회복의 축복: DF/PP/HP 중 자신이 사용하는 쪽을 최대치의 27%[(15 + 스킬레벨/2)%, 소수점은 버린다.] 회복, 특정한 회복 불가 상황에도 회복 가능

--- a/dpmModule/jobs/jobclass/demon.py
+++ b/dpmModule/jobs/jobclass/demon.py
@@ -11,13 +11,13 @@ def CallMastemaWrapper(vEhc, num1, num2):
     MastemaClaw = core.OptionalElement(CallMastema.is_active(), MastemaClaw_Attack)
     return CallMastema, MastemaClaw
 
-
-class AnotherWorldGoddessWrapper(core.BuffSkillWrapper):
-    def __init__(self, vEhc, num1, num2):
-        self.vlevel = vEhc.getV(num1, num2)
-        vlevel = self.vlevel
-        super(AnotherWorldGoddessWrapper, self).__init__(skill = core.BuffSkill("이계 여신의 축복", num1, num2, pdamage_indep=6+(vlevel-1)//5).isV(vEhc, num1, num2))
-        self.skillList = [core.BuffSkill("회복의 축복"), core.BuffSkill("방패의 축복"), core.BuffSkill("보호의 축복"), core.BuffSkill(("이계의 공허"))]
+def AnotherWorldWrapper(vEhc, num1, num2):
+    # 공격 확률 100%로 가정
+    void_chance = 1
+    AnotherGoddessBuff = core.BuffSkill("이계 여신의 축복", 630, 40000, cooltime = 120000, pdamage_indep=6+(vEhc.getV(num1, num2)-1)//5).wrap(core.BuffSkillWrapper)
+    AnotherVoid = core.SummonSkill("이계의 공허", 0, 3000 / void_chance, 1200+48*vEhc.getV(num1, num2), 12, 40000, cooltime = -1).wrap(core.BuffSkillWrapper)
+    AnotherGoddessBuff.onAfter(AnotherVoid)
+    return AnotherGoddessBuff, AnotherVoid
 
 '''
 최대 HP의 5% 소비, 40초 동안 최종 데미지 [1레벨에서 6%, 6, 11, 16, 21, 26레벨에서 1%씩 증가] 증가, 일정 시간마다 각종 축복 및 공격을 시전, 축복 시전 시 이전 축복이 남아있다면 소멸

--- a/dpmModule/jobs/jobclass/flora.py
+++ b/dpmModule/jobs/jobclass/flora.py
@@ -5,6 +5,10 @@ from ...character import characterKernel as ck
 from functools import partial
 
 #레프
+def FloraGoddessBlessWrapper(vEhc, num1, num2, WEAPON_ATT):
+    # 장비 비례 증가 수치는 최대치로 가정
+    FloraGoddessBless = core.BuffSkill("그란디스 여신의 축복(레프)", 450, 40*1000, att = 10 + 3 * vEhc.getV(num1, num2) + 1.5 * WEAPON_ATT, cooltime = 240*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
+    return FloraGoddessBless
 
 class MagicCircuitFullDriveBuilder():
     def __init__(self, vEhc, num1, num2, mana=100):

--- a/dpmModule/jobs/jobclass/flora.py
+++ b/dpmModule/jobs/jobclass/flora.py
@@ -11,12 +11,13 @@ def FloraGoddessBlessWrapper(vEhc, num1, num2, WEAPON_ATT):
     return FloraGoddessBless
 
 class MagicCircuitFullDriveBuilder():
-    def __init__(self, vEhc, num1, num2, mana=100):
+    def __init__(self, vEhc, num1, num2, mana = 100):
         # 마나 최대치 유지 가정, 비율에 따라 수치가 어떻게 변동되는지 확인 필요
         # 마력 폭풍 발생 시 데미지 증가량 갱신하지 않음
         self.MANA = mana
-        self.MagicCircuitFullDriveBuff = core.BuffSkill("매직 서킷 풀드라이브 (버프)", 0, 30+vEhc.getV(num1, num2), cooltime = 200*1000, pdamage= (20+vEhc.getV(num1, num2)) * (self.MANA/100)).wrap(core.BuffSkillWrapper)
+        self.MagicCircuitFullDriveBuff = core.BuffSkill("매직 서킷 풀드라이브 (버프)", 720, 30+vEhc.getV(num1, num2), cooltime = 200*1000, pdamage= (20+vEhc.getV(num1, num2)) * (self.MANA/100)).wrap(core.BuffSkillWrapper)
         self.ManaStorm = core.SummonSkill("매직 서킷 풀드라이브 (마나 폭풍)", 0, 4000, 500+20*vEhc.getV(num1, num2), 3, 30+vEhc.getV(num1, num2), cooltime = -1).wrap(core.SummonSkillWrapper)
+        self.MagicCircuitFullDriveBuff.onAfter(self.ManaStorm)
 
     def get_skill(self):
         return self.MagicCircuitFullDriveBuff, self.ManaStorm

--- a/dpmModule/jobs/jobclass/nova.py
+++ b/dpmModule/jobs/jobclass/nova.py
@@ -4,9 +4,10 @@ from ...kernel.core import CharacterModifier as MDF
 from ...character import characterKernel as ck
 from functools import partial
 
-#TODO: 판테온 추가 4000%[(스킬 레벨*80+2000)%] 데미지로 10번 공격, 쿨타임 1200초
-
 def NovaGoddessBlessWrapper(vEhc, num1, num2):
     #TODO: (40+0.5*스킬레벨)%, 소수점 아래로 버림. 확률로 재사용 대기시간 미적용, 최대 5회까지만 미적용 가능
     NovaGoddessBless = core.BuffSkill("그란디스 여신의 축복(노바)", 450, 40*1000, pdamage = 5+vEhc.getV(num1, num2), cooltime = 240*1000).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     return NovaGoddessBless
+
+def PantheonWrapper(vEhc, num1, num2):
+    Pantheon = core.DamageSkill("판테온", 510, 2000 + 80 * vEhc.getV(num1, num2), 10, cooltime = 1200*1000).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/jobclass/nova.py
+++ b/dpmModule/jobs/jobclass/nova.py
@@ -11,3 +11,4 @@ def NovaGoddessBlessWrapper(vEhc, num1, num2):
 
 def PantheonWrapper(vEhc, num1, num2):
     Pantheon = core.DamageSkill("판테온", 510, 2000 + 80 * vEhc.getV(num1, num2), 10, cooltime = 1200*1000).wrap(core.DamageSkillWrapper)
+    return Pantheon

--- a/dpmModule/jobs/kaiser.py
+++ b/dpmModule/jobs/kaiser.py
@@ -79,8 +79,8 @@ class JobGenerator(ck.JobGenerator):
         BlazeUp = core.BuffSkill("블레이즈 업", 0, 240000, att = 20, rem = True).wrap(core.BuffSkillWrapper)
     
         FinalFiguration = core.BuffSkill("파이널 피규레이션", 0, 60000, pdamage_indep = 15, cooltime = -1).wrap(MorphGaugeWrapper)
-        Wingbit_1 = core.SummonSkill("윙비트", 540, 300, 200, 1, 19400, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 3, False).wrap(core.SummonSkillWrapper)  #48타
-        Wingbit_2 = core.SummonSkill("윙비트(2)", 540, 300, 200, 1, 19400, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 3, False).wrap(core.SummonSkillWrapper)  #48타
+        Wingbit_1 = core.SummonSkill("윙비트", 360, 300, 200, 1, 19400, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 3, False).wrap(core.SummonSkillWrapper)  #48타
+        Wingbit_2 = core.SummonSkill("윙비트(2)", 360, 300, 200, 1, 19400, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 3, False).wrap(core.SummonSkillWrapper)  #48타
         
         GigaSlasher_ = core.DamageSkill("기가 슬래셔", 540, 330, 9+1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         GigaSlasher_Fig = core.DamageSkill("기가 슬래셔(변신)", 540, 330, 11+1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -154,8 +154,8 @@ class JobGenerator(ck.JobGenerator):
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 180 * 1000, rem = True).wrap(core.BuffSkillWrapper)    #딜레이 모름
         PodicMeditaion = core.BuffSkill("포딕 메디테이션", 0, 1800000, att = 40).wrap(core.BuffSkillWrapper)
-        DarkCrescendo = core.BuffSkill("다크 크레센도", 450, 180 * 1000, pdamage = 28, rem = True).wrap(core.BuffSkillWrapper)#<- 제대로 계산 필요함. 딜레이 모름
-        DarknessSocery = core.BuffSkill("다크니스 소서리(버프)", 510, 180 * 1000, rem = True).wrap(core.BuffSkillWrapper)    #딜레이 모름
+        DarkCrescendo = core.BuffSkill("다크 크레센도", 360, 180 * 1000, pdamage = 28, rem = True).wrap(core.BuffSkillWrapper)#<- 제대로 계산 필요함. 딜레이 모름
+        DarknessSocery = core.BuffSkill("다크니스 소서리(버프)", 210, 180 * 1000, rem = True).wrap(core.BuffSkillWrapper)    #딜레이 모름
         HerosOath = core.BuffSkill("히어로즈 오쓰", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10, rem = True).wrap(core.BuffSkillWrapper)
         Memorize = core.BuffSkill("메모라이즈", 600, 10, cooltime = 150 * 1000, rem = True).wrap(core.BuffSkillWrapper)#Memorize <- 역시 제대로 계산 필요함. 딜레이 모음
     
@@ -175,8 +175,8 @@ class JobGenerator(ck.JobGenerator):
         Attack = core.DamageSkill('기본 공격', 0, 0, 0).wrap(core.DamageSkillWrapper)
         
         
-        LightReflection = core.DamageSkill("라이트 리플렉션", 720, 400, 4 * 1.5, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        Apocalypse = core.DamageSkill("아포칼립스", 855, 340, 7 * 1.5,modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        LightReflection = core.DamageSkill("라이트 리플렉션", 690, 400, 4 * 1.5, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        Apocalypse = core.DamageSkill("아포칼립스", 720, 340, 7 * 1.5,modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         AbsoluteKill = core.DamageSkill("앱솔루트 킬", 600, 385, 7*2,modifier = core.CharacterModifier(pdamage = 20, crit = 100, armor_ignore=40)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
         AbsoluteKillCooltimed = core.DamageSkill('앱솔루트 킬(쿨타임)', 600, 385, 7*2, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 20, crit = 100, armor_ignore=40)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -7,9 +7,8 @@ from . import globalSkill
 from .jobclass import resistance
 from .jobbranch import pirates
 
-#TODO:
-
-#[로봇 마스터리] : 로봇의 최종 데미지 증가량이 70%에서 105%로 증가됩니다.
+# TODO: 워머신 타이탄 추가 (로봇 마스터리 적용)
+# TODO: [메탈아머 전탄발사] : 호밍 미사일 리로드 지속시간이 4초에서 2초로 감소되고 지속시간이 좀 더 정확하게 적용됩니다.
 
 ######   Passive Skill   ######
 
@@ -63,18 +62,18 @@ class JobGenerator(ck.JobGenerator):
         #로봇들 :: 로봇당 총뎀6%
         Opengate = core.SummonSkill("오픈 게이트:GX-9", 600, 300*1000, 0,0,300*1000*1.4, rem = True).wrap(core.SummonSkillWrapper)#임의 딜레이
         
-        Robolauncher = core.SummonSkill("로보런쳐:RM7", 630, 1000, (250+135)*2.05, 1, 60*1000*1.4, rem=True).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        RobolauncherFinal = core.DamageSkill("로보런쳐:RM7(폭발)", 0, 400*2.05, 1, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        RobolauncherBuff = core.BuffSkill("로보런쳐:RM7(버프)", 0, 60*1000*1.4, cooltime = -1, pdamage = 6).wrap(core.BuffSkillWrapper)
+        Robolauncher = core.SummonSkill("로봇런쳐:RM7", 630, 1000, (250+135)*2.05, 1, 60*1000*1.4, rem=True).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        RobolauncherFinal = core.DamageSkill("로봇런쳐:RM7(폭발)", 0, 400*2.05, 1, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        RobolauncherBuff = core.BuffSkill("로봇런쳐:RM7(버프)", 0, 60*1000*1.4, cooltime = -1, pdamage = 6).wrap(core.BuffSkillWrapper)
         #MagneticField = core.SummonSkill("마그네틱 필드", ?, ?, 200, 60*1000, cooltime = 180*1000) 자폭 550% V.getEhc(2, vEnhance[0])
         
         SupportWaver = core.SummonSkill("서포트 웨이버", 630, 80000*1.4, 0, 0, 80*1000*1.4).wrap(core.SummonSkillWrapper)
         SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*1.4, pdamage_indep=15, pdamage= 5 + 6, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)    #하이퍼(+5), 소환수직속 영향받게..
         SupportWaverFinal = core.DamageSkill("서포트 웨이버(폭발)", 0, 1100*2.05, 1, cooltime = -1).wrap(core.DamageSkillWrapper)
         
-        RoboFactory = core.SummonSkill("로보 팩토리", 630, 3000, 500*2.05, 3, 30*1000*1.4, cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
-        RoboFactoryFinal = core.DamageSkill("로보 팩토리(폭발)", 0, 1000*2.05, 1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
-        RoboFactoryBuff = core.BuffSkill("로보 팩토리(버프)", 0, 30*1000*1.4, cooltime = -1, pdamage = 6).wrap(core.BuffSkillWrapper)
+        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500*2.05, 3, 30*1000*1.4, cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
+        RoboFactoryFinal = core.DamageSkill("로봇 팩토리(폭발)", 0, 1000*2.05, 1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*1.4, cooltime = -1, pdamage = 6).wrap(core.BuffSkillWrapper)
         
         BomberTime = core.BuffSkill("봄버 타임", 990, 10*1000, cooltime = 100*1000).wrap(core.BuffSkillWrapper)
         DistortionField = core.SummonSkill("디스토션 필드", 690, 4000/30, 350, 2, 4000-1, cooltime = 8000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -82,9 +82,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = 150
-        OverdriveBuff = pirates.OverdriveWrapper(vEhc, WEAPON_ATT, 5, 5)
-        Overdrive = OverdriveBuff.Overdrive
-        OverdrivePenalty = OverdriveBuff.OverdrivePenalty
+        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         RegistanceLineInfantry = resistance.ResistanceLineInfantryWrapper(vEhc, 3, 3)
         MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1500, 75+2*vEhc.getV(2,1), 6, (115+6*vEhc.getV(2,1))*1000, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
@@ -132,8 +130,6 @@ class JobGenerator(ck.JobGenerator):
         
         RoboFactory.onAfter(RoboFactoryFinal.controller(1))
         RoboFactory.onAfter(RoboFactoryBuff.controller(1))
-        
-        Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
 
         BusterCallBuff.protect_from_running()
         

--- a/dpmModule/jobs/michael.py
+++ b/dpmModule/jobs/michael.py
@@ -74,14 +74,14 @@ class JobGenerator(ck.JobGenerator):
         
         SoulAttack = core.BuffSkill("소울 어택", 0, 10000, cooltime = -1, pdamage_indep = 25, crit = 20).wrap(core.BuffSkillWrapper)
         
-        FinalAttack = core.DamageSkill("파이널 어택", 0, 185*2, 0.75).setV(vEhc, 3, 4, False).wrap(core.DamageSkillWrapper)
+        FinalAttack = core.DamageSkill("파이널 어택", 0, 95*4, 0.75).setV(vEhc, 3, 4, False).wrap(core.DamageSkillWrapper)
         Booster = core.BuffSkill("부스터", 0, 180000, rem = True).wrap(core.BuffSkillWrapper)
         Invigorate = core.BuffSkill("격려", 0, 180000, rem = True, att = 30).wrap(core.BuffSkillWrapper)
         
-        SoulAssult = core.DamageSkill("소울 어썰트", 600, 280, 8+1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)   #암흑 20%
+        SoulAssult = core.DamageSkill("소울 어썰트", 600, 210, 11+1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)   #암흑 20%
         
-        ShiningCross = core.DamageSkill("샤이닝 크로스", 640, 440, 4 + 1, cooltime = 7000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #암흑 30% 10초
-        ShiningCrossInstall = core.SummonSkill("샤이닝 크로스(인스톨)", 0, 1200, 75, 4+1, 7000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)    #100% 암흑 5초
+        ShiningCross = core.DamageSkill("샤이닝 크로스", 600, 440, 4 + 1, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #암흑 30% 10초
+        ShiningCrossInstall = core.SummonSkill("샤이닝 크로스(인스톨)", 0, 1200, 75, 4+1, 12000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)    #100% 암흑 5초
         
         #하이퍼
         SacredCube = core.BuffSkill("세이크리드 큐브", 90, 30000, cooltime = 210000, pdamage = 10).wrap(core.BuffSkillWrapper)
@@ -97,8 +97,8 @@ class JobGenerator(ck.JobGenerator):
         ClauSolis = core.DamageSkill("클라우 솔리스", 900, 700+28*vEhc.getV(4,4), 7, red = True, cooltime = 12000).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)    #로얄가드 버프지속시간 6초 증가. 100% 암흑 5초
         ClauSolisSummon = core.SummonSkill("클라우 솔리스(소환)", 0, 5000, 350+14*vEhc.getV(4,4), 7, 9000, cooltime = -1).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)   #100% 암흑 5초
     
-        SwordOfSoullight = core.BuffSkill("소드 오브 소울라이트", 1050, 30000, red = True, cooltime = 180*1000, patt = 15+int(0.5*vEhc.getV(1,1)), crit = 100, armor_ignore = 100).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)
-        SoullightSlash = core.DamageSkill("소울 라이트 슬래시", 600, 650+26*vEhc.getV(1,1), 7).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        SwordOfSoullight = core.BuffSkill("소드 오브 소울 라이트", 1050, 30000, red = True, cooltime = 180*1000, patt = 15+int(0.5*vEhc.getV(1,1)), crit = 100, armor_ignore = 100).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)
+        SoullightSlash = core.DamageSkill("소울 라이트 슬래시", 600, 400+16*vEhc.getV(1,1), 12).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         ##### Build Graph
         
         BasicAttack = core.OptionalElement(SwordOfSoullight.is_active, SoullightSlash, SoulAssult)

--- a/dpmModule/jobs/nightlord.py
+++ b/dpmModule/jobs/nightlord.py
@@ -78,7 +78,8 @@ class JobGenerator(ck.JobGenerator):
     
         #_VenomBurst = core.DamageSkill("베놈 버스트", ??) ## 패시브 50%확률로 10초간 160+6*vlevel dot. 사용시 도트뎀 모두 피해 + (500+20*vlevel) * 5. 어차피 안쓰는 스킬이므로 작성X
         
-        UltimateDarksight = core.BuffSkill("얼티밋 다크사이트", 750, 30*1000, cooltime = (220-vEhc.getV(3,3))*1000, pdamage_indep=int(0.5*vEhc.getV(3,3))).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
+        UltimateDarksight = thieves.UltimateDarkSightWrapper(vEhc, 3, 3)
+        #UltimateDarksight = core.BuffSkill("얼티밋 다크사이트", 750, 30*1000, cooltime = (220-vEhc.getV(3,3))*1000, pdamage_indep=int(0.5*vEhc.getV(3,3))).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 1, 1)
 #        ReadyToDie = core.BuffSkill("레디 투 다이", 780, 30*1000, cooltime = (90-int(0.5*vlevel))*1000, pdamage_indep = 30+int(0.2*vlevel)).wrap(core.BuffSkillWrapper)
         

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -8,6 +8,8 @@ from . import globalSkill
 from .jobbranch import warriors
 
 #TODO : 5차 신스킬 적용
+# 4차 스킬은 컴뱃오더스 적용 기준으로 작성해야 함.
+# 생츄어리 필요한지 확인바람
 
 ######   Passive Skill   ######
 
@@ -65,7 +67,7 @@ class JobGenerator(ck.JobGenerator):
         LighteningChargeDOT = core.DotSkill("라이트닝 차지(도트)", 115, 6000).wrap(core.SummonSkillWrapper)
         DivineCharge = core.DamageSkill("디바인 차지", 810, 462, 3, cooltime = 60 * 1000).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         
-        Blast = core.DamageSkill("블래스트", 630, 318, 8+2+1, modifier = core.CharacterModifier(crit=20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        Blast = core.DamageSkill("블래스트", 630, 291, 8+2+1, modifier = core.CharacterModifier(crit=20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
         #Summon Skills
         BlessedHammer = core.SummonSkill("블레스드 해머", 0, 600, (250 + vEhc.getV(1,1)*10), 2, 999999* 10000).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)   #딜레이 반영
@@ -76,7 +78,7 @@ class JobGenerator(ck.JobGenerator):
         GrandCrossLargeTick = core.DamageSkill("그랜드 크로스(강화)", 800, 600 + vEhc.getV(3,3)*24, 43, modifier = core.CharacterModifier(crit = 100, crit_damage = 100)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper) #6s
         GrandCross = core.DamageSkill("그랜드 크로스", 480, 0, 0, cooltime = 150 * 1000).wrap(core.DamageSkillWrapper)#Loop = 480인걸로 봐서 재정의 필요할 수도 있음
                 
-        FinalAttack = core.DamageSkill("파이널 어택", 0, 150, 0.4).setV(vEhc, 3, 5, True).wrap(core.DamageSkillWrapper)
+        FinalAttack = core.DamageSkill("파이널 어택", 0, 80, 2*0.4).setV(vEhc, 3, 5, True).wrap(core.DamageSkillWrapper)
         
         ######   Skill Wrapper   ######
     

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -9,7 +9,7 @@ from .jobbranch import warriors
 
 #TODO : 5차 신스킬 적용
 # 4차 스킬은 컴뱃오더스 적용 기준으로 작성해야 함.
-# 생츄어리 필요한지 확인바람
+# 생츄어리 필요한지 확인바람 (딜레이 750)
 
 ######   Passive Skill   ######
 
@@ -72,8 +72,6 @@ class JobGenerator(ck.JobGenerator):
         #Summon Skills
         BlessedHammer = core.SummonSkill("블레스드 해머", 0, 600, (250 + vEhc.getV(1,1)*10), 2, 999999* 10000).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)   #딜레이 반영
         BlessedHammerActive = core.SummonSkill("블레스드 해머(활성화)", 0, 600, (525+vEhc.getV(1,1)*21)*3-(250+vEhc.getV(1,1)*10)*2, 1, 30 * 1000, cooltime = 60 * 1000).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)#딜레이 반영
-        #http://www.inven.co.kr/board/maple/2294/21881?category=%ED%8C%94%EB%9D%BC%EB%94%98&name=subject&keyword=%EA%B7%B8%ED%81%AC
-        #TODO : 오라웨폰 미발동 적용해야 할 필요 있음.
         GrandCrossSmallTick = core.DamageSkill("그랜드 크로스(작은)", 800, 350 + vEhc.getV(3,3)*14, 13, modifier = core.CharacterModifier(crit = 100, crit_damage = 100)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper) #6s
         GrandCrossLargeTick = core.DamageSkill("그랜드 크로스(강화)", 800, 600 + vEhc.getV(3,3)*24, 43, modifier = core.CharacterModifier(crit = 100, crit_damage = 100)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper) #6s
         GrandCross = core.DamageSkill("그랜드 크로스", 480, 0, 0, cooltime = 150 * 1000).wrap(core.DamageSkillWrapper)#Loop = 480인걸로 봐서 재정의 필요할 수도 있음

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -76,7 +76,7 @@ class JobGenerator(ck.JobGenerator):
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
         
         AncientGuidance = core.InformedCharacterModifier("에인션트 가이던스(패시브)", pdamage_indep = 10)
-        EssenceOfArcher = core.InformedCharacterModifier("에센스 오브 아처", crit = 10, pdamage = 20, armor_ignore = 30)
+        EssenceOfArcher = core.InformedCharacterModifier("에센스 오브 아처", crit = 10, pdamage = 10, armor_ignore = 30)
         
         AdditionalTransitionPassive = core.InformedCharacterModifier("에디셔널 트랜지션(패시브)", patt = 20)
         

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -74,7 +74,7 @@ class JobGenerator(ck.JobGenerator):
         Booster = core.BuffSkill("부스터", 0, 240 * 1000, rem = True).wrap(core.BuffSkillWrapper)    #딜레이 모름
         
         MileAiguillesInit = core.BuffSkill("얼티밋 드라이브(개시)", 240, 240).wrap(core.BuffSkillWrapper)
-        MileAiguilles = core.DamageSkill("얼티밋 드라이브", 150, 110 + 2*combat, 3, modifier = core.CharacterModifier(pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        MileAiguilles = core.DamageSkill("얼티밋 드라이브", 150, 125 + 2*combat, 3, modifier = core.CharacterModifier(pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
 
         CarteNoir = core.DamageSkill("느와르 카르트", 0, 270, min(chtr.get_modifier().crit/100,1)).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         CarteNoir_ = core.DamageSkill("느와르 카르트(저지먼트)", 0, 270, 10).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
@@ -87,8 +87,14 @@ class JobGenerator(ck.JobGenerator):
     
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 3, 3)
         
+        # 트와일라이트 미적용 상태
+        Twilight = core.BuffSkill("트와일라이트", 120, 15000, cooltime = 15000, armor_ignore = 20).wrap(core.BuffSkillWrapper)
+        TwilightHit = core.DamageSkill("트와일라이트(공격)", 540, 450, 3, cooltime = -1).wrap(core.DamageSkillWrapper)
+
+
         #조커가 소환기가 아님!
-        Joker = core.SummonSkill("조커", 720, 100*5, 240+9*vEhc.getV(4,4), 1*JOKERRATE*7*5, 7000-1, cooltime = 150000, red = True).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
+        # TODO: 카드 수 12% 감소 반영필요
+        Joker = core.SummonSkill("조커", 720, 100*5, 240+9*vEhc.getV(4,4), 1*JOKERRATE*7*5, (6+vEhc.getV(4,4)//25)*1000-1, cooltime = 150000, red = True).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
         JokerInit = core.DamageSkill("조커(시전)", 720, 0, 0, cooltime = 150000, red = True).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
         JokerDamage = core.DamageSkill("조커(피격)", 100*5, 240+9*vEhc.getV(4,4), 1*JOKERRATE*7*5).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)  #14회 반복
         JokerBuff = core.BuffSkill("조커(버프)", 0, 30000, cooltime = -1, pdamage_indep = (vEhc.getV(4,4)//5)/2).isV(vEhc,4,4).wrap(core.BuffSkillWrapper)
@@ -124,8 +130,8 @@ class JobGenerator(ck.JobGenerator):
         TempestOfCardInit.onAfter(core.RepeatElement(TempestOfCard, 56))
         TempestOfCard.onAfter(CarteNoir)
         
-        #Joker.onTick(CarteNoir)    #조커는 느와르를 미발동
-        Joker.onAfter(JokerBuff.controller(7000))
+        Joker.onTick(CarteNoir)    #조커는 느와르를 발동
+        Joker.onAfter(JokerBuff.controller((vEhc.getV(4,4)//25+6) * 1000))
         
         JokerInit.onAfter(core.RepeatElement(JokerDamage, 14))
         JokerInit.onAfter(JokerBuff)

--- a/dpmModule/jobs/readme.md
+++ b/dpmModule/jobs/readme.md
@@ -107,3 +107,24 @@ jobs.py
     - `SkillNum` : 사용하는 5차 스킬의 개수입니다.
     - `vEnhanceNum` : 가능한 5차 강화스킬의 가짓수입니다.
     - `passiveSkillList` : 패시브 스킬 효과를 담고 있는 리스트 입니다. generate 전까지는 계산되지 않습니다.
+
+하위 모듈
+-------------
+jobs의 하위 모듈로는 `jobbranch`와 `jobclass`가 존재합니다. 여기에는 각각 직업 계열과 직업군별 공용 스킬이 저장되어 있습니다.
+
+단일 직업군의 스킬은 해당 직업의 스크립트에 포함되어 있습니다. (제로, 키네시스)
+
+- jobbranch 모듈은 다음을 포함합니다.
+  - `warriors.py` : 전사 공용 스킬입니다.
+  - `magicians.py` : 마법사 공용 스킬입니다.
+  - `bowmen.py` : 궁수 공용 스킬입니다.
+  - `thieves.py` : 도적 공용 스킬입니다.
+  - `pirates.py` : 해적 공용 스킬입니다.
+- jobclass 모듈은 다음을 포함합니다.
+  - `adventurer.py` : 모험가 공용 스킬입니다.
+  - `cygnus.py` : 시그너스 기사단 공용 스킬입니다.
+  - `heroes.py` : 영웅 공용 스킬입니다.
+  - `resistance.py` : 레지스탕스(데몬 제외) 공용 스킬입니다.
+  - `demon.py` : 데몬 공용 스킬입니다.
+  - `nova.py` : 노바 공용 스킬입니다.
+  - `flora.py` : 레프 공용 스킬입니다.

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -104,7 +104,8 @@ class JobGenerator(ck.JobGenerator):
         
         #_VenomBurst = core.DamageSkill("베놈 버스트", ??) ## 패시브 50%확률로 10초간 160+6*vlevel dot. 사용시 도트뎀 모두 피해 + (500+20*vlevel) * 5. 어차피 안쓰는 스킬이므로 작성X
         
-        UltimateDarksight = core.BuffSkill("얼티밋 다크사이트", 750, 30000, cooltime = (220-vEhc.getV(3,3))*1000, pdamage_indep = (10 + int(0.2*vEhc.getV(3,3))/1.05 )).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
+        UltimateDarksight = thieves.UltimateDarkSightWrapper(vEhc, 3, 3, 5)
+        #UltimateDarksight = core.BuffSkill("얼티밋 다크사이트", 750, 30000, cooltime = (220-vEhc.getV(3,3))*1000, pdamage_indep = (10 + int(0.2*vEhc.getV(3,3))/1.05 )).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 2, 2)
         
         Eviscerate = core.DamageSkill("절개", 570, 1900+76*vEhc.getV(0,0), 7*1.7, modifier = core.CharacterModifier(crit=100, armor_ignore=100), cooltime = 14000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -7,18 +7,20 @@ from . import globalSkill
 from .jobbranch import thieves
 
 class MesoStack(core.DamageSkillWrapper, core.StackSkillWrapper):
+    # 메익 리인포스 미적용 기준
     def __init__(self, vEhc):
         self.vEhc = vEhc
-        skill = core.DamageSkill("메소익스플로전", 0, 220, 1).setV(vEhc, 2, 3, False)
+        skill = core.DamageSkill("메소익스플로전", 0, 100, 2).setV(vEhc, 2, 3, False)
         super(core.DamageSkillWrapper, self).__init__(skill, 20)
         self.modifierInvariantFlag = False
         
     def _use(self, rem = 0, red = 0):
         mdf = self.skill.get_modifier()
-        dmg = 220
+        dmg = 100
         stack = self.stack
         self.stack = 0
-        return core.ResultObject(0, mdf.copy(),  dmg * stack, sname = self._id, spec = 'deal')
+        # 확인 필요
+        return core.ResultObject(0, mdf.copy(),  dmg, sname = self._id, spec = 'deal', hit = 2 * stack)
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -87,11 +89,11 @@ class JobGenerator(ck.JobGenerator):
         ShadowerInstinct = core.BuffSkill("섀도어 인스팅트", 0, 200*1000, rem = True, att = 40+30).wrap(core.BuffSkillWrapper)
         ShadowPartner = core.BuffSkill("섀도우 파트너", 1000, 2000*1000, rem = True).wrap(core.BuffSkillWrapper)
         
-        Assasinate1 = core.DamageSkill("암살(1타)", 630, 550, 3 * 1.7, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타")   #쉐파
-        Assasinate2 = core.DamageSkill("암살(2타)", 630+30, 700, 3 * 1.7, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타")   #쉐파
+        Assasinate1 = core.DamageSkill("암살(1타)", 630, 275, 6 * 1.7, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타")   #쉐파
+        Assasinate2 = core.DamageSkill("암살(2타)", 630+30, 350, 6 * 1.7, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타")   #쉐파
         
-        Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 550, 3 * 1.7, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
-        Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 630+30, 700, 3 * 1.7, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
+        Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 275, 6 * 1.7, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
+        Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 630+30, 350, 6 * 1.7, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
         
         BailOfShadow = core.DamageSkill("베일 오브 섀도우", 810, 800, 15, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         #킬포3개 사용시 최종뎀 100% 증가.

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -69,8 +69,11 @@ class JobGenerator(ck.JobGenerator):
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
         #Damage Skills
-        Snipping = core.DamageSkill("스나이핑", 660, 730+combat*10, 5 + 1, modifier = core.CharacterModifier(crit = 100, armor_ignore = 20 + combat*1, pdamage = 20, boss_pdamage = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-        TrueSnippingTick = core.DamageSkill("트루 스나이핑(타격)", 700, 1200+vEhc.getV(2,2)*48, 9+1, modifier = core.CharacterModifier(pdamage_indep = 100, armor_ignore = 100)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        # TODO: 롱레인지 트루샷: MP 300 소비, 범위 내 12명의 적에게 450% 데미지로 9번 공격
+        #재사용 대기시간 15초
+
+        Snipping = core.DamageSkill("스나이핑", 630, 465+combat*5, 9 + 1, modifier = core.CharacterModifier(crit = 100, armor_ignore = 20 + combat*1, pdamage = 20, boss_pdamage = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        TrueSnippingTick = core.DamageSkill("트루 스나이핑(타격)", 700, 950+vEhc.getV(2,2)*30, 14+1, modifier = core.CharacterModifier(pdamage_indep = 100, armor_ignore = 100)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         TrueSnipping = core.DamageSkill("트루 스나이핑", 0, 0, 0, cooltime = 180 * 1000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         #TODO : 차지드 애로우용 홀더 생성이 필요함.

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -104,9 +104,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = 154
-        OverdriveBuff = pirates.OverdriveWrapper(vEhc, WEAPON_ATT, 5, 5)
-        Overdrive = OverdriveBuff.Overdrive
-        OverdrivePenalty = OverdriveBuff.OverdrivePenalty
+        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
 
         ShinNoiHapL = core.BuffSkill("신뇌합일", 0, (30+vEhc.getV(3,2)//2) * 1000, red = True, cooltime = (121-vEhc.getV(3,2)//2)*1000, pdamage_indep=4+vEhc.getV(3,2)//5).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
         ShinNoiHapLAttack = core.SummonSkill("신뇌합일(공격)", 0, 3000, 16*vEhc.getV(3,2) + 400, 7, (30+vEhc.getV(3,2)//2) * 1000, cooltime = -1).isV(vEhc,3,2).wrap(core.SummonSkillWrapper)
@@ -128,8 +126,6 @@ class JobGenerator(ck.JobGenerator):
         #Huricane_SkyOpen = core.OptionalElement(SkyOpen.is_active(), Huricane_NoCool, name = "태풍(천지개벽)" )
         
         #조건부 파이널어택으로 설정함.
-
-        Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
 
         HuricaneBuff.onAfter(Huricane)
         #BasicAttack.onAfter(ThunderConcat)

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -105,9 +105,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = 154
-        OverdriveBuff = pirates.OverdriveWrapper(vEhc, WEAPON_ATT, 5, 5)
-        Overdrive = OverdriveBuff.Overdrive
-        OverdrivePenalty = OverdriveBuff.OverdrivePenalty
+        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
         
         Transform = core.BuffSkill("트랜스폼", 450, (50+vEhc.getV(1,1))*1000, cooltime = 180 * 1000, pdamage_indep = (20 + 0.2*vEhc.getV(1,1))).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)#에너지 완충
         TransformEnergyOrb = core.DamageSkill("에너지 오브", 1140, 450 +vEhc.getV(1,1)*18, (2+(vEhc.getV(1,1) == 25)*1) * 8, modifier = core.CharacterModifier(crit = 50, armor_ignore = 50)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
@@ -139,8 +137,6 @@ class JobGenerator(ck.JobGenerator):
     
         UnityOfPower.onAfter(EnergyCharge.stackController(-1500))
         UnityOfPower.onAfter(UnityOfPowerBuff)
-    
-        Overdrive.onAfter(OverdrivePenalty.controller(30000))
         
         Transform.onAfter(EnergyCharge.stackController(10000, name = "트랜스폼"))
         Transform.onAfter(core.RepeatElement(TransformEnergyOrb, 3))

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -6,7 +6,7 @@ from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobclass import resistance
 from .jobbranch import bowmen
-# TODO: 재규어 맥시멈 추가
+# TODO: 재규어 맥시멈, 드릴 컨테이너 추가
 
 class JaguerStack(core.DamageSkillWrapper, core.TimeStackSkillWrapper):
     def __init__(self, level, vEhc):

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -74,7 +74,7 @@ class JobGenerator(ck.JobGenerator):
         #Summon Skills
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 5, 5)
         HowlingGail = core.SummonSkill("하울링 게일 1스택", 780, 10 * 1000 / 33, 250 + 10*vEhc.getV(1,1), 2 * 3, 10000, cooltime = 20 * 1000).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) #딜레이 모름, 64���
-        WindWall = core.SummonSkill("윈드 월", 720, 2000, (550 + vEhc.getV(2,2)*22) / 2, 12 , 45 * 1000, cooltime = 90 * 1000).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
+        WindWall = core.SummonSkill("윈드 월", 720, 2000, (550 + vEhc.getV(2,2)*22) / 2, 5*3 , 45 * 1000, cooltime = 90 * 1000).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         #TODO : 이볼브 계산
     
         

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -10,6 +10,16 @@ from .jobbranch import warriors
 
 # 제로 메용은 쓸컴뱃을 적용받지 않음
 
+# 초월자 륀느의 기원 : 미적용 상태
+def RhinneBlessWrapper(enhancer, skill_importance, enhance_importance):
+    # TODO: 재사용 대기시간 초기화 구현
+    RhinneBless = core.BuffSkill("초월자 륀느의 기원", 630, 30+enhancer.getV(skill_importance, enhance_importance)//2, cooltime = 240000, att = 10+3*enhancer.getV(skill_importance, enhance_importance)).wrap(core.BuffSkillWrapper)
+    RhinneBlessAttack_hit = core.DamageSkill("초월자 륀느의 기원 (타격)", 0, 125+5*enhancer.getV(skill_importance, enhance_importance), 5, cooltime = 0).wrap(core.DamageSkillWrapper)
+    RhinneBlessAttack = core.OptionalElement(RhinneBless.is_active(), RhinneBlessAttack_hit)
+
+    return RhinneBless, RhinneBlessAttack
+
+
 # 현재로는 계산 알고리즘 작성 구문에서 연산과정에 접근을 할 수 없도록 캡슐화되어 있으므로 사용 불가능
 '''
 class LimitBreakNew():
@@ -103,65 +113,76 @@ class JobGenerator(ck.JobGenerator):
         BetaState = core.BuffSkill("상태-베타", 0, 9999*10000, cooltime = -1, pdamage_indep = 9.70, crit = 15-40, boss_pdamage = 30, att = 80-40, pdamage = 40, armor_ignore = -42.85, crit_damage = -(50 + (20*4/35))).wrap(core.BuffSkillWrapper)
 
         #### 알파 ####
-        MoonStrike = core.DamageSkill("문 스트라이크", 390, 180, 4).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        MoonStrikeTAG = core.DamageSkill("문 스트라이크(태그)", 0, 180, 4).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        MoonStrike = core.DamageSkill("문 스트라이크", 390, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        MoonStrikeTAG = core.DamageSkill("문 스트라이크(태그)", 0, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
-        PierceStrike = core.DamageSkill("피어스 쓰러스트", 510, 250, 4 ).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        PierceStrikeTAG = core.DamageSkill("피어스 쓰러스트(태그)", 0, 250, 4 ).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        PierceStrike = core.DamageSkill("피어스 쓰러스트", 510, 170, 6 ).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        PierceStrikeTAG = core.DamageSkill("피어스 쓰러스트(태그)", 0, 170, 6 ).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
         '''
-        ShadowStrike = core.DamageSkill("쉐도우 스트라이크", ?, 310, 5)
+        ShadowStrike = core.DamageSkill("쉐도우 스트라이크", ?, 195, 8)
         ShadowStrikeAura = core.DamageSkill("쉐도우 스트라이크", 0, 310, 1)
         '''
-        FlashAssault = core.DamageSkill("플래시 어썰터", 480, 330, 4 ).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        FlashAssaultTAG = core.DamageSkill("플래시 어썰터(태그)", 0, 330, 4 ).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        FlashAssault = core.DamageSkill("플래시 어썰터", 480, 165, 8 ).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        FlashAssaultTAG = core.DamageSkill("플래시 어썰터(태그)", 0, 165, 8 ).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedSpinCutter = core.DamageSkill("어드밴스드 스핀 커터", 630, 520, 5 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedSpinCutterTAG = core.DamageSkill("어드밴스드 스핀 커터(태그)", 0, 520, 5 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedSpinCutterAura = core.DamageSkill("어드밴스드 스핀 커터(오라)", 0, 475, 1 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedSpinCutter = core.DamageSkill("어드밴스드 스핀 커터", 630, 260, 10 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedSpinCutterTAG = core.DamageSkill("어드밴스드 스핀 커터(태그)", 0, 260, 10 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedSpinCutterAura = core.DamageSkill("어드밴스드 스핀 커터(오라)", 0, 130, 4 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedRollingCurve = core.DamageSkill("어드밴스드 롤링 커브", 960, 530, 8 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingCurveTAG = core.DamageSkill("어드밴스드 롤링 커브(태그)", 0, 530, 8 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingCurveAura = core.DamageSkill("어드밴스드 롤링 커브(오라)", 0, 700, 1 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingCurve = core.DamageSkill("어드밴스드 롤링 커브", 960, 365, 12 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingCurveTAG = core.DamageSkill("어드밴스드 롤링 커브(태그)", 0, 365, 12 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingCurveAura = core.DamageSkill("어드밴스드 롤링 커브(오라)", 0, 350, 2 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedRollingAssulter = core.DamageSkill("어드밴스드 롤링 어썰터", 960, 745, 6 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingAssulterTAG = core.DamageSkill("어드밴스드 롤링 어썰터(태그)", 0, 745, 6 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingAssulterAura = core.DamageSkill("어드밴스드 롤링 어썰터(오라)", 0, 745, 1 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingAssulter = core.DamageSkill("어드밴스드 롤링 어썰터", 960, 375, 12 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingAssulterTAG = core.DamageSkill("어드밴스드 롤링 어썰터(태그)", 0, 375, 12 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingAssulterAura = core.DamageSkill("어드밴스드 롤링 어썰터(오라)", 0, 250, 3 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
-        WindCutter = core.DamageSkill("윈드 커터", 540, 325, 4 ).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        WindCutterSummon = core.DamageSkill("윈드 커터(소환)", 0, 325, 3 ).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper) #3타 타격
-        WindStrike = core.DamageSkill("윈드 스트라이크",600, 500, 4 ).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
-        StormBreak = core.DamageSkill("어드밴스드 스톰 브레이크", 690, 670, 5 ).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        StormBreakSummon = core.DamageSkill("어드밴스드 스톰 브레이크(소환)", 0, 670, 2).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) #2타 타격
-        StormBreakElectric = core.DamageSkill("어드밴스드 스톰 브레이크(전기)", 0, 230, 3 ).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        WindCutter = core.DamageSkill("윈드 커터", 540, 165, 8 ).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        WindCutterSummon = core.SummonSkill("윈드 커터(소환)", 0, 500, 110, 3, 3000).setV(vEhc, 7, 2, False).wrap(core.SummonSkillWrapper)
+        #WindCutterSummon = core.DamageSkill("윈드 커터(소환)", 0, 110, 3*3 ).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper) #3타 타격
+
+        WindStrike = core.DamageSkill("윈드 스트라이크",600, 250, 8).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+
+        StormBreak = core.DamageSkill("어드밴스드 스톰 브레이크", 690, 335, 10 ).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        StormBreakSummon = core.SummonSkill("어드밴스드 스톰 브레이크(소환)", 0, 500, 335, 4, 3000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        #StormBreakSummon = core.DamageSkill("어드밴스드 스톰 브레이크(소환)", 0, 335, 4).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) #2타 타격
+        StormBreakElectric = core.DotSkill("어드밴스드 스톰 브레이크(전기)", 230, 3000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        #StormBreakElectric = core.DamageSkill("어드밴스드 스톰 브레이크(전기)", 0, 230, 3 ).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
 
         #### 베타 ####
         
 
-        UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 630, 2).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 630, 2).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 210, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
-        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 980, 3).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 980, 3).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 980, 3).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330, 9).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330, 9).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330, 9).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
-        FlashCut = core.DamageSkill("프론트 슬래시", 630, 610, 2).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550, 2 * 5).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
+        THROWINGHIT = 5
+        FlashCut = core.DamageSkill("프론트 슬래시", 630, 205, 6).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 360, 300, 550, 2, THROWINGHIT*300).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
+        #ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550, 2 * 5).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
         
-        SpinDriver = core.DamageSkill("터닝 드라이브", 540, 780, 2).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 400, 7).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
+        SpinDriver = core.DamageSkill("터닝 드라이브", 540, 260, 6).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 200, 2*7).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
         
-        GigaCrash = core.DamageSkill("기가 크래시", 630, 750, 2).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        GigaCrashTAG = core.DamageSkill("기가 크래시(태그)", 0, 750, 2).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        GigaCrash = core.DamageSkill("기가 크래시", 630, 250, 6).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        GigaCrashTAG = core.DamageSkill("기가 크래시(태그)", 0, 250, 6).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
-        FallingStar = core.DamageSkill("점핑 크래시", 660, 670, 3).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
-        FallingStarTAG = core.DamageSkill("점핑 크래시(태그)", 0, 670, 3).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        FallingStar = core.DamageSkill("점핑 크래시", 660, 225, 6).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        # 충격파 값 포함
+        FallingStarTAG = core.DamageSkill("점핑 크래시(태그)", 0, 225, 6).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        FallingStarWave = core.DamageSkill("점핑 크래시(충격파)", 0, 225, 3).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 760, 5).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 760, 5).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
+        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 380, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 380, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
         
-        AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(전기)(파동)", 0, 570, 5).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340, 5).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(파동)", 0, 285, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        
+        AdvancedEarthBreakElectric = core.DotSkill("어드밴스드 어스 브레이크(전기)", 340, 5).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        #AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340, 5).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
 
         DoubleTime = core.BuffSkill("래피드 타임", 0, 9999*10000, crit = 20, pdamage = 10).wrap(core.BuffSkillWrapper)
         TimeDistortion = core.BuffSkill("타임 디스토션", 540, 30000, cooltime = 240 * 1000, pdamage = 25).wrap(core.BuffSkillWrapper)
@@ -194,6 +215,19 @@ class JobGenerator(ck.JobGenerator):
         ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 0, 750+30*vEhc.getV(2,2), 12 * 2).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)
+
+        '''
+        초월자 륀느의 기원
+        RhinneBless, RhinneBlessAttack = RhinneBlessWrapper(vEhc, 0, 0)
+        모든 스킬에 onAfter(RhinneBlessAttack) 추가
+        for sk in [MoonStrike, PierceStrike, FlashAssault, AdvancedSpinCutter,
+                    AdvancedRollingCurve, AdvancedRollingAssulter, StormBreak, UpperStrike, AirRiot, GigaCrash,
+                    FallingStar, AdvancedEarthBreak, TwinBladeOfTime_end]:
+            sk.onAfter(RhinneBlessAttack)
+        스킬 쿨타임 초기화
+        '''
+
+
         ######   Skill Wrapper   ######
         
         '''제로의 콤보 사용방식 정리!
@@ -240,12 +274,12 @@ class JobGenerator(ck.JobGenerator):
         SpinDriver.onAfter(AdvancedWheelWind)
         
         GigaCrash.onAfter(FallingStar)
-        FallingStar.onAfter(AdvancedEarthBreak)
+        FallingStar.onAfters([AdvancedEarthBreak, FallingStarWave])
         AdvancedEarthBreak.onAfter(AdvancedEarthBreakWave)
         AdvancedEarthBreak.onAfter(AdvancedEarthBreakElectric)
         
         GigaCrashTAG.onAfter(FallingStarTAG)
-        FallingStarTAG.onAfter(AdvancedEarthBreakTAG)
+        FallingStarTAG.onAfters([AdvancedEarthBreakTAG, FallingStarWave])
         AdvancedEarthBreakTAG.onAfter(AdvancedEarthBreakWave)
         AdvancedEarthBreakTAG.onAfter(AdvancedEarthBreakElectric)
         

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -10,6 +10,35 @@ from .jobbranch import warriors
 
 # 제로 메용은 쓸컴뱃을 적용받지 않음
 
+# 현재로는 계산 알고리즘 작성 구문에서 연산과정에 접근을 할 수 없도록 캡슐화되어 있으므로 사용 불가능
+'''
+class LimitBreakNew():
+    def __init__(self, enhancer, skill_importance, enhance_importance):
+        self.damage_start = 0
+        self.damage_end = 0
+        self.analytics = core.Analytics()
+        self.vLevel = enhancer.getV(skill_importance, enhance_importance)
+
+        self.LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*self.vLevel, 5).isV(enhancer, skill_importance, enhance_importance).wrap(core.DamageSkillWrapper)
+        self.LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+self.vLevel//2)*1000, pdamage_indep = (30+self.vLevel//5) * 1.2 + 20, cooltime = 240*1000).isV(enhancer, skill_importance, enhance_importance).wrap(core.BuffSkillWrapper)
+        self.LimitBreak.onAfter(self.LimitBreakAttack)
+        
+    def LimitBreakStart(self):
+        self.damage_start = self.analytics.total_damage
+        return LimitBreak
+
+    def LimitBreakEnd(self):
+        self.damage_end = self.analytics.total_damage - self.damage_start
+        # 지속시간 동안 가한 데미지의 20% / 15
+        # 퍼뎀이 아니라 고정값으로 뜨게 수정해야 함
+        return core.DamageSkill("리미트 브레이크(막타)", 0, damage_end / 75, 15).wrap(core.DamageSkillWrapper)
+    def get_buff(self):
+        return self.LimitBreak
+
+# LimitBreakSet = LimitBreakNew(vEhc, 0, 0)
+# LimitBreak = LimitBreakSet.get_buff()
+'''
+
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()


### PR DESCRIPTION
제가 건드릴 수 있는건 최대한 해봤습니다.

패치 미적용된 직업 목록 : 불독, 캡틴(배틀쉽 봄버),  듀블(히든 블레이드 딜레이), 에반(딜사이클 수정), 팬텀(조커 카드), 와헌(드릴 컨테이너), 메카닉(전탄발사), 제로(초월자 륀느의 기원), 아델, 아크

에반의 경우는 이번에 또 너프가 예정되어 있어서 이번 패치를 보고 수정해야 될 것 같습니다.