### PR TITLE
데몬어벤져, 섀도어 변경사항

### DIFF
--- a/dpmModule/jobs/demonavenger.py
+++ b/dpmModule/jobs/demonavenger.py
@@ -93,7 +93,10 @@ class JobGenerator(ck.JobGenerator):
         EnhancedExceed = core.DamageSkill("인핸스드 익시드", 0, 200, 2*0.8).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
 
         #일정 주기로 마족의 피가 바닥에 뿌려져 5초 동안 최대 10명의 적을 일정주기 마다 300+8n%로 2번 공격
-        FrenzyDOT = core.DamageSkill("프렌지 장판", 0, 300 + 8 * vEhc.getV(0, 0), 2).wrap(core.DamageSkillWrapper)
+        # 초당 22타 가정
+        FrenzyStack = 1
+        FrenzyPerSecond = 11
+        FrenzyDOT = core.SummonSkill("프렌지 장판", 0, 1000/FrenzyPerSecond, 300 + 8 * vEhc.getV(0, 0), 2*FrenzyStack, 999999).wrap(core.SummonSkillWrapper)
 
         # 블피 (즉시 시전)
         DemonicBlast = core.DamageSkill("블러드 피스트", 0, 500 + 20*vEhc.getV(0,0), 7, cooltime = 10000, modifier = CharacterModifier(crit = 100, armor_ignore = 100)).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/demonavenger.py
+++ b/dpmModule/jobs/demonavenger.py
@@ -46,6 +46,13 @@ class JobGenerator(ck.JobGenerator):
         HP_RATE = 100
         #최대 HP 대비 소모된 HP 3%(24레벨가지는 4%)당 최종 데미지 1% 증가
         FrenzyPassive = core.InformedCharacterModifier("데몬 프렌지 (최종 데미지)", pdamage_indep = (100 - HP_RATE) // (4 - (self.vEhc.getV(0, 0) // 25)))
+
+        RUIN_USE = False
+        if RUIN_USE:
+            # 극한 HP = 800(600+200), 루인 HP = 560
+            RuinForceShield = core.InformedCharacterModifier("루인 포스실드", stat_main = -240, stat_sub = -2, pdamage_indep = 10)
+
+
         return [AbyssalRage, AdvancedDesperadoMastery, OverwhelmingPower, DefenseExpertise, DemonicSharpness, MapleHeroesDemon, InnerStrength, DiabolicRecovery, FrenzyPassive]
 
     def get_not_implied_skill_list(self):
@@ -96,15 +103,15 @@ class JobGenerator(ck.JobGenerator):
         # 초당 22타 가정
         FrenzyStack = 1
         FrenzyPerSecond = 11
-        FrenzyDOT = core.SummonSkill("프렌지 장판", 0, 1000/FrenzyPerSecond, 300 + 8 * vEhc.getV(0, 0), 2*FrenzyStack, 999999).wrap(core.SummonSkillWrapper)
+        FrenzyDOT = core.SummonSkill("프렌지 장판", 0, 1000/FrenzyPerSecond, 300 + 8 * vEhc.getV(0, 0), FrenzyStack, 999999).wrap(core.SummonSkillWrapper)
 
         # 블피 (즉시 시전)
         DemonicBlast = core.DamageSkill("블러드 피스트", 0, 500 + 20*vEhc.getV(0,0), 7, cooltime = 10000, modifier = CharacterModifier(crit = 100, armor_ignore = 100)).wrap(core.DamageSkillWrapper)
         
         #평딜이냐 극딜이냐... 소스코드는 서버렉 미적용
         # 참고자료: https://blog.naver.com/oe135/221372243858
-        DimensionSword = core.SummonSkill("디멘션 소드(평딜)", 480, 3000, 1250+14*vEhc.getV(0,0), 8, 40*1000, cooltime = 120*1000, modifier=core.CharacterModifier(armor_ignore=100)).wrap(core.SummonSkillWrapper)
-        DimensionSwordReuse = core.SummonSkill("디멘션 소드 (극딜)", 0, 210, 300+vEhc.getV(0,0)*12, 6, 8*1000, cooltime=120*1000, modifier=core.CharacterModifier(armor_ignore=100)).wrap(core.SummonSkillWrapper)
+        #DimensionSword = core.SummonSkill("디멘션 소드(평딜)", 480, 3000, 1250+14*vEhc.getV(0,0), 8, 40*1000, cooltime = 120*1000, modifier=core.CharacterModifier(armor_ignore=100)).wrap(core.SummonSkillWrapper)
+        DimensionSwordReuse = core.SummonSkill("디멘션 소드 (극딜)", 480, 210, 300+vEhc.getV(0,0)*12, 6, 8*1000, cooltime=120*1000, modifier=core.CharacterModifier(armor_ignore=100)).wrap(core.SummonSkillWrapper)
         
 
         #BatSwarm = core.SummonSkill("배츠 스웜", 0, 0, 200, 1, 0)
@@ -129,9 +136,9 @@ class JobGenerator(ck.JobGenerator):
         
         
         ######   Skill Wrapper   ######
-        # TODO: 딜사이클을 알아야 작성가능
         '''딜 사이클 정리
-        
+        https://blog.naver.com/oe135/221538210455
+        매 3분마다 버프류 스킬 사용하여 극딜
         '''
         
         ArmorBreak.onAfter(ArmorBreakBuff.controller(1))

--- a/dpmModule/jobs/demonavenger.py
+++ b/dpmModule/jobs/demonavenger.py
@@ -15,18 +15,20 @@ class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
         self.buffrem = False
-        self.jobtype = "hp"
-        self.vEnhanceNum = 15
-        self.preEmptiveSkills = 1
+        self.jobtype = "str"
+        self.vEnhanceNum = 12
+        # 쓸샾, 쓸뻥, 쓸오더(아직 미구현)
+        self.preEmptiveSkills = 3
         
-        self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'reuse', 'mess')
+        self.ability_list = Ability_tool.get_ability_set('reuse', 'crit', 'boss_pdamage')
     
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(armor_ignore = 20)
 
     def get_passive_skill_list(self):
 
