### PR TITLE
스트라이커, 제로 수정

### DIFF
--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -43,7 +43,7 @@ class JobGenerator(ck.JobGenerator):
         '''
         트리니티 버프는 2.8중첩으로 계산
         
-        하이퍼 : 소울시커-메이크업, 피나투라페투치아-인핸스/쿨리듀스
+        하이퍼 : 소울시커-메이크업/리인포스, 피나투라페투치아-쿨리듀스
         트리니티 - 리인포스/스플릿데미지
         
         스포트라이트 히트 3, 공속 1500ms
@@ -71,8 +71,8 @@ class JobGenerator(ck.JobGenerator):
         Booster = core.BuffSkill("리리컬 크로스", 0, 200*1000).wrap(core.BuffSkillWrapper)
         
         SoulContract = core.BuffSkill("소울 컨트랙트", 600, 10000, rem = True, red = True, cooltime = 90000, pdamage = 90).wrap(core.BuffSkillWrapper)
-        SoulSeekerExpert = core.DamageSkill("소울 시커", 0, 320 * 0.75, 1 * 0.35 * 6.03).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
-        SoulSeekerExpert_PR = core.DamageSkill("소울 시커(프라이멀 로어)", 0, 320 * 0.75, 1 * 0.5 * 6.03).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        SoulSeekerExpert = core.DamageSkill("소울 시커", 0, 320 * 0.75, 1 * 0.35 * 6.03, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        SoulSeekerExpert_PR = core.DamageSkill("소울 시커(프라이멀 로어)", 0, 320 * 0.75, 1 * 0.5 * 6.03, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         Trinity_1 = core.DamageSkill("트리니티", 470, 650, 2+1, modifier = core.CharacterModifier(pdamage =20, armor_ignore=20) +core.CharacterModifier(pdamage =28, armor_ignore=28)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper, name = "트리니티(1타)")
         Trinity_2 = core.DamageSkill("트리니티(2타)", 470, 650, 3+1, modifier = core.CharacterModifier(pdamage =20, armor_ignore=20) +core.CharacterModifier(pdamage =28, armor_ignore=28)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper, name = "트리니티(2타)")

--- a/dpmModule/jobs/cadena.py
+++ b/dpmModule/jobs/cadena.py
@@ -55,7 +55,7 @@ class JobGenerator(ck.JobGenerator):
         self.buffrem = False
         self.vEnhanceNum = 11
         self.jobtype = "luk"
-        self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'buff_rem', 'crit')
+        self.ability_list = Ability_tool.get_ability_set('reuse', 'boss_pdamage', 'mess')
         self.preEmptiveSkills = 1
         
     def get_passive_skill_list(self):

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -90,12 +90,12 @@ class JobGenerator(ck.JobGenerator):
         ######   Skill   ######
         # http://m.inven.co.kr/board/powerbbs.php?come_idx=2297&stype=subject&svalue=%EC%8A%A4%ED%83%9D&l=52201
 
-        # 크로아 서버 스킨헤드님 제보 (https://maple.gg/u/%EC%8A%A4%ED%82%A8%ED%97%A4%EB%93%9C)
-        # http://m.dcinside.com/board/maplestory/10616710
-        # http://m.dcinside.com/board/maplestory/10616992
+        # 1타 94.6%, 2타 100%
+        # 크로아 서버 스킨헤드님 (https://maple.gg/u/%EC%8A%A4%ED%82%A8%ED%97%A4%EB%93%9C)
+        # https://drive.google.com/file/d/1ORJc-F77ELssCSVWgHiuQP49pifgCjpo/view
 
-        STACK1RATE = 70
-        STACK2RATE = 95
+        STACK1RATE = 94.6
+        STACK2RATE = 100
 
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 200*1000).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -60,7 +60,10 @@ class JobGenerator(ck.JobGenerator):
         섬멸, 벽력, 승천, (뇌성)
         
         뇌전버프 상시 풀스택 가정
-        태풍은 버프 쿨타임마다만 사용
+        연계 100% 가정
+
+        천지개벽 ON: 태풍 - 섬멸
+        천지개벽 OFF: 벽력 - 섬멸
         
         벽섬 : 1080ms (420 / 660)
         
@@ -76,23 +79,19 @@ class JobGenerator(ck.JobGenerator):
         Booster = core.BuffSkill("부스터", 0, 180000, rem = True).wrap(core.BuffSkillWrapper)
         ChookRoi = core.BuffSkill("축뢰", 1620, 180000, rem = True).wrap(core.BuffSkillWrapper) # 타수증가 적용으로 계싼할지는 염두에 두어야 함
         WindBooster = core.BuffSkill("윈드 부스터", 0, 300000, rem = True).wrap(core.BuffSkillWrapper)
+        HuricaneBuff = core.BuffSkill("태풍(버프)", 0, 90000, rem = True, pdamage = 35).wrap(core.BuffSkillWrapper)
     
 
         # 5차 강화에 포함해야 할 수도 있음
-        # 버프 통합 필요
-        Huricane = core.DamageSkill("태풍", 0, 390, 5).wrap(core.DamageSkillWrapper)
-        #Huricane_NoCool = core.DamageSkill("태풍(노쿨)", 900, 390, 5).wrap(core.DamageSkillWrapper)
-        HuricaneBuff = core.BuffSkill("태풍(버프)", 900, 90000, rem = True, pdamage = 35).wrap(core.BuffSkillWrapper)
+        Huricane = core.DamageSkill("태풍", 900, 390, 5, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2).wrap(core.DamageSkillWrapper)
         
         Destroy = core.DamageSkill("섬멸", 420, 350, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         Thunder = core.DamageSkill("벽력", 660, 320, 5 + 1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         DestroyConcat = core.DamageSkill("섬멸(연계)", 420, 350, 2 + 5, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20, pdamage_indep = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         ThunderConcat = core.DamageSkill("벽력(연계)", 660, 320, 5 + 1, modifier = core.CharacterModifier(pdamage = 20, pdamage_indep = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #연계최종뎀 20%
         
-        
-        
-        #BasicAttack = core.DamageSkill("섬멸", 420, 350, 2 + 5, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        BasicAttack = core.DamageSkill("벽력(기본공격)", 660, 320, 5 + 1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)        
+        #BasicAttack = core.DamageSkill("섬멸(기본공격)", 420, 350, 2 + 5, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        #BasicAttack = core.DamageSkill("벽력(기본공격)", 660, 320, 5 + 1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)        
 
         # 하이퍼
         # 딜레이 추가 필요
@@ -111,38 +110,36 @@ class JobGenerator(ck.JobGenerator):
         ShinNoiHapL = core.BuffSkill("신뇌합일", 0, (30+vEhc.getV(3,2)//2) * 1000, red = True, cooltime = (121-vEhc.getV(3,2)//2)*1000, pdamage_indep=4+vEhc.getV(3,2)//5).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
         ShinNoiHapLAttack = core.SummonSkill("신뇌합일(공격)", 0, 3000, 16*vEhc.getV(3,2) + 400, 7, (30+vEhc.getV(3,2)//2) * 1000, cooltime = -1).isV(vEhc,3,2).wrap(core.SummonSkillWrapper)
         ShinNoiHapLAttack_ChookRoi = core.DamageSkill('신뇌합일(축뢰)', 0, (16*vEhc.getV(3,2) + 400) * CHOOKROI, 7 ).wrap(core.DamageSkillWrapper)
-        GioaTan = core.DamageSkill("교아탄", 480, 1000+40*vEhc.getV(2,1), 7, cooltime = 8000).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #  교아탄-벽력 콤보 사용함
+        GioaTan = core.DamageSkill("교아탄", 480, 1000+40*vEhc.getV(2,1), 7, cooltime = 8000, modifier = core.CharacterModifier(pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #  교아탄-벽력 콤보 사용함
 
         NoiShinChanGeuk = core.DamageSkill("뇌신창격", 0, 150+6*vEhc.getV(0,0), 6, cooltime = 7000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         NoiShinChanGeukAttack = core.SummonSkill("뇌신창격(공격)", 0, 1000, 200 + 8*vEhc.getV(0,0), 7, 3999, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)    #4번 발동
         NoiShinChanGeukAttack_ChookRoi = core.DamageSkill("뇌신창격(축뢰)", 0, (200 + 8*vEhc.getV(0,0)) * CHOOKROI, 7).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         #섬멸 연계
+
+        BasicAttack = core.OptionalElement(SkyOpen.is_active, Huricane, ThunderConcat)
+        BasicAttackWrapper = core.DamageSkill('기본 공격', 0,0,0).wrap(core.DamageSkillWrapper)
+        BasicAttackWrapper.onAfter(BasicAttack)
+
+        Huricane.onAfter(DestroyConcat)
+        ThunderConcat.onAfter(DestroyConcat)
         
-        for skill in [Destroy, Thunder, DestroyConcat, BasicAttack, ThunderConcat, GioaTan, NoiShinChanGeuk]:
+        for skill in [Destroy, Thunder, DestroyConcat, ThunderConcat, Huricane, GioaTan, NoiShinChanGeuk]:
             contrib.create_auxilary_attack(skill, CHOOKROI)
+        
         ShinNoiHapLAttack.onTick(ShinNoiHapLAttack_ChookRoi)
         NoiShinChanGeukAttack.onTick(NoiShinChanGeukAttack_ChookRoi)
-
-        #천지개벽 발동 중에는 태풍을 노쿨로 사용
-        #Huricane_NoCool.onAfter(HuricaneBuff)
-        #Huricane_SkyOpen = core.OptionalElement(SkyOpen.is_active(), Huricane_NoCool, name = "태풍(천지개벽)" )
-        
-        #조건부 파이널어택으로 설정함.
-
-        HuricaneBuff.onAfter(Huricane)
-        #BasicAttack.onAfter(ThunderConcat)
-        BasicAttack.onAfter(DestroyConcat)
         
         ShinNoiHapL.onAfter(ShinNoiHapLAttack)
-        GioaTan.onAfter(ThunderConcat)
+        #GioaTan.onAfter(DestroyConcat)
         NoiShinChanGeuk.onAfter(NoiShinChanGeukAttack)
 
-        return(BasicAttack,
+        return(BasicAttackWrapper,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Lightening, Booster, ChookRoi, WindBooster, LuckyDice,
-                    HuricaneBuff, GloryOfGuardians, Overdrive, OverdrivePenalty, ShinNoiHapL,
+                    HuricaneBuff, GloryOfGuardians, SkyOpen, Overdrive, OverdrivePenalty, ShinNoiHapL,
                     globalSkill.soul_contract()] +\
                 [GioaTan, CygnusPalanks, NoiShinChanGeuk] +\
                 [ShinNoiHapLAttack, NoiShinChanGeukAttack] +\
                 [] +\
-                [BasicAttack])
+                [BasicAttackWrapper])

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -38,6 +38,17 @@ class LimitBreakNew():
 # LimitBreak = LimitBreakSet.get_buff()
 '''
 
