### PR TITLE
Priority fetching policy (Do not merge)

### DIFF
--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -47,6 +47,12 @@ class JobGenerator(ck.JobGenerator):
         MetalArmorTank = core.InformedCharacterModifier("메탈아머:탱크",crit=30)
         
         return [WeaponConstant, Mastery, MetalArmorTank]
+
+    def get_skill_priority(self):
+        return ['메이플 용사', '쓸만한 샤프 아이즈', '부스터', '로디드 다이스', '호밍 미사일(더미)',
+            '서포트 웨이버', '서포트 웨이버(버프)', '로봇 팩토리', '로봇 팩토리(버프)', '로봇 런처(:RM7)', '로봇 런처(:RM7)(버프)',
+            '멀티플 옵션(개틀링)', '윌 오브 리버티', '오버 드라이브', '오버 드라이브(페널티)', '디스토션 필드', '소울 컨트랙트',
+            '마이크로 미사일 컨테이너', '레지스탕스 라인 인팬트리', '봄버 타임', '메탈아머 전탄발사(시전)', '매시브 파이어']
         
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''

--- a/dpmModule/kernel/policy.py
+++ b/dpmModule/kernel/policy.py
@@ -214,7 +214,21 @@ class TypebaseFetchingPolicy(FetchingPolicy):
     def get_sorted(self):
         return [i for i in self.sorted]
     
+class PriorityFetchingPolicy(FetchingPolicy):
+    def __init__(self, priority_list):
+        super(PriorityFetchingPolicy, self).__init__()
+        self.priority_list = priority_list
 
+    def __call__(self, graph):
+        super(PriorityFetchingPolicy, self).__call__(graph)
+        self.sorted = []
+        ids = list(map(lambda x: x._id, self.target))
+        for skill_name in self.priority_list:
+            self.sorted += [self.target[ids.index(skill_name)]]
+        return self
+    
+    def get_sorted(self):
+        return [i for i in self.sorted]
 
 class AbstractRule():
     '''Rule defines given element will be aceepted or not. This concept is somewhat simmillar with Constraint,

--- a/dpmModule/util/dpmgenerator.py
+++ b/dpmModule/util/dpmgenerator.py
@@ -35,11 +35,7 @@ class IndividualDPMGenerator():
         v_builder = core.AlwaysMaximumVBuilder()
         graph = gen.package(target, v_builder, ulevel = ulevel, weaponstat = weaponstat, vEnhanceGenerateFlag = "njb_style")
         sche = policy.AdvancedGraphScheduler(graph,
-            policy.TypebaseFetchingPolicy(priority_list = [
-                core.BuffSkillWrapper,
-                core.SummonSkillWrapper,
-                core.DamageSkillWrapper
-            ]), 
+            policy.PriorityFetchingPolicy(priority_list = gen.get_skill_priority()), 
             [rules.UniquenessRule()] + gen.get_predefined_rules(rules.RuleSet.BASE)) #가져온 그래프를 토대로 스케줄러를 생성합니다.
         analytics = core.Analytics(printFlag=printFlag)  #데이터를 분석할 분석기를 생성합니다.
         if printFlag:


### PR DESCRIPTION
`TypeBaseFetchingPolicy`는 대체로 잘 동작하나, 소환수가 버프를 제공하는 경우, 소환수가 극딜인 경우, 여러 종류의 버프를 한번에 사용하는 경우 사용 순서가 꼬여 최적의 딜사이클이 나오지 않는 문제가 있습니다.

이를 해결하기 위해 `PriorityFetchingPolicy`를 간단하게 만들어 보았습니다. `JobGenerator`에 `get_skill_priority()`를 작성해두면 우선순위 목록을 읽어오고, 이후로는 `TypeBaseFetchingPolicy`와 비슷하게 동작합니다.

예시로 `mechanic.py`에 `get_skill_priority()`를 작성해 두었습니다. 여기서 의아했던 점은 `'서포트 웨이버(버프)` 등 설치기의 onAfter으로 걸려있는 버프도 일일이 명시해줘야만 버프 효과가 제대로 동작한다는 것이였습니다. `오버 드라이브(페널티)`도 마찬가지입니다. 그런데 `메탈아머 전탄발사(버프)`는 또 없어도 괜찮고... 이 부분은 확인 부탁드립니다.

적용하면 1800s 기준 약 2%정도의 딜 차이를 보입니다. 큰 차이는 아니지만 두가지 장점이 있습니다.

* 딜점유율이 더 정확하게 나옵니다.
  * 기존에는 호밍 미사일(봄버)(전탄)의 점유율이 지나치게 낮게 나왔습니다. 스킬 가동 순서가 꼬여서 봄버와 전탄 사이에 딜레이가 매우 길었습니다.
* 10초 딜을 측정할 때 더 정확합니다.
  * 가장 문제되던 부분이 맨 처음이였으므로, 10초딜에서는 확실한 차이를 보입니다.
  * 메카닉 기준 약 5.8%의 딜 차이가 납니다.