-        
+        #TODO: 블러드 컨트랙트, 컨버전 스타포스
+
         #와일드레이지 : 데미지10%, 링크에 반영되므로 미고려.
         #주스탯 미반영, 추가바람.
         AbyssalRage = core.InformedCharacterModifier("어비셜 레이지", att=40)
@@ -36,7 +38,7 @@ class JobGenerator(ck.JobGenerator):
         DemonicSharpness = core.InformedCharacterModifier("데모닉 샤프니스", crit=20)
 
         # 메용: 체력+15%로 수정
-        MapleHeroesDemon = core.InformedCharacterModifier("메이플 용사(데몬어벤져)", stat_main = 0.15*(25 + level * 5))
+        MapleHeroesDemon = core.InformedCharacterModifier("메이플 용사(데몬어벤져)", pstat_main = 15)
         # 최종데미지 (릴리즈 오버로드, 데몬 프렌지)
         InnerStrength = core.InformedCharacterModifier("이너 스트렝스", stat_main = 600)
         DiabolicRecovery = core.InformedCharacterModifier("디아볼릭 리커버리", pstat_main=25)
@@ -57,13 +59,10 @@ class JobGenerator(ck.JobGenerator):
         코강 순서: 익시드 엑스큐션, 실드 체이싱 -> 문라이트 슬래시(사용하지 않음)
         '''
         '''
+
+        하이퍼: 익시드 3종, 실드 체이싱 리인포스, 엑스트라 타겟 적용
         TODO:
-        이즈 익시드 페인(익시드 스킬 데미지 20% 증가) - 어떤 스킬에 적용되는 것인지 확인필요
-
-        하이퍼: 익시드 - 리인포스: 익시드 스킬 데미지 20% 증가
-
         오라 웨폰 - 작성 필요
-        이계 여신의 축복 - 이 스킬을 과연 쓰는가?
 
         데몬 프렌지 - DPM 기준을 어떻게 할것인지?
         블러드 피스트 - 작성 필요
@@ -72,26 +71,38 @@ class JobGenerator(ck.JobGenerator):
         #V코어 값은 전면 재작성 필요
         
         # TODO: OptionalElement로 변경해야 함