+'''
+스킬 사용 시 공격 받은 적이 스킬의 최대 공격 가능한 몬스터 수보다 적을 때 1명 당 8%의 데미지 증가
+
+각각 베타 스킬에 꼭 적용해주세요. 툴팁에 나와있는 몬스터 수를 그대로 작성해주시면 됩니다.
+
+vlevel = 코어 20레벨 효과인 타겟 수 증가를 적용하기 위한 변수입니다. 5차 스킬은 레벨에 따른 타겟 수 증가가 없으니 -1으로 써주세요.
+'''
+def beta_enrage(target, vlevel):
+    target += (vlevel >= 20)
+    return core.CharacterModifier(pdamage = 8 * (target - 1))
+
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
@@ -94,12 +105,12 @@ class JobGenerator(ck.JobGenerator):
             core.CharacterModifier(crit = 40) + \
             core.CharacterModifier(crit_damage = 50)
         BetaMastery = core.CharacterModifier(pdamage_indep = 49) + \
-                    core.CharacterModifier(crit = 15, boss_pdamage = 30 + 30, att = 80, pdamage = 40) + \
+                    core.CharacterModifier(crit = 15, boss_pdamage = 30 + 30, att = 80) + \
                     core.CharacterModifier(armor_ignore = 50)
         
         # 알파: 크리티컬 바인드 크뎀 평균값 적용
         AlphaState = core.BuffSkill("상태-알파", 0, 9999*10000, cooltime = -1, crit_damage = (20*4/35)).wrap(core.BuffSkillWrapper)
