### PR TITLE
fix sniper, darknight, zero and global skills

### DIFF
--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -8,6 +8,7 @@ from . import globalSkill
 from .jobbranch import warriors
 from .jobclass import cygnus
 from .jobclass import flora
+from . import jobutils
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -27,7 +28,7 @@ class JobGenerator(ck.JobGenerator):
 
     def get_passive_skill_list(self):
         # 매직 서킷: 앱솔 기준 15.4
-        WEAPON_ATT = 205
+        WEAPON_ATT = jobutils.getWeaponATT("튜너")
         
         MagicCircuit = core.InformedCharacterModifier("매직 서킷", att=WEAPON_ATT * 0.15)  #무기 마력의 25%, 최대치 가정.
         Pace = core.InformedCharacterModifier("패이스", crit_damage=10, patt=10)

--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -5,6 +5,7 @@ from functools import partial
 from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobbranch import pirates
+from . import jobutils
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self, vEhc = None):
@@ -92,7 +93,7 @@ class JobGenerator(ck.JobGenerator):
         
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
-        WEAPON_ATT = 154
+        WEAPON_ATT = jobutils.getWeaponATT("소울슈터")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 3, 3, WEAPON_ATT)
     
         EnergyBurst = core.DamageSkill("에너지 버스트", 900, (600+20*vEhc.getV(4,4)) * 3, 12, red = True, cooltime = 120 * 1000).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, MutualRule
 from . import globalSkill
 from .jobbranch import pirates
+from . import jobutils
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self, vEhc = None):
@@ -25,7 +26,7 @@ class JobGenerator(ck.JobGenerator):
         vEhc = self.vEhc
         
         # 매직 서킷: 앱솔 기준 15.4
-        WEAPON_ATT = 154
+        WEAPON_ATT = jobutils.getWeaponATT("너클")
         
         MagicCircuit = core.InformedCharacterModifier("매직 서킷", att = WEAPON_ATT * 0.1)  #무기 마력의 25%, 최대치 가정.
         MisticArtsMastery = core.InformedCharacterModifier("미스틱 아츠 마스터리", att = 20)
@@ -155,7 +156,7 @@ class JobGenerator(ck.JobGenerator):
     
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
-        WEAPON_ATT = 154
+        WEAPON_ATT = jobutils.getWeaponATT("너클")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         MagicCircuitFullDrive = core.BuffSkill("매직서킷 풀드라이브", 720, (30+vEhc.getV(4,4))*1000, pdamage = (20 + vEhc.getV(3,2)), cooltime = 200*1000).isV(vEhc,4,4).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
+from . import jobutils
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -76,7 +77,7 @@ class JobGenerator(ck.JobGenerator):
     
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
-        WEAPON_ATT = 210
+        WEAPON_ATT = jobutils.getWeaponATT("핸드캐논")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         PirateFlag = PirateFlag = adventurer.PirateFlagWrapper(vEhc, 4, 3, chtr.level)

--- a/dpmModule/jobs/captain.py
+++ b/dpmModule/jobs/captain.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
+from . import jobutils
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -115,7 +116,7 @@ class JobGenerator(ck.JobGenerator):
         PirateFlag = adventurer.PirateFlagWrapper(vEhc, 2, 1, chtr.level)
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
-        WEAPON_ATT = 150
+        WEAPON_ATT = jobutils.getWeaponATT("건")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 4, 4, WEAPON_ATT)
         
         BulletParty = core.DamageSkill("불릿 파티", 0, 0, 0, cooltime = 75000).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/darknight.py
+++ b/dpmModule/jobs/darknight.py
@@ -14,7 +14,7 @@ class JobGenerator(ck.JobGenerator):
         self.buffrem = True
         self.jobtype = "str"
         self.vEnhanceNum = 9
-        self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'buff_rem', 'crit')
+        self.ability_list = Ability_tool.get_ability_set('buff_rem', 'reuse', 'boss_pdamage')
         self.preEmptiveSkills = 2
         
     def get_passive_skill_list(self):

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobclass import heroes
 from .jobbranch import pirates
+from . import jobutils
 
 class SoulTrapBuffWrapper(core.StackSkillWrapper):
     def __init__(self, skill):
