### PR TITLE
메카닉 스킬 수정

### DIFF
--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -80,7 +80,7 @@ class JobGenerator(ck.JobGenerator):
         RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*1.4, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         
         BomberTime = core.BuffSkill("봄버 타임", 990, 10*1000, cooltime = 100*1000).wrap(core.BuffSkillWrapper)
-        DistortionField = core.SummonSkill("디스토션 필드", 690, 4000/30, 350, 2, 4000-1, cooltime = 8000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)
+        DistortionField = core.SummonSkill("디스토션 필드", 690, 4000/15, 350, 2, 4000-1, cooltime = 8000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)
     
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
@@ -88,8 +88,8 @@ class JobGenerator(ck.JobGenerator):
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         RegistanceLineInfantry = core.SummonSkill("레지스탕스 라인 인팬트리", 360, 1000, (215+8*vEhc.getV(3, 3))*(2.08+combat*0.03), 9, 10*1000, cooltime = 25000).isV(vEhc,3, 3).wrap(core.SummonSkillWrapper) # 메카닉은 인팬트리에 로봇 마스터리 최종뎀이 적용됨
-        MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1500, 200+8*vEhc.getV(2,1), 6, (115+6*vEhc.getV(2,1))*1000, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
-        MultipleOptionMissle = core.SummonSkill("멀티플 옵션(미사일)", 0, 8000, 350+10*vEhc.getV(2,1), 24, (115+6*vEhc.getV(2,1))*1000, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
+        MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1901, (200+8*vEhc.getV(2,1))*(2.08+combat*0.03), 6, (75+2*vEhc.getV(2,1))*1000, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper) # 원래 공격주기는 1500이나, 미사일로 인해 손실되는 타수를 보정하기 위해 1901로 기입함.
+        MultipleOptionMissle = core.SummonSkill("멀티플 옵션(미사일)", 0, 8000, (350+10*vEhc.getV(2,1))*(2.08+combat*0.03), 24, (75+2*vEhc.getV(2,1))*1000, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         
         MicroMissle = core.DamageSkill("마이크로 미사일 컨테이너", 540, 375+17*vEhc.getV(0,0), (30 + vEhc.getV(0,0) // 3) * 5, cooltime = 25000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         BusterCall_ = core.DamageSkill("메탈아머 전탄발사", 8500/37, 400+16*vEhc.getV(4,4), 11).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -63,21 +63,20 @@ class JobGenerator(ck.JobGenerator):
         #로디드 데미지 고정.
         LuckyDice = core.BuffSkill("로디드 다이스", 0, 180*1000, pdamage = 40*1/72 + 30*1/6 + 20*(59/72)).isV(vEhc,1,2).wrap(core.BuffSkillWrapper)
         
-        #로봇들 :: 로봇당 총뎀6%
-        Opengate = core.SummonSkill("오픈 게이트:GX-9", 600, 300*1000, 0,0,300*1000*1.4, rem = True).wrap(core.SummonSkillWrapper)#임의 딜레이
+        #로봇들 :: 로봇당 총뎀6%, 어빌리티 적용 시 7%
         
-        Robolauncher = core.SummonSkill("로봇 런처(:RM7)", 630, 1000, (250+135)*(2.08+combat*0.03), 1, 60*1000*1.4, rem=True).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        Robolauncher = core.SummonSkill("로봇 런처(:RM7)", 630, 1000, (250+135)*(2.08+combat*0.03), 1, 60*1000*(1+chtr.summonRemain+0.4)).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
         RobolauncherFinal = core.DamageSkill("로봇 런처(:RM7)(폭발)", 0, 400*(2.08+combat*0.03), 1, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        RobolauncherBuff = core.BuffSkill("로봇 런처(:RM7)(버프)", 0, 60*1000*1.4, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
+        RobolauncherBuff = core.BuffSkill("로봇 런처(:RM7)(버프)", 0, 60*1000*(1+chtr.summonRemain+0.4), cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         #MagneticField = core.SummonSkill("마그네틱 필드", ?, ?, 200, 60*1000, cooltime = 180*1000) 자폭 550% V.getEhc(2, vEnhance[0])
         
-        SupportWaver = core.SummonSkill("서포트 웨이버", 630, 80000*1.4, 0, 0, 80*1000*1.4).wrap(core.SummonSkillWrapper)
-        SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*1.4, pdamage_indep=16, pdamage = 7, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)    #하이퍼(+5), 소환수직속 영향받게..
+        SupportWaver = core.SummonSkill("서포트 웨이버", 630, 80000*(1+chtr.summonRemain+0.4), 0, 0, 80*1000*(1+chtr.summonRemain+0.4)).wrap(core.SummonSkillWrapper)
+        SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*(1+chtr.summonRemain+0.4), pdamage_indep=16, pdamage = 7, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)
         SupportWaverFinal = core.DamageSkill("서포트 웨이버(폭발)", 0, 1100*(2.08+combat*0.03), 1, cooltime = -1).wrap(core.DamageSkillWrapper)
         
-        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500*(2.08+combat*0.03), 3, 30*1000*1.4, cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
+        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500*(2.08+combat*0.03), 3, 30*1000*(1+chtr.summonRemain+0.4), cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
+        RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*(1+chtr.summonRemain+0.4), cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         RoboFactoryFinal = core.DamageSkill("로봇 팩토리(폭발)", 0, 1000*(2.08+combat*0.03), 1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
-        RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*1.4, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         
         BomberTime = core.BuffSkill("봄버 타임", 990, 10*1000, cooltime = 100*1000).wrap(core.BuffSkillWrapper)
         DistortionField = core.SummonSkill("디스토션 필드", 690, 4000/15, 350, 2, 4000-1, cooltime = 8000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)
@@ -126,13 +125,13 @@ class JobGenerator(ck.JobGenerator):
         BusterCall.onAfter(BusterCallEnd)
         BusterCallInit.onAfters([BusterCall, BusterCallBuff])
         
-        Robolauncher.onAfter(RobolauncherFinal.controller(84000))
+        Robolauncher.onAfter(RobolauncherFinal.controller(60*1000*(1+chtr.summonRemain+0.4)))
         Robolauncher.onAfter(RobolauncherBuff.controller(1))
         
+        SupportWaver.onAfter(SupportWaverFinal.controller(80*1000*(1+chtr.summonRemain+0.4)))
         SupportWaver.onAfter(SupportWaverBuff.controller(1))
-        SupportWaver.onAfter(SupportWaverFinal.controller(112000))
         
-        RoboFactory.onAfter(RoboFactoryFinal.controller(1))
+        RoboFactory.onAfter(RoboFactoryFinal.controller(30*1000*(1+chtr.summonRemain+0.4)))
         RoboFactory.onAfter(RoboFactoryBuff.controller(1))
 
         BusterCallBuff.protect_from_running()

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -91,7 +91,7 @@ class JobGenerator(ck.JobGenerator):
         MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1500, 200+8*vEhc.getV(2,1), 6, (115+6*vEhc.getV(2,1))*1000, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         MultipleOptionMissle = core.SummonSkill("멀티플 옵션(미사일)", 0, 8000, 350+10*vEhc.getV(2,1), 24, (115+6*vEhc.getV(2,1))*1000, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         
-        MicroMissle = core.DamageSkill("마이크로 미사일 컨테이너", 540, 375+17*vEhc.getV(0,0), (30+10)*5, cooltime = 25000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        MicroMissle = core.DamageSkill("마이크로 미사일 컨테이너", 540, 375+17*vEhc.getV(0,0), (30 + vEhc.getV(0,0) // 3) * 5, cooltime = 25000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         BusterCall_ = core.DamageSkill("메탈아머 전탄발사", 8500/37, 400+16*vEhc.getV(4,4), 11).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
         BusterCallInit = core.DamageSkill("메탈아머 전탄발사(시전)", 1500, 0, 0, cooltime = 200*1000).wrap(core.DamageSkillWrapper) # 선딜레이 1.5초
         BusterCallBuff = core.BuffSkill("메탈아머 전탄발사(버프)", 0, 8500, cooltime = 200*1000).isV(vEhc,4,4).wrap(core.BuffSkillWrapper) # spentime에 넣으면 됨.

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -6,6 +6,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import RuleSet, ConcurrentRunRule, ReservationRule
 from . import globalSkill
 from .jobclass import resistance
 from .jobbranch import pirates
@@ -47,7 +48,13 @@ class JobGenerator(ck.JobGenerator):
         MetalArmorTank = core.InformedCharacterModifier("메탈아머:탱크",crit=30)
         
         return [WeaponConstant, Mastery, MetalArmorTank]
-        
+
+    def get_ruleset(self):
+        ruleset = RuleSet()
+        ruleset.add_rule(ConcurrentRunRule('메탈아머 전탄발사(시전)', '봄버 타임'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('봄버 타임', '소울 컨트랙트'), RuleSet.BASE)
+        ruleset.add_rule(ReservationRule('소울 컨트랙트', '봄버 타임'), RuleSet.BASE)
+        return ruleset
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
         코강 순서:

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -87,7 +87,7 @@ class JobGenerator(ck.JobGenerator):
         WEAPON_ATT = jobutils.get_weapon_att("건")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
-        RegistanceLineInfantry = core.SummonSkill("레지스탕스 라인 인팬트리", 360, 1000, (215+8*vEhc.getV(3, 3))*(2.08+combat*0.03), 9, 10*1000, cooltime = 25000).isV(vEhc,3, 3).wrap(core.SummonSkillWrapper)
+        RegistanceLineInfantry = core.SummonSkill("레지스탕스 라인 인팬트리", 360, 1000, (215+8*vEhc.getV(3, 3))*(2.08+combat*0.03), 9, 10*1000, cooltime = 25000).isV(vEhc,3, 3).wrap(core.SummonSkillWrapper) # 메카닉은 인팬트리에 로봇 마스터리 최종뎀이 적용됨
         MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1500, 200+8*vEhc.getV(2,1), 6, (115+6*vEhc.getV(2,1))*1000, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         MultipleOptionMissle = core.SummonSkill("멀티플 옵션(미사일)", 0, 8000, 350+10*vEhc.getV(2,1), 24, (115+6*vEhc.getV(2,1))*1000, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -53,6 +53,9 @@ class JobGenerator(ck.JobGenerator):
         코강 순서:
         매시브-호밍-디스토션-마그네틱필드-RM7-RM1
         '''
+        #Constants
+        ROBOT_SUMMON_REMAIN = 1 + chtr.summonRemain + 0.4
+
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 180 * 1000, rem = True).wrap(core.BuffSkillWrapper)    #딜레이 모름
         WillOfLiberty = core.BuffSkill("윌 오브 리버티", 0, 60*1000, cooltime = 120*1000, pdamage = 10).wrap(core.BuffSkillWrapper)
@@ -65,17 +68,17 @@ class JobGenerator(ck.JobGenerator):
         
         #로봇들 :: 로봇당 총뎀6%, 어빌리티 적용 시 7%
         
-        Robolauncher = core.SummonSkill("로봇 런처(:RM7)", 630, 1000, (250+135)*(2.08+combat*0.03), 1, 60*1000*(1+chtr.summonRemain+0.4)).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        Robolauncher = core.SummonSkill("로봇 런처(:RM7)", 630, 1000, (250+135)*(2.08+combat*0.03), 1, 60*1000*ROBOT_SUMMON_REMAIN).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
         RobolauncherFinal = core.DamageSkill("로봇 런처(:RM7)(폭발)", 0, 400*(2.08+combat*0.03), 1, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        RobolauncherBuff = core.BuffSkill("로봇 런처(:RM7)(버프)", 0, 60*1000*(1+chtr.summonRemain+0.4), cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
+        RobolauncherBuff = core.BuffSkill("로봇 런처(:RM7)(버프)", 0, 60*1000*ROBOT_SUMMON_REMAIN, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         #MagneticField = core.SummonSkill("마그네틱 필드", ?, ?, 200, 60*1000, cooltime = 180*1000) 자폭 550% V.getEhc(2, vEnhance[0])
         
-        SupportWaver = core.SummonSkill("서포트 웨이버", 630, 80000*(1+chtr.summonRemain+0.4), 0, 0, 80*1000*(1+chtr.summonRemain+0.4)).wrap(core.SummonSkillWrapper)
-        SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*(1+chtr.summonRemain+0.4), pdamage_indep=16, pdamage = 7, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)
+        SupportWaver = core.SummonSkill("서포트 웨이버", 630, 80000*ROBOT_SUMMON_REMAIN, 0, 0, 80*1000*ROBOT_SUMMON_REMAIN).wrap(core.SummonSkillWrapper)
+        SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*ROBOT_SUMMON_REMAIN, pdamage_indep=16, pdamage = 7, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)
         SupportWaverFinal = core.DamageSkill("서포트 웨이버(폭발)", 0, 1100*(2.08+combat*0.03), 1, cooltime = -1).wrap(core.DamageSkillWrapper)
         
-        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500*(2.08+combat*0.03), 3, 30*1000*(1+chtr.summonRemain+0.4), cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
-        RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*(1+chtr.summonRemain+0.4), cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
+        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500*(2.08+combat*0.03), 3, 30*1000*ROBOT_SUMMON_REMAIN, cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
+        RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*ROBOT_SUMMON_REMAIN, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         RoboFactoryFinal = core.DamageSkill("로봇 팩토리(폭발)", 0, 1000*(2.08+combat*0.03), 1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         
         BomberTime = core.BuffSkill("봄버 타임", 990, 10*1000, cooltime = 100*1000).wrap(core.BuffSkillWrapper)
@@ -125,13 +128,13 @@ class JobGenerator(ck.JobGenerator):
         BusterCall.onAfter(BusterCallEnd)
         BusterCallInit.onAfters([BusterCall, BusterCallBuff])
         
-        Robolauncher.onAfter(RobolauncherFinal.controller(60*1000*(1+chtr.summonRemain+0.4)))
+        Robolauncher.onAfter(RobolauncherFinal.controller(60*1000*ROBOT_SUMMON_REMAIN))
         Robolauncher.onAfter(RobolauncherBuff.controller(1))
         
-        SupportWaver.onAfter(SupportWaverFinal.controller(80*1000*(1+chtr.summonRemain+0.4)))
+        SupportWaver.onAfter(SupportWaverFinal.controller(80*1000*ROBOT_SUMMON_REMAIN))
         SupportWaver.onAfter(SupportWaverBuff.controller(1))
         
-        RoboFactory.onAfter(RoboFactoryFinal.controller(30*1000*(1+chtr.summonRemain+0.4)))
+        RoboFactory.onAfter(RoboFactoryFinal.controller(30*1000*ROBOT_SUMMON_REMAIN))
         RoboFactory.onAfter(RoboFactoryBuff.controller(1))
 
         BusterCallBuff.protect_from_running()

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -61,23 +61,23 @@ class JobGenerator(ck.JobGenerator):
         MassiveFire2 = core.DamageSkill("매시브 파이어(2)", 0, 350, 1, modifier = core.CharacterModifier(pdamage=10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
         #로디드 데미지 고정.
-        LuckyDice = core.BuffSkill("로디드 다이스", 0, 180*1000, pdamage = 20 * 4 / 3).isV(vEhc,1,2).wrap(core.BuffSkillWrapper)
+        LuckyDice = core.BuffSkill("로디드 다이스", 0, 180*1000, pdamage = 40*1/72 + 30*1/6 + 20*(59/72)).isV(vEhc,1,2).wrap(core.BuffSkillWrapper)
         
         #로봇들 :: 로봇당 총뎀6%
         Opengate = core.SummonSkill("오픈 게이트:GX-9", 600, 300*1000, 0,0,300*1000*1.4, rem = True).wrap(core.SummonSkillWrapper)#임의 딜레이
         
-        Robolauncher = core.SummonSkill("로봇 런처(:RM7)", 630, 1000, (250+135)*2.05, 1, 60*1000*1.4, rem=True).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        RobolauncherFinal = core.DamageSkill("로봇 런처(:RM7)(폭발)", 0, 400*2.05, 1, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        RobolauncherBuff = core.BuffSkill("로봇 런처(:RM7)(버프)", 0, 60*1000*1.4, cooltime = -1, pdamage = 6).wrap(core.BuffSkillWrapper)
+        Robolauncher = core.SummonSkill("로봇 런처(:RM7)", 630, 1000, (250+135)*(2.08+combat*0.03), 1, 60*1000*1.4, rem=True).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        RobolauncherFinal = core.DamageSkill("로봇 런처(:RM7)(폭발)", 0, 400*(2.08+combat*0.03), 1, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        RobolauncherBuff = core.BuffSkill("로봇 런처(:RM7)(버프)", 0, 60*1000*1.4, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         #MagneticField = core.SummonSkill("마그네틱 필드", ?, ?, 200, 60*1000, cooltime = 180*1000) 자폭 550% V.getEhc(2, vEnhance[0])
         
         SupportWaver = core.SummonSkill("서포트 웨이버", 630, 80000*1.4, 0, 0, 80*1000*1.4).wrap(core.SummonSkillWrapper)
-        SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*1.4, pdamage_indep=15, pdamage= 5 + 6, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)    #하이퍼(+5), 소환수직속 영향받게..
-        SupportWaverFinal = core.DamageSkill("서포트 웨이버(폭발)", 0, 1100*2.05, 1, cooltime = -1).wrap(core.DamageSkillWrapper)
+        SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*1.4, pdamage_indep=16, pdamage = 7, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)    #하이퍼(+5), 소환수직속 영향받게..
+        SupportWaverFinal = core.DamageSkill("서포트 웨이버(폭발)", 0, 1100*(2.08+combat*0.03), 1, cooltime = -1).wrap(core.DamageSkillWrapper)
         
-        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500*2.05, 3, 30*1000*1.4, cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
-        RoboFactoryFinal = core.DamageSkill("로봇 팩토리(폭발)", 0, 1000*2.05, 1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
-        RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*1.4, cooltime = -1, pdamage = 6).wrap(core.BuffSkillWrapper)
+        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500*(2.08+combat*0.03), 3, 30*1000*1.4, cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
+        RoboFactoryFinal = core.DamageSkill("로봇 팩토리(폭발)", 0, 1000*(2.08+combat*0.03), 1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*1.4, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         
         BomberTime = core.BuffSkill("봄버 타임", 990, 10*1000, cooltime = 100*1000).wrap(core.BuffSkillWrapper)
         DistortionField = core.SummonSkill("디스토션 필드", 690, 4000/30, 350, 2, 4000-1, cooltime = 8000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)
@@ -87,11 +87,11 @@ class JobGenerator(ck.JobGenerator):
         WEAPON_ATT = jobutils.get_weapon_att("건")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
-        RegistanceLineInfantry = resistance.ResistanceLineInfantryWrapper(vEhc, 3, 3)
-        MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1500, 75+2*vEhc.getV(2,1), 6, (115+6*vEhc.getV(2,1))*1000, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
+        RegistanceLineInfantry = core.SummonSkill("레지스탕스 라인 인팬트리", 360, 1000, (215+8*vEhc.getV(3, 3))*(2.08+combat*0.03), 9, 10*1000, cooltime = 25000).isV(vEhc,3, 3).wrap(core.SummonSkillWrapper)
+        MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1500, 200+8*vEhc.getV(2,1), 6, (115+6*vEhc.getV(2,1))*1000, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         MultipleOptionMissle = core.SummonSkill("멀티플 옵션(미사일)", 0, 8000, 350+10*vEhc.getV(2,1), 24, (115+6*vEhc.getV(2,1))*1000, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         
-        MicroMissle = core.DamageSkill("마이크로 미사일 컨테이너", 540, 375+17*vEhc.getV(0,0), (30+8)*5, cooltime = 25000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        MicroMissle = core.DamageSkill("마이크로 미사일 컨테이너", 540, 375+17*vEhc.getV(0,0), (30+10)*5, cooltime = 25000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         BusterCall_ = core.DamageSkill("메탈아머 전탄발사", 8500/37, 400+16*vEhc.getV(4,4), 11).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
         BusterCallInit = core.DamageSkill("메탈아머 전탄발사(시전)", 1500, 0, 0, cooltime = 200*1000).wrap(core.DamageSkillWrapper) # 선딜레이 1.5초
         BusterCallBuff = core.BuffSkill("메탈아머 전탄발사(버프)", 0, 8500, cooltime = 200*1000).isV(vEhc,4,4).wrap(core.BuffSkillWrapper) # spentime에 넣으면 됨.


### PR DESCRIPTION
https://github.com/oleneyl/maplestory_dpm_calc/issues/90

* 패시브 +1 어빌리티 효과를 더 정확하게 적용
  * 로봇 마스터리 스택당 6% -> 7%
  * 서포트 웨이버 최종 데미지 15% -> 16%
  * 로봇 마스터리 로봇 최종데미지 105% -> 108% (어빌리티 패시브+1까지 적용시 111%)
* 멀티플 옵션(개틀링) 퍼뎀 수정
* 레지스탕스 라인 인팬트리에 로봇 마스터리 효과 적용
  * `ResistanceLineInfantryWrapper`를 사용할 수 없어 내부 코드 복붙 후 퍼뎀을 다시 적용
* 서포트 웨이버의 로봇 마스터리 스택으로 인한 버프 `pdamage` 11 -> 7 수정
* 마이크로 미사일 컨테이너 타수 `38*5` -> `40*5`
  * 더 정확히 적용하면 `(30 + floor(코어레벨/3)) * 5` 로 되어야 하는데, vEhc.getV() 메소드를 제대로 이해했는 지 확실하지 않아 일단 40*5로 고정했습니다.
* 로디드 다이스 데미지 증가량 수정
  * 제가 제시한 수식이 맞다면, 더블 럭키 다이스를 가지고 있는 모험가 해적도 동일하게 수정되어야 할 것입니다.