-        BetaState = core.BuffSkill("상태-베타", 0, 9999*10000, cooltime = -1, pdamage_indep = 9.70, crit = 15-40, boss_pdamage = 30, att = 80-40, pdamage = 40, armor_ignore = -42.85, crit_damage = -(50 + (20*4/35))).wrap(core.BuffSkillWrapper)
+        BetaState = core.BuffSkill("상태-베타", 0, 9999*10000, cooltime = -1, pdamage_indep = 9.70, crit = 15-40, boss_pdamage = 30, att = 80-40, armor_ignore = -42.85, crit_damage = -(50 + (20*4/35))).wrap(core.BuffSkillWrapper)
 
         #### 알파 ####
         MoonStrike = core.DamageSkill("문 스트라이크", 390, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
@@ -149,36 +160,36 @@ class JobGenerator(ck.JobGenerator):
         #### 베타 ####
         
 
-        UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 210, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
-        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330, 9).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330, 9).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330, 9).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
         THROWINGHIT = 5
-        FlashCut = core.DamageSkill("프론트 슬래시", 630, 205, 6).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 360, 300, 550, 2, THROWINGHIT*300, cooltime=-1).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
-        #ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550, 2 * 5).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
+        FlashCut = core.DamageSkill("프론트 슬래시", 630, 205, 6, modifier = beta_enrage(6, vEhc.getV(6, 2))).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 360, 300, 550, 2, THROWINGHIT*300, cooltime=-1, modifier = beta_enrage(6, vEhc.getV(1, 2))).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
+        #ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550, 2 * 5, modifier = beta_enrage(6, vEhc.getV(1 , 2))).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
         