@@ -101,7 +102,8 @@ class JobGenerator(ck.JobGenerator):
     
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
-        WEAPON_ATT = 154
+
+        WEAPON_ATT = jobutils.getWeaponATT("너클")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
         
         SoulConcentrate = core.BuffSkill("정령 집속", 960, (30+vEhc.getV(2,1))*1000, cooltime = 120*1000, pdamage_indep = (5+vEhc.getV(2,1)//2)).isV(vEhc,2,1).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -59,3 +59,12 @@ class SpiderInMirrorBuilder():
     def get_skill(self):
         return self.SpiderInMirror
 
+# 창조의 아이온 (즉시 재시전)
+def genesis_aeonian_rise():
+    AeonianRise = core.DamageSkill("창조의 아이온", 0, 1500, 7, cooltime = 180000).wrap(core.DamageSkillWrapper)
+    return AeonianRise
+
+# 파괴의 얄다바오트
+def genesis_tanadian_ruin():
+    TandadianRuin = core.BuffSkill("파괴의 얄다바오트", 0, 30000, cooltime = 90000, pdamage_indep = 15).wrap(core.BuffSkillWrapper)
+    return TandadianRuin

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -3,21 +3,23 @@ from ..kernel import core
 
 #_SoulContract = core.BuffSkill("SoulContract", 600, 1000, cooltime = 9000, pdamage = 45)
 
-# 데벤져 추가할시 쓸만한 하이퍼바디 추가바람
+# TODO: CharacterModifier 반환 방식으로 변경
+passiveStat = lambda slevel : (slevel + 4) // 5
 
+# 미완성 코드
 def useful_hyper_body_demonavenger(slevel = 1):
     # 딜레이 클라기준
-    UsefulHyperBody = core.BuffSkill("쓸만한 하이퍼 바디 (데몬어벤져)", 600, (180 + slevel * 3)*1000, pstat_main = 40, stat_sub = 1, rem = False).wrap(core.BuffSkillWrapper)
+    UsefulHyperBody = core.BuffSkill("쓸만한 하이퍼 바디 (데몬어벤져)", 600, (180 + slevel * 3)*1000, pstat_main = 40, stat_sub = passiveStat(slevel), rem = False).wrap(core.BuffSkillWrapper)
     return UsefulHyperBody
 
 def useful_hyper_body_zenon(slevel = 1):
     # 마나뻥 처리는 직업코드에서
-    UsefulHyperBody = core.BuffSkill("쓸만한 하이퍼 바디", 600, (180 + slevel * 3)*1000, stat_main = 1, stat_sub = 1, rem = False).wrap(core.BuffSkillWrapper)
+    UsefulHyperBody = core.BuffSkill("쓸만한 하이퍼 바디", 600, (180 + slevel * 3)*1000, stat_main = passiveStat(slevel), stat_sub = passiveStat(slevel), rem = False).wrap(core.BuffSkillWrapper)
     return UsefulHyperBody
 
 # 기본 90초, 직업별 딜사이클에 따라 쿨타임 조절가능
 def soul_contract(Cool = 90*1000):
-    SoulContract = core.BuffSkill("소울 컨트랙트", 900, 10*1000, cooltime = Cool, pdamage = 45, rem = True).wrap(core.BuffSkillWrapper)
+    SoulContract = core.BuffSkill("소울 컨트랙트", 900, 10*1000, cooltime = Cool, pdamage = 45, rem = True, red = True).wrap(core.BuffSkillWrapper)
     return SoulContract
 
 # 쓸컴뱃 = 1, 팔라딘 = 2
@@ -25,21 +27,22 @@ def maple_heros(level, combat = 0):
     MapleHeros = core.BuffSkill("메이플 용사", 0, (900+15*combat)*1000, stat_main = (0.15 + 0.005 * combat)*(25 + level * 5), rem = True).wrap(core.BuffSkillWrapper)
     return MapleHeros
 
+# 1레벨
 def useful_combat_orders():
-    UsefulCombatOrders = core.BuffSkill("쓸만한 컴뱃 오더스", 1500, (180 + slevel * 3)*1000, rem = False).wrap(core.BuffSkillWrapper)
+    UsefulCombatOrders = core.BuffSkill("쓸만한 컴뱃 오더스", 1500, (180 + 3)*1000, rem = False).wrap(core.BuffSkillWrapper)
     return UsefulCombatOrders
     
 def useful_sharp_eyes(slevel = 1):
-    UsefulSharpEyes = core.BuffSkill("쓸만한 샤프 아이즈", 900, (180 + slevel * 3) * 1000, rem = False, crit = 10, crit_damage = 8, stat_main = (slevel + 4) // 5, stat_sub = (slevel + 4) // 5).wrap(core.BuffSkillWrapper)
+    UsefulSharpEyes = core.BuffSkill("쓸만한 샤프 아이즈", 900, (180 + slevel * 3) * 1000, rem = False, crit = 10, crit_damage = 8, stat_main = passiveStat(slevel), stat_sub = passiveStat(slevel)).wrap(core.BuffSkillWrapper)
     return UsefulSharpEyes
     
 def useful_wind_booster(slevel = 1):
-    UsefulWindBooster = core.BuffSkill("쓸만한 윈드 부스터", 900, (180 + slevel * 3) * 1000, rem = False, stat_main = (slevel + 4) // 5, stat_sub = (slevel + 4) // 5).wrap(core.BuffSkillWrapper)
+    UsefulWindBooster = core.BuffSkill("쓸만한 윈드 부스터", 900, (180 + slevel * 3) * 1000, rem = False, stat_main = passiveStat(slevel), stat_sub = passiveStat(slevel)).wrap(core.BuffSkillWrapper)
     return UsefulWindBooster
 
-def useful_advanced_bless(slevel = 1):
+def useful_advanced_bless(slevel = 1, useHP = False):
     # TODO: HP, MP 475 증가 반영
-    UsefulAdvancedBless = core.BuffSkill("쓸만한 어드밴스드 블레스", (180 + slevel * 3) * 1000, rem = False, att = 20).wrap(core.BuffSkillWrapper)
+    UsefulAdvancedBless = core.BuffSkill("쓸만한 어드밴스드 블레스", (180 + slevel * 3) * 1000, rem = False, att = 20, stat_main = 475 * useHP).wrap(core.BuffSkillWrapper)
 
 def SpiderInMirrorWrapper(enhancer, skill_importance, enhance_importance, LEVEL):
     MirrorBreak = core.DamageSkill("스파이더 인 미러(공간 붕괴)", 960, 750+30*enhancer.getV(skill_importance, enhance_importance), 12, cooltime = 250*1000).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -23,8 +23,8 @@ def soul_contract(Cool = 90*1000):
     return SoulContract
 
 # 쓸컴뱃 = 1, 팔라딘 = 2
-def maple_heros(level, combat = 0):
-    MapleHeros = core.BuffSkill("메이플 용사", 0, (900+15*combat)*1000, stat_main = (0.15 + 0.005 * combat)*(25 + level * 5), rem = True).wrap(core.BuffSkillWrapper)
+def maple_heros(level, combatLevel = 0):
+    MapleHeros = core.BuffSkill("메이플 용사", 0, (900+15*combatLevel)*1000, stat_main = (0.15 + 0.005 * combatLevel)*(25 + level * 5), rem = True).wrap(core.BuffSkillWrapper)
     return MapleHeros
 
 # 1레벨

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -44,12 +44,18 @@ def useful_advanced_bless(slevel = 1, useHP = False):
     # TODO: HP, MP 475 증가 반영
     UsefulAdvancedBless = core.BuffSkill("쓸만한 어드밴스드 블레스", (180 + slevel * 3) * 1000, rem = False, att = 20, stat_main = 475 * useHP).wrap(core.BuffSkillWrapper)
 
-def SpiderInMirrorWrapper(enhancer, skill_importance, enhance_importance, LEVEL):
-    MirrorBreak = core.DamageSkill("스파이더 인 미러(공간 붕괴)", 960, 750+30*enhancer.getV(skill_importance, enhance_importance), 12, cooltime = 250*1000).wrap(core.DamageSkillWrapper)
-    # 5번 연속 공격 후 종료, 재돌입 대기시간 3초
-    MirrorSpider = core.SummonSkill("스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+17*enhancer.getV(skill_importance, enhance_importance), 8, 15*1000, cooltime = -1).wrap(core.SummonSkillWrapper)
-    MirrorBreak.onAfter(MirrorSpider)
-    # 235레벨 이상만 사용가능
-    SpiderInMirror = core.OptionalElement(lambda : (LEVEL >= 235), MirrorBreak)
+class SpiderInMirrorBuilder():
+    def __init__(self, enhancer, skill_importance, enhance_importance, chtr_level):
+        self.MirrorBreak = core.DamageSkill(
+            "스파이더 인 미러(공간 붕괴)", 960, 750+30*enhancer.getV(skill_importance, enhance_importance), 12, cooltime = 250*1000
+        ).wrap(core.DamageSkillWrapper)
+        # 5번 연속 공격 후 종료, 재돌입 대기시간 3초
+        self.MirrorSpider = core.SummonSkill(
+            "스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+17*enhancer.getV(skill_importance, enhance_importance), 8, 15*1000, cooltime = -1
+        ).wrap(core.SummonSkillWrapper)
+        self.MirrorBreak.onAfter(self.MirrorSpider.controller(3000))
+        self.SpiderInMirror = core.OptionalElement(cthr_level >= 235, MirrorBreak)
 
-    return SpiderInMirror, MirrorBreak, MirrorSpider
+    def get_skill(self):
+        return self.SpiderInMirror
+

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -66,5 +66,5 @@ def genesis_aeonian_rise():
 
 # 파괴의 얄다바오트
 def genesis_tanadian_ruin():
-    TandadianRuin = core.BuffSkill("파괴의 얄다바오트", 0, 30000, cooltime = 90000, pdamage_indep = 15).wrap(core.BuffSkillWrapper)
+    TandadianRuin = core.BuffSkill("파괴의 얄다바오트", 0, 30000, cooltime = 120000, pdamage_indep = 15).wrap(core.BuffSkillWrapper)
     return TandadianRuin

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -5,32 +5,48 @@ from ..kernel import core
 
 # 데벤져 추가할시 쓸만한 하이퍼바디 추가바람
 
-def soul_contract():
-    SoulContract = core.BuffSkill("소울 컨트랙트", 600, 10*1000, cooltime = 90*1000, pdamage = 45, rem = True).wrap(core.BuffSkillWrapper)
+def useful_hyper_body_demonavenger(slevel = 1):
+    # 딜레이 클라기준
+    UsefulHyperBody = core.BuffSkill("쓸만한 하이퍼 바디 (데몬어벤져)", 600, (180 + slevel * 3)*1000, pstat_main = 40, stat_sub = 1, rem = False).wrap(core.BuffSkillWrapper)
+    return UsefulHyperBody
+
+def useful_hyper_body_zenon(slevel = 1):
+    # 마나뻥 처리는 직업코드에서
+    UsefulHyperBody = core.BuffSkill("쓸만한 하이퍼 바디", 600, (180 + slevel * 3)*1000, stat_main = 1, stat_sub = 1, rem = False).wrap(core.BuffSkillWrapper)
+    return UsefulHyperBody
+
+# 기본 90초, 직업별 딜사이클에 따라 쿨타임 조절가능
+def soul_contract(Cool = 90*1000):
+    SoulContract = core.BuffSkill("소울 컨트랙트", 900, 10*1000, cooltime = Cool, pdamage = 45, rem = True).wrap(core.BuffSkillWrapper)
     return SoulContract
 
-def maple_heros(level):
-    MapleHeros = core.BuffSkill("메이플 용사", 0, 900*1000, stat_main = 0.15*(25 + level * 5), rem = True).wrap(core.BuffSkillWrapper)
+# 쓸컴뱃 = 1, 팔라딘 = 2
+def maple_heros(level, combat = 0):
+    MapleHeros = core.BuffSkill("메이플 용사", 0, (900+15*combat)*1000, stat_main = (0.15 + 0.005 * combat)*(25 + level * 5), rem = True).wrap(core.BuffSkillWrapper)
     return MapleHeros
 
 def useful_combat_orders():
-    UsefulCombatOrders = core.BuffSkill("쓸만한 컴뱃 오더스", 1350, 183*1000, rem = False).wrap(core.BuffSkillWrapper)
+    UsefulCombatOrders = core.BuffSkill("쓸만한 컴뱃 오더스", 1500, (180 + slevel * 3)*1000, rem = False).wrap(core.BuffSkillWrapper)
     return UsefulCombatOrders
     
-def useful_sharp_eyes():
-    UsefulSharpEyes = core.BuffSkill("쓸만한 샤프 아이즈", 1080, 183 * 1000, rem = False, crit = 10, crit_damage = 8).wrap(core.BuffSkillWrapper)
+def useful_sharp_eyes(slevel = 1):
+    UsefulSharpEyes = core.BuffSkill("쓸만한 샤프 아이즈", 900, (180 + slevel * 3) * 1000, rem = False, crit = 10, crit_damage = 8, stat_main = (slevel + 4) // 5, stat_sub = (slevel + 4) // 5).wrap(core.BuffSkillWrapper)
     return UsefulSharpEyes
     
-def useful_wind_booster():
-    UsefulWindBooster = core.BuffSkill("쓸만한 윈드 부스터", 1080, 183*1000, rem = False).wrap(core.BuffSkillWrapper)
+def useful_wind_booster(slevel = 1):
+    UsefulWindBooster = core.BuffSkill("쓸만한 윈드 부스터", 900, (180 + slevel * 3) * 1000, rem = False, stat_main = (slevel + 4) // 5, stat_sub = (slevel + 4) // 5).wrap(core.BuffSkillWrapper)
     return UsefulWindBooster
+
+def useful_advanced_bless(slevel = 1):
+    # TODO: HP, MP 475 증가 반영
+    UsefulAdvancedBless = core.BuffSkill("쓸만한 어드밴스드 블레스", (180 + slevel * 3) * 1000, rem = False, att = 20).wrap(core.BuffSkillWrapper)
 
 def SpiderInMirrorWrapper(enhancer, skill_importance, enhance_importance, LEVEL):
     MirrorBreak = core.DamageSkill("스파이더 인 미러(공간 붕괴)", 960, 750+30*enhancer.getV(skill_importance, enhance_importance), 12, cooltime = 250*1000).wrap(core.DamageSkillWrapper)
     # 5번 연속 공격 후 종료, 재돌입 대기시간 3초
-    MirrorSpider = core.SummonSkill("스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+17*enhancer.getV(skill_importance, enhance_importance), 8, 15*1000).wrap(core.SummonSkillWrapper)
+    MirrorSpider = core.SummonSkill("스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+17*enhancer.getV(skill_importance, enhance_importance), 8, 15*1000, cooltime = -1).wrap(core.SummonSkillWrapper)
     MirrorBreak.onAfter(MirrorSpider)
     # 235레벨 이상만 사용가능
     SpiderInMirror = core.OptionalElement(lambda : (LEVEL >= 235), MirrorBreak)
 
-    return SpiderInMirror
+    return SpiderInMirror, MirrorBreak, MirrorSpider

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -5,6 +5,7 @@ from functools import partial
 from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobbranch import magicians
+from . import jobutils
 
 class IliumStackWrapper(core.StackSkillWrapper):
     def __init__(self, skill, _max, fastChargeJudge, stopJudge, name = None):
@@ -54,7 +55,7 @@ class JobGenerator(ck.JobGenerator):
     def get_passive_skill_list(self):
         vEhc = self.vEhc
         # 앱솔 무기 마력 241
-        WEAPON_ATT = 241
+        WEAPON_ATT = jobutils.getWeaponATT("건틀렛")
         MagicCircuit = core.InformedCharacterModifier("매직 서킷", att = WEAPON_ATT*0.2)
         
         MagicGuntletMastery = core.InformedCharacterModifier("매직 건틀렛 마스터리", crit = 20)

--- a/dpmModule/jobs/jobutils.py
+++ b/dpmModule/jobs/jobutils.py
@@ -1,6 +1,8 @@
 from ..item import RootAbyss, Absolab, Arcane
 
-def getWeaponATT(WEAPON_NAME, spec):
+# 스펙 측정시마다 수동으로 변경 필요
+
+def getWeaponATT(WEAPON_NAME, spec = 6000):
     if spec < 5000:
         #파프
         return RootAbyss.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).att

--- a/dpmModule/jobs/jobutils.py
+++ b/dpmModule/jobs/jobutils.py
@@ -1,0 +1,12 @@
+from ..item import RootAbyss, Absolab, Arcane
+
+def getWeaponATT(WEAPON_NAME, spec):
+    if spec < 5000:
+        #파프
+        return RootAbyss.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).att
+    elif spec < 7000:
+        #앱솔
+        return Absolab.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).att
+    else:
+        #아케인
+        return Arcane.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).att

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -9,6 +9,7 @@ from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobclass import resistance
 from .jobbranch import pirates
+from . import jobutils
 
 # TODO: 워머신 타이탄 추가 (로봇 마스터리 적용)
 # TODO: [메탈아머 전탄발사] : 호밍 미사일 리로드 지속시간이 4초에서 2초로 감소되고 지속시간이 좀 더 정확하게 적용됩니다.
@@ -83,7 +84,7 @@ class JobGenerator(ck.JobGenerator):
     
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
-        WEAPON_ATT = 150
+        WEAPON_ATT = jobutils.getWeaponATT("건")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         RegistanceLineInfantry = resistance.ResistanceLineInfantryWrapper(vEhc, 3, 3)

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -97,7 +97,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeaponCooltimeDummy = auraweapon_builder.get_buff()
                         
         return(Blast,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, combatLevel = 2), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Threat, BlessingArmor, ElementalForce, EpicAdventure, HolyUnity, AuraWeaponBuff,
                     globalSkill.soul_contract()] +\
                 [LighteningCharge, DivineCharge, GrandCross] +\

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -38,7 +38,7 @@ class JobGenerator(ck.JobGenerator):
 
     def get_not_implied_skill_list(self):
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 35)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5 + 0.5 * self.combat)
         
         DistancingSence = core.InformedCharacterModifier("디스턴싱 센스",pdamage_indep = 40 + self.combat * 2) #최대 사정거리
         MortalBlow = core.InformedCharacterModifier("모탈 블로우",pdamage = 2)        

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -40,7 +40,7 @@ class JobGenerator(ck.JobGenerator):
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 35)
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5)
         