-        # 익시드 0~4스택
-        Execution = core.DamageSkill("익시드: 엑스큐션", 0, 540, 4, modifier = core.CharacterModifier(armor_ignore = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+
+        # 익시드 0~3스택: 딜레이 900, 900, 840, 780
+        Execution_0 = core.DamageSkill("익시드: 엑스큐션 (0스택)", 660, 540, 4, modifier = core.CharacterModifier(armor_ignore = 30, pdamage = 20 + 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        Execution_1 = core.DamageSkill("익시드: 엑스큐션 (1스택)", 660, 540, 4, modifier = core.CharacterModifier(armor_ignore = 30, pdamage = 20 + 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        Execution_2 = core.DamageSkill("익시드: 엑스큐션 (2스택)", 630, 540, 4, modifier = core.CharacterModifier(armor_ignore = 30, pdamage = 20 + 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        Execution_3 = core.DamageSkill("익시드: 엑스큐션 (3스택)", 570, 540, 4, modifier = core.CharacterModifier(armor_ignore = 30, pdamage = 20 + 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         # 익시드 5스택 이상
-        ExecutionExceed = core.DamageSkill("익시드: 엑스큐션 (강화)", 540, 540, 6, modifier = core.CharacterModifier(armor_ignore = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        ExecutionExceed = core.DamageSkill("익시드: 엑스큐션 (강화)", 540, 540, 6, modifier = core.CharacterModifier(armor_ignore = 30, pdamage = 20 + 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
 
         # 방어력 2배 무시가 30퍼를 한번 더 계산하는건지, 아니면 60퍼로 적용되는건지 알아볼 필요가 있음.
         # 최대 10회 공격
-        # 공격 주기 등 정보를 알아야 젱확히 작성가능
-        ShieldChasing = core.SummonSkill("실드 체이싱", 0, 0, 500, 2, 5000-1, cooltime = 6000, modifier = core.CharacterModifier(armor_ignore = 30, pdamage=20), red = True).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)
+        ShieldChasing = core.DamageSkill("실드 체이싱", 540, 500, 2*(8+2), cooltime = 6000, modifier = core.CharacterModifier(armor_ignore = 30, pdamage=20), red = True).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)
 
         ArmorBreak = core.DamageSkill("아머 브레이크", 0, 350, 4, cooltime = 30 * 1000).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         ArmorBreakBuff = core.BuffSkill("아머 브레이크(디버프)", 0, 30*1000, armor_ignore = 30).wrap(core.BuffSkillWrapper)
 
-        ThousandSword = core.Damageskill("사우전드 소드", 0, 500, 8, cooltime = 8*1000).setV(vEhc, 0, 0, False).wrap(core.DamageSkillWrapper)
+        #ThousandSword = core.Damageskill("사우전드 소드", 0, 500, 8, cooltime = 8*1000).setV(vEhc, 0, 0, False).wrap(core.DamageSkillWrapper)
 
         # 보너스 찬스 70% -> 80%
         EnhancedExceed = core.DamageSkill("인핸스드 익시드", 0, 200, 2*0.8).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
 
         #일정 주기로 마족의 피가 바닥에 뿌려져 5초 동안 최대 10명의 적을 일정주기 마다 300+8n%로 2번 공격
-        FrenzyDOT = core.DamageSkill("프렌지 장판", 0, 300 + 8 * vEhc.getV(0, 0), 2).isV(vEhc, 0, 0).wrap(core.DamageSkillWrapper)
+        FrenzyDOT = core.DamageSkill("프렌지 장판", 0, 300 + 8 * vEhc.getV(0, 0), 2).wrap(core.DamageSkillWrapper)
+
+        # 블피 (즉시 시전)
+        DemonicBlast = core.DamageSkill("블러드 피스트", 0, 500 + 20*vEhc.getV(0,0), 7, cooltime = 10000, modifier = CharacterModifier(crit = 100, armor_ignore = 100)).wrap(core.DamageSkillWrapper)
+        
+        #평딜이냐 극딜이냐... 소스코드는 서버렉 미적용
+        # 참고자료: https://blog.naver.com/oe135/221372243858
+        DimensionSword = core.SummonSkill("디멘션 소드(평딜)", 480, 3000, 1250+14*vEhc.getV(0,0), 8, 40*1000, cooltime = 120*1000, modifier=core.CharacterModifier(armor_ignore=100)).wrap(core.SummonSkillWrapper)
+        DimensionSwordReuse = core.SummonSkill("디멘션 소드 (극딜)", 0, 210, 300+vEhc.getV(0,0)*12, 6, 8*1000, cooltime=120*1000, modifier=core.CharacterModifier(armor_ignore=100)).wrap(core.SummonSkillWrapper)
+        
 
         #BatSwarm = core.SummonSkill("배츠 스웜", 0, 0, 200, 1, 0)
 
@@ -107,11 +118,13 @@ class JobGenerator(ck.JobGenerator):
         DemonicFortitude = core.BuffSkill("데모닉 포티튜드", 0, 60*1000, cooltime=120*1000, pdamage=10).wrap(core.BuffSkillWrapper)
 
         ReleaseOverload = core.BuffSkill("릴리즈 오버로드", 0, 60*1000, pdamage_indep= 25).wrap(core.BuffSkillWrapper)
-        CallMastema = core.SummonSkill("콜 마스테마", 690, 5000, 500 + vEhc.getV(4,4)*20, 8, (30+vEhc.getV(4,4))*1000, cooltime = 150*1000).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
-        #CallMastemaAnother = core.SummonSkill("콜 마스테마+", 0, ).wrap(core.BuffSkillWrapper)    #러블리 테리토리..데미지 없음.
         
-        DimensionSword = core.SummonSkill("디멘션 소드", 0, 3000, 1250+14*vEhc.getV(0,0), 8, 40*1000, cooltime = 120*1000, modifier=core.CharacterModifier(armor_ignore=100)).isV(vEhc, 0, 0).wrap(core.SummonSkillWrapper)
-        DimensionSwordReuse = core.SummonSkill("디멘션 소드 (재시전)", 0, 0, 300+vEhc.getV(0,0)*12, 6, 8*1000, cooltime=120*1000, modifier=core.CharacterModifier(armor_ignore=100)).isV(vEhc, 0, 0).wrap(core.SummonSkillWrapper)
+        # 데몬 5차 공용
+        CallMastema, MastemaClaw = demon.CallMastemaWrapper(vEhc, 0, 0)
+        AnotherGoddessBuff, AnotherVoid = demon.AnotherWorldWrapper(vEhc, 0, 0)
+
+        
+        
         ######   Skill Wrapper   ######
         # TODO: 딜사이클을 알아야 작성가능
         '''딜 사이클 정리
@@ -126,11 +139,11 @@ class JobGenerator(ck.JobGenerator):
         ExceedOpt = core.OptionalElement(Exceed.judge(5, 1), ExecutionExceed, Execution)
 
         #사우전드 소드 : 사용 시 익시드 오버로드 5 증가
-        ThousandSword.onAfter(Exceed.stackController(5))
+        #ThousandSword.onAfter(Exceed.stackController(5))
 
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 3, 2)
-        for sk in [Execution, ExecutionExceed, ShieldChasing, ArmorBreak, ThousandSword]:
+        for sk in [Execution_0, Execution_1, Execution_2, Execution_3, ExecutionExceed, ShieldChasing, ArmorBreak, DemonicBlast]:
             auraweapon_builder.add_aura_weapon(sk)
         AuraWeaponBuff, AuraWeaponCooltimeDummy = auraweapon_builder.get_buff()
         

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -77,23 +77,38 @@ class JobGenerator(ck.JobGenerator):
         암살-부스-익플-배오섀
         '''
 
+        def shadow_partner_builder(sk : core.DamageSkillWrapper):
+            skill = sk.skill
+            copial = core.DamageSkill(skill.name.evaluate() + '(쉐도우파트너)', 
+                0,
+                skill.damage.evaluate() * 0.7,
+                skill.hit.evaluate(),
+                cooltime=skill.cooltime.evaluate(),
+                modifier=skill._static_skill_modifier.evaluate()).wrap(core.DamageSkillWrapper)
+            sk.onAfter(copial)
         
         ######   Skill   ######
         # http://m.inven.co.kr/board/powerbbs.php?come_idx=2297&stype=subject&svalue=%EC%8A%A4%ED%83%9D&l=52201
-        STACK1RATE = 19
-        STACK2RATE = 80
+
+        # 크로아 서버 스킨헤드님 제보 (https://maple.gg/u/%EC%8A%A4%ED%82%A8%ED%97%A4%EB%93%9C)
+        # http://m.dcinside.com/board/maplestory/10616710
+        # http://m.dcinside.com/board/maplestory/10616992
+
+        STACK1RATE = 70
+        STACK2RATE = 95
 
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 200*1000).wrap(core.BuffSkillWrapper)
         FlipTheCoin = core.BuffSkill("플립 더 코인", 0, 24000, pdamage = 5*5, crit = 10*5).wrap(core.BuffSkillWrapper)
         ShadowerInstinct = core.BuffSkill("섀도어 인스팅트", 0, 200*1000, rem = True, att = 40+30).wrap(core.BuffSkillWrapper)
+        # 더미 데이터
         ShadowPartner = core.BuffSkill("섀도우 파트너", 1000, 2000*1000, rem = True).wrap(core.BuffSkillWrapper)
         
-        Assasinate1 = core.DamageSkill("암살(1타)", 630, 275, 6 * 1.7, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타")   #쉐파
-        Assasinate2 = core.DamageSkill("암살(2타)", 630+30, 350, 6 * 1.7, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타")   #쉐파
+        Assasinate1 = core.DamageSkill("암살(1타)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타")   #쉐파
+        Assasinate2 = core.DamageSkill("암살(2타)", 630+30, 350, 6, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타")   #쉐파
         
-        Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 275, 6 * 1.7, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
-        Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 630+30, 350, 6 * 1.7, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
+        Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
+        Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 630+30, 350, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
         
         BailOfShadow = core.DamageSkill("베일 오브 섀도우", 810, 800, 15, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         #킬포3개 사용시 최종뎀 100% 증가.
@@ -110,11 +125,11 @@ class JobGenerator(ck.JobGenerator):
         #UltimateDarksight = core.BuffSkill("얼티밋 다크사이트", 750, 30000, cooltime = (220-vEhc.getV(3,3))*1000, pdamage_indep = (10 + int(0.2*vEhc.getV(3,3))/1.05 )).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 2, 2)
         
-        Eviscerate = core.DamageSkill("절개", 570, 1900+76*vEhc.getV(0,0), 7*1.7, modifier = core.CharacterModifier(crit=100, armor_ignore=100), cooltime = 14000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        Eviscerate = core.DamageSkill("절개", 570, 1900+76*vEhc.getV(0,0), 7, modifier = core.CharacterModifier(crit=100, armor_ignore=100), cooltime = 14000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
 		
 		# 1.2.324 패치 적용
         SonicBlow = core.DamageSkill("소닉 블로우", 900, 0, 0, cooltime = 80 * 1000).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
-        SonicBlowTick = core.DamageSkill("소닉 블로우(틱)", 125, 500+20*vEhc.getV(1,1), 7*1.7, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper, name = "소닉 블로우(사용)")#20타
+        SonicBlowTick = core.DamageSkill("소닉 블로우(틱)", 125, 500+20*vEhc.getV(1,1), 7, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper, name = "소닉 블로우(사용)")#20타
         
         ### build graph relationships
         def isNotDarkSight():
@@ -153,6 +168,9 @@ class JobGenerator(ck.JobGenerator):
         Assasinate = core.OptionalElement(AdvancedDarkSight.is_active, Assasinate1_D, Assasinate1, name = "닼사 여부")
         BasicAttackWrapper = core.DamageSkill('기본 공격',0,0,0).wrap(core.DamageSkillWrapper)
         BasicAttackWrapper.onAfter(Assasinate)
+
+        for sk in [Assasinate1, Assasinate2, Assasinate1_D, Assasinate2_D, Eviscerate, SonicBlowTick]:
+            shadow_partner_builder(sk)
         
         return(BasicAttackWrapper, 
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),


### PR DESCRIPTION
데벤져 (아직 딜사이클, 5차강화순서 미작성)

1. 어빌리티 변경 (재사용, 크확, 보공)

2. 단계별 엑스큐션, 프렌지 장판, 블피, 디멘션소드 추가

섀도어

1. 쉐파 적용 (듀블 코드 복붙)

2. 암살 스택 확률 70% / 95%로 변경 ([스킨헤드](https://maple.gg/u/%EC%8A%A4%ED%82%A8%ED%97%A4%EB%93%9C)님 제보)