-        SpinDriver = core.DamageSkill("터닝 드라이브", 540, 260, 6).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 200, 2*7).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
+        SpinDriver = core.DamageSkill("터닝 드라이브", 540, 260, 6, modifier = beta_enrage(6, vEhc.getV(2 , 2))).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 200, 2*7, modifier = beta_enrage(6, vEhc.getV(3 , 2))).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
         
-        GigaCrash = core.DamageSkill("기가 크래시", 630, 250, 6).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        GigaCrashTAG = core.DamageSkill("기가 크래시(태그)", 0, 250, 6).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        GigaCrash = core.DamageSkill("기가 크래시", 630, 250, 6, modifier = beta_enrage(6, vEhc.getV(7 , 2))).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        GigaCrashTAG = core.DamageSkill("기가 크래시(태그)", 0, 250, 6, modifier = beta_enrage(6, vEhc.getV(7 , 2))).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
-        FallingStar = core.DamageSkill("점핑 크래시", 660, 225, 6).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        FallingStar = core.DamageSkill("점핑 크래시", 660, 225, 6, modifier = beta_enrage(6, vEhc.getV(8 , 2))).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
         # 충격파 값 포함
-        FallingStarTAG = core.DamageSkill("점핑 크래시(태그)", 0, 225, 6).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
-        FallingStarWave = core.DamageSkill("점핑 크래시(충격파)", 0, 225, 3).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        FallingStarTAG = core.DamageSkill("점핑 크래시(태그)", 0, 225, 6, modifier = beta_enrage(6, vEhc.getV(8 , 2))).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        FallingStarWave = core.DamageSkill("점핑 크래시(충격파)", 0, 225, 3, modifier = beta_enrage(6, vEhc.getV(8 , 2))).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 380, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 380, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
+        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 380, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 380, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
         
-        AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(파동)", 0, 285, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(파동)", 0, 285, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
         #AdvancedEarthBreakElectric = core.DotSkill("어드밴스드 어스 브레이크(전기)", 340, 5).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340, 5).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340, 5, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
 
         DoubleTime = core.BuffSkill("래피드 타임", 0, 9999*10000, crit = 20, pdamage = 10).wrap(core.BuffSkillWrapper)
         TimeDistortion = core.BuffSkill("타임 디스토션", 540, 30000, cooltime = 240 * 1000, pdamage = 25).wrap(core.BuffSkillWrapper)
@@ -193,25 +204,25 @@ class JobGenerator(ck.JobGenerator):
         #### 5차 스킬 ####
         #5차스킬들 마스터리 알파/베타 구분해서 적용할것.
         