-        DistancingSence = core.InformedCharacterModifier("디스턴싱 센스",pdamage_indep = 42) #최대 사정거리
+        DistancingSence = core.InformedCharacterModifier("디스턴싱 센스",pdamage_indep = 40 + self.combat * 2) #최대 사정거리
         MortalBlow = core.InformedCharacterModifier("모탈 블로우",pdamage = 2)        
         ExtremeArchery = core.InformedCharacterModifier("익스트림 아처리:석궁",crit_damage = 20)
         
@@ -69,8 +69,7 @@ class JobGenerator(ck.JobGenerator):
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
         #Damage Skills
-        # TODO: 롱레인지 트루샷: MP 300 소비, 범위 내 12명의 적에게 450% 데미지로 9번 공격
-        #재사용 대기시간 15초
+        # 롱레인지 트루샷: 나무위키피셜 DPM 떨어지므로 보류
 
         Snipping = core.DamageSkill("스나이핑", 630, 465+combat*5, 9 + 1, modifier = core.CharacterModifier(crit = 100, armor_ignore = 20 + combat*1, pdamage = 20, boss_pdamage = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         TrueSnippingTick = core.DamageSkill("트루 스나이핑(타격)", 700, 950+vEhc.getV(2,2)*30, 14+1, modifier = core.CharacterModifier(pdamage=100, armor_ignore = 100)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -7,6 +7,8 @@ from . import globalSkill
 from . import contrib
 from .jobbranch import pirates
 from .jobclass import cygnus
+from . import jobutils
+
 #TODO : 5차 신스킬 적용
 #TODO : 천지개벽 발동 중에는 태풍을 노쿨로 사용하도록
 
@@ -103,7 +105,7 @@ class JobGenerator(ck.JobGenerator):
 
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
-        WEAPON_ATT = 154
+        WEAPON_ATT = jobutils.getWeaponATT("너클")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
 
         ShinNoiHapL = core.BuffSkill("신뇌합일", 0, (30+vEhc.getV(3,2)//2) * 1000, red = True, cooltime = (121-vEhc.getV(3,2)//2)*1000, pdamage_indep=4+vEhc.getV(3,2)//5).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
+from . import jobutils
 #TODO : 5차 신스킬 적용
 
 class EnergyChargeWrapper(core.StackSkillWrapper):
@@ -104,7 +105,7 @@ class JobGenerator(ck.JobGenerator):
         
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
-        WEAPON_ATT = 154
+        WEAPON_ATT = jobutils.getWeaponATT("너클")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
         
         Transform = core.BuffSkill("트랜스폼", 450, (50+vEhc.getV(1,1))*1000, cooltime = 180 * 1000, pdamage_indep = (20 + 0.2*vEhc.getV(1,1))).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)#에너지 완충

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -8,8 +8,6 @@ from .jobbranch import warriors
 
 # TODO: 4카 5앱 적용, 리미트 막타 추가
 
-# 제로 메용은 쓸컴뱃을 적용받지 않음
-
 # 초월자 륀느의 기원 : 미적용 상태
 def RhinneBlessWrapper(enhancer, skill_importance, enhance_importance):
     # TODO: 재사용 대기시간 초기화 구현
@@ -324,7 +322,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeaponCooltimeDummy = auraweapon_builder.get_buff()
 
         return(ComboHolder,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, combatLevel = 0), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     AlphaState, BetaState, AuraWeaponBuff, DoubleTime, TimeDistortion, TimeHolding, IntensiveTime, LimitBreak,
                     globalSkill.soul_contract()]+\
                 [ShadowRain, TwinBladeOfTime, ShadowFlashAlpha, ShadowFlashBeta]+\

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -8,15 +8,6 @@ from .jobbranch import warriors
 
 # TODO: 4카 5앱 적용, 리미트 막타 추가
 
-# 초월자 륀느의 기원 : 미적용 상태
-def RhinneBlessWrapper(enhancer, skill_importance, enhance_importance):
-    # TODO: 재사용 대기시간 초기화 구현
-    RhinneBless = core.BuffSkill("초월자 륀느의 기원", 630, 30+enhancer.getV(skill_importance, enhance_importance)//2, cooltime = 240000, att = 10+3*enhancer.getV(skill_importance, enhance_importance)).wrap(core.BuffSkillWrapper)
-    RhinneBlessAttack_hit = core.DamageSkill("초월자 륀느의 기원 (타격)", 0, 125+5*enhancer.getV(skill_importance, enhance_importance), 5, cooltime = 0).wrap(core.DamageSkillWrapper)
-    RhinneBlessAttack = core.OptionalElement(RhinneBless.is_active(), RhinneBlessAttack_hit)
-
-    return RhinneBless, RhinneBlessAttack
-
 
 # 현재로는 계산 알고리즘 작성 구문에서 연산과정에 접근을 할 수 없도록 캡슐화되어 있으므로 사용 불가능
 '''
@@ -197,11 +188,14 @@ class JobGenerator(ck.JobGenerator):
         # 딜레이 확인필요, 딜사이클에 포함되는 스킬인지 확인필요
         ShadowRain = core.DamageSkill("쉐도우 레인", 0, 1400, 14, cooltime = 300*1000).wrap(core.DamageSkillWrapper)
         
+        SoulContract = globalSkill.soul_contract()
+
         #### 5차 스킬 ####
         #5차스킬들 마스터리 알파/베타 구분해서 적용할것.
         
         LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*vEhc.getV(0,0), 5).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+vEhc.getV(0,0)//2)*1000, pdamage_indep = (30+vEhc.getV(0,0)//5) *1.2 + 20, cooltime = 240*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        
         #LimitBreakFinal = core.DamageSkill("리미트 브레이크 (막타)", 0, '''지속시간 동안 가한 데미지의 20% / 15''', 15)
         # 베타로 사용함.
         TwinBladeOfTime = core.DamageSkill("조인트 어택", 0, 0, 0, cooltime = 120*1000, red = True).wrap(core.DamageSkillWrapper)
@@ -221,15 +215,11 @@ class JobGenerator(ck.JobGenerator):
         
         ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)
 
+        #초월자 륀느의 기원
         '''
-        초월자 륀느의 기원
-        RhinneBless, RhinneBlessAttack = RhinneBlessWrapper(vEhc, 0, 0)
-        모든 스킬에 onAfter(RhinneBlessAttack) 추가
-        for sk in [MoonStrike, PierceStrike, FlashAssault, AdvancedSpinCutter,
-                    AdvancedRollingCurve, AdvancedRollingAssulter, StormBreak, UpperStrike, AirRiot, GigaCrash,
-                    FallingStar, AdvancedEarthBreak, TwinBladeOfTime_end]:
-            sk.onAfter(RhinneBlessAttack)
-        스킬 쿨타임 초기화
+        RhinneBless = core.BuffSkill("초월자 륀느의 기원", 630, 30+vEhc.getV(0, 0)//2, cooltime = 240000, att = 10+3*vEhc.getV(0, 0)).wrap(core.BuffSkillWrapper)
+        RhinneBlessAttack_hit = core.DamageSkill("초월자 륀느의 기원 (타격)", 0, 125+5*vEhc.getV(0, 0), 5, cooltime = -1).wrap(core.DamageSkillWrapper)
+        RhinneBlessAttack = core.OptionalElement(RhinneBless.is_active(), RhinneBlessAttack_hit)
         '''
 
 
@@ -242,7 +232,7 @@ class JobGenerator(ck.JobGenerator):
         윈드커터-윈드스트라이크-스톰브레이크 / 문스트라이크-피어스쓰러스트 / 문스트라이크-피어스 쓰러스트 /
         기가크래시-점핑크래시-어드어스브레이크 / 어퍼슬래시-파워스텀프 / 어퍼슬래시-파워스텀프/
         '''
-        
+
         ### 스킬 연결 ###
         ### 알파 ###
         MoonStrike.onAfter(PierceStrike)
@@ -309,7 +299,15 @@ class JobGenerator(ck.JobGenerator):
         ShadowFlashAlpha.onAfter(ShadowFlashAlphaEnd)
         ShadowFlashBeta.onAfter(ShadowFlashBetaEnd)
         LimitBreak.onAfter(LimitBreakAttack)
+
+        LimitBreakCDR = core.BuffSkill("리미트 브레이크(재사용 대기시간 감소)", 0, 0, cooltime = -1).wrap(core.BuffSkillWrapper)
+        LimitBreak.onAfter(LimitBreakCDR)
+        for sk in [ShadowRain, TimeDistortion, SoulContract]:
+            # 재사용 대기시간 초기화의 효과를 받지 않는 스킬을 제외한 스킬의 재사용 대기시간이 (기본 200%에 5레벨마다 10%씩) 더 빠르게 감소
+            LimitBreakCDR.onAfter(sk.controller(2000 + 20 * vEhc.getV(0, 0), 'reduce_cooltime'))
         
+        LimitBreakCDR.onAfter(core.OptionalElement(LimitBreak.is_active, LimitBreakCDR.controller(1000)))
+
         StateTAG = core.OptionalElement(AlphaState.is_active, SetBeta, SetAlpha)
         
         ### 국콤 생성
@@ -328,10 +326,21 @@ class JobGenerator(ck.JobGenerator):
             auraweapon_builder.add_aura_weapon(sk)
         AuraWeaponBuff, AuraWeaponCooltimeDummy = auraweapon_builder.get_buff()
 
+        '''
+        스킬 사용 후 초월자 륀느의 기원 발동
+        for sk in [MoonStrike, PierceStrike, FlashAssault, AdvancedSpinCutter,
+                    AdvancedRollingCurve, AdvancedRollingAssulter, StormBreak, UpperStrike, AirRiot, GigaCrash,
+                    FallingStar, AdvancedEarthBreak]:
+            sk.onAfter(RhinneBlessAttack)
+
+        스킬 쿨타임 초기화
+        RhinneBless.onAfters(TimeDistortion.controller(1, 'reduce_cooltime_p'), ShadowRain.controller(1, 'reduce_cooltime_p'), SoulContract.controller(1, 'reduce_cooltime_p'))
+        '''
+
         return(ComboHolder,
                 [globalSkill.maple_heros(chtr.level, combatLevel = 0), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     AlphaState, BetaState, AuraWeaponBuff, DoubleTime, TimeDistortion, TimeHolding, IntensiveTime, LimitBreak,
-                    globalSkill.soul_contract()]+\
+                    SoulContract]+\
                 [ShadowRain, TwinBladeOfTime, ShadowFlashAlpha, ShadowFlashBeta]+\
                 [StormBreakSummon, WindCutterSummon, ThrowingWeapon]+\
                 [AuraWeaponCooltimeDummy]+\


### PR DESCRIPTION
* 신궁
  * 디스턴싱 센스, 숙련도에 컴뱃오더스 적용
* 다크나이트
  * 어빌 변경 (벞지, 재사용, 보공)
* 제로
  * 리미트 브레이크: 지속시간 동안 스킬 쿨타임 빠르게 감소 (틱마다 자동화하는 방법이 있을까요...?)
* 공통 사항
  * 무기 순공격력 함수 추가 및 직업 코드에 임시 적용 (#66 )
  * 쓸뻥, 쓸어블 추가
  * 쓸만한 스킬들 패시브 능력치 추가
  * 메용에 컴뱃오더스 적용
  * 스인미 구현 방식 변경
  * 엔버링크 쿨타임 초기화 가능, 직업별로 쿨타임 조절 가능
  * 제네시스 무기 스킬 추가