-        LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*vEhc.getV(0,0), 5).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*vEhc.getV(0,0), 5, modifier = beta_enrage(15, -1)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+vEhc.getV(0,0)//2)*1000, pdamage_indep = (30+vEhc.getV(0,0)//5) *1.2 + 20, cooltime = 240*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         
         #LimitBreakFinal = core.DamageSkill("리미트 브레이크 (막타)", 0, '''지속시간 동안 가한 데미지의 20% / 15''', 15)
         # 베타로 사용함.
-        TwinBladeOfTime = core.DamageSkill("조인트 어택", 0, 0, 0, cooltime = 120*1000, red = True).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_1 = core.DamageSkill("조인트 어택(1)", 3480, 875+35*vEhc.getV(1,1), 8).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_2 = core.DamageSkill("조인트 어택(2)", 0, 835+33*vEhc.getV(1,1), 8).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_3 = core.DamageSkill("조인트 어택(3)", 0, 1000+40*vEhc.getV(1,1), 13).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime = core.DamageSkill("조인트 어택", 0, 0, 0, cooltime = 120*1000, modifier = beta_enrage(12, -1)).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_1 = core.DamageSkill("조인트 어택(1)", 3480, 875+35*vEhc.getV(1,1), 8, modifier = beta_enrage(12, -1)).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_2 = core.DamageSkill("조인트 어택(2)", 0, 835+33*vEhc.getV(1,1), 8, modifier = beta_enrage(12, -1)).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_3 = core.DamageSkill("조인트 어택(3)", 0, 1000+40*vEhc.getV(1,1), 13, modifier = beta_enrage(12, -1)).wrap(core.DamageSkillWrapper)
         # 45타수가 시스템상으로 잘 반영되는지 확인필요.
-        TwinBladeOfTime_end = core.DamageSkill("조인트 어택(4)", 0, 900+36*vEhc.getV(1,1), 45, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_end = core.DamageSkill("조인트 어택(4)", 0, 900+36*vEhc.getV(1,1), 45, modifier = (beta_enrage(12, -1) + core.CharacterModifier(armor_ignore = 100))).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         
         #알파
-        ShadowFlashAlpha = core.DamageSkill("쉐도우 플래시(알파)", 670, 500+20*vEhc.getV(2,2), 6, cooltime = 40*1000, red=True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashAlpha = core.DamageSkill("쉐도우 플래시(알파)", 670, 500+20*vEhc.getV(2,2), 6, cooltime = 40*1000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         ShadowFlashAlphaEnd = core.DamageSkill("쉐도우 플래시(알파)(종료)", 0, 400+16*vEhc.getV(2,2), 15*3).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         #베타
-        ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 670, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, red=True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
-        ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 0, 750+30*vEhc.getV(2,2), 12 * 2).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 670, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, modifier = beta_enrage(8, -1)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 0, 750+30*vEhc.getV(2,2), 12 * 2, modifier = beta_enrage(8, -1)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)
 

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -39,14 +39,17 @@ class LimitBreakNew():
 '''
 
 '''
-스킬 사용 시 공격 받은 적이 스킬의 최대 공격 가능한 몬스터 수보다 적을 때 1명 당 8%의 데미지 증가
+beta_enrage
+
+대검 마스터리: 스킬 사용 시 공격 받은 적이 스킬의 최대 공격 가능한 몬스터 수보다 적을 때 1명 당 8%의 데미지 증가
 
 각각 베타 스킬에 꼭 적용해주세요. 툴팁에 나와있는 몬스터 수를 그대로 작성해주시면 됩니다.
 
 vlevel = 코어 20레벨 효과인 타겟 수 증가를 적용하기 위한 변수입니다. 5차 스킬은 레벨에 따른 타겟 수 증가가 없으니 -1으로 써주세요.
 '''
 def beta_enrage(target, vlevel):
-    target += (vlevel >= 20)
+    if vlevel >= 20:
+        target += 1
     return core.CharacterModifier(pdamage = 8 * (target - 1))
 
 class JobGenerator(ck.JobGenerator):
@@ -120,6 +123,8 @@ class JobGenerator(ck.JobGenerator):
         PierceStrikeTAG = core.DamageSkill("피어스 쓰러스트(태그)", 0, 170, 6 ).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
         '''
+        미사용 스킬
+
         ShadowStrike = core.DamageSkill("쉐도우 스트라이크", ?, 195, 8)
         ShadowStrikeAura = core.DamageSkill("쉐도우 스트라이크", 0, 310, 1)
         '''
@@ -217,11 +222,11 @@ class JobGenerator(ck.JobGenerator):
         TwinBladeOfTime_end = core.DamageSkill("조인트 어택(4)", 0, 900+36*vEhc.getV(1,1), 45, modifier = (beta_enrage(12, -1) + core.CharacterModifier(armor_ignore = 100))).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         
         #알파
-        ShadowFlashAlpha = core.DamageSkill("쉐도우 플래시(알파)", 670, 500+20*vEhc.getV(2,2), 6, cooltime = 40*1000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashAlpha = core.DamageSkill("쉐도우 플래시(알파)", 670, 500+20*vEhc.getV(2,2), 6, cooltime = 40*1000, red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         ShadowFlashAlphaEnd = core.DamageSkill("쉐도우 플래시(알파)(종료)", 0, 400+16*vEhc.getV(2,2), 15*3).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         #베타
-        ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 670, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, modifier = beta_enrage(8, -1)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 670, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, modifier = beta_enrage(8, -1), red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 0, 750+30*vEhc.getV(2,2), 12 * 2, modifier = beta_enrage(8, -1)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)
@@ -317,6 +322,7 @@ class JobGenerator(ck.JobGenerator):
             # 재사용 대기시간 초기화의 효과를 받지 않는 스킬을 제외한 스킬의 재사용 대기시간이 (기본 200%에 5레벨마다 10%씩) 더 빠르게 감소
             LimitBreakCDR.onAfter(sk.controller(2000 + 20 * vEhc.getV(0, 0), 'reduce_cooltime'))
         
+        # 리미트 브레이크 지속시간동안 쿨감효과 반복
         LimitBreakCDR.onAfter(core.OptionalElement(LimitBreak.is_active, LimitBreakCDR.controller(1000)))
 
         StateTAG = core.OptionalElement(AlphaState.is_active, SetBeta, SetAlpha)

--- a/full_test.py
+++ b/full_test.py
@@ -8,11 +8,17 @@ import dpmModule.jobs as maplejobs
 full_test.py
 전체 테스트를 위한 스크립트입니다.
 
-등록된 모든 직업의 표준 DPM 수치를 계산하여 파일로 출력합니다.
+등록된 모든 직업의 모든 스펙 기준 DPM 수치를 계산하여 파일로 출력합니다.
 '''
 
-sys.stdout = open('output.txt','w')
+charTemplate = {4000: template.getU4000CharacterTemplate, 5000: template.getU5000CharacterTemplate, 6000: template.getU6000CharacterTemplate, 7000: template.getU7000CharacterTemplate, 8000: template.getU8000CharacterTemplate, 8500: template.getU8500CharacterTemplate}
+
+sys.stdout = open('output.txt','w', encoding= 'utf-8')
 
 for value in maplejobs.jobList.values():
-    gen = IndividualDPMGenerator(value, template.getU6000CharacterTemplate)
-    print(value, gen.get_dpm(ulevel = 6000))
+    union_level_list = [4000, 5000, 6000, 7000, 8000, 8500]
+    print(value, end = '\t')
+    for union_level in union_level_list:
+        gen = IndividualDPMGenerator(value, charTemplate[union_level])
+        print(gen.get_dpm(ulevel = union_level), end = '\t')
+    print("")


### PR DESCRIPTION
스커는 지난번 천지개벽 패치를 적용하고 그에 따라 딜사이클을 수정했습니다.

연계 100% 가정으로 천지개벽이 켜져 있을때 태풍과 섬멸을 반복하며 꺼져 있을 때는 벽력과 섬멸을 반복합니다.

제로는 대검 마스터리가 올바르게 작동하도록 수정했습니다. (타겟수 1마리 감소할때마다 데미지 8% 증가) 리밋브, 조택이 베타일때 발동하는 걸로 가정하고 작성했습니다. 제로는 이거 말고도 고칠 게 엄청 많은 편이라 나중에 시간나면 정리해서 올리겠습니다.


두 직업 모두 유의미한 딜 상승이 확인되었으나, 제가 볼 수 있는 건 결과값뿐이므로 제작자분께서 사이클이 돌아가는지 한번 더 확인해주셔야 할 것 같습니다...