### PR TITLE
듀얼블레이드 스킬 수정

### DIFF
--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -113,7 +113,7 @@ class JobGenerator(ck.JobGenerator):
         HiddenBladeOpt = core.OptionalElement(HiddenBladeBuff.is_active, HiddenBlade)
         
         FlashBang.onAfter(FlashBangDebuff)
-        for sk in [FinalCut, PhantomBlow, SuddenRaid, FlashBang, AsuraTick, BladeStorm, BladeStormTick, BladeTornado, BladeTornadoSummon]:
+        for sk in [FinalCut, PhantomBlow, SuddenRaid, FlashBang, AsuraTick, BladeStorm, BladeStormTick, BladeTornado]:
             sk.onAfter(HiddenBladeOpt)
             
         for sk in [PhantomBlow, AsuraTick, BladeStormTick]:

--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -74,7 +74,7 @@ class JobGenerator(ck.JobGenerator):
         
         PhantomBlow = core.DamageSkill("팬텀 블로우", 540, 315, 6+1, modifier = core.CharacterModifier(armor_ignore = 44, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         SuddenRaid = core.DamageSkill("써든레이드", 900, 1150, 3, cooltime = 30000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)    #파컷의 남은 쿨타임 20% 감소
-        SuddenRaidDOT = core.DotSkill("써든레이드(도트)", 210/1.7, 10000).wrap(core.SummonSkillWrapper)
+        SuddenRaidDOT = core.DotSkill("써든레이드(도트)", 210, 10000).wrap(core.SummonSkillWrapper)
         
         FinalCut = core.DamageSkill("파이널 컷", 870, 2000, 1, cooltime = 90000).wrap(core.DamageSkillWrapper)
         FinalCutBuff = core.BuffSkill("파이널 컷(버프)", 0, 60000, rem = True, cooltime = -1, pdamage_indep = 40).wrap(core.BuffSkillWrapper)
@@ -83,11 +83,11 @@ class JobGenerator(ck.JobGenerator):
         
         FlashBang = core.DamageSkill("플래시 뱅", 600, 250, 1, cooltime = 60000).wrap(core.DamageSkillWrapper)  #임의 딜레이.
         FlashBangDebuff = core.BuffSkill("플래시 뱅(디버프)", 0, 50000/2, cooltime = -1, pdamage = 10 * 0.9).wrap(core.BuffSkillWrapper)
-        Venom = core.DotSkill("페이탈 베놈", 160*3/1.7, 8000).wrap(core.SummonSkillWrapper)
+        Venom = core.DotSkill("페이탈 베놈", 160*3, 8000).wrap(core.SummonSkillWrapper)
         
         # TODO: 버프 시전 딜레이 적용
         HiddenBladeBuff = core.BuffSkill("히든 블레이드(버프)", 0, 60000, cooltime = 90000, pdamage = 10).wrap(core.BuffSkillWrapper)
-        HiddenBlade = core.DamageSkill("히든 블레이드", 0, 140 / 1.7, 2).setV(vEhc, 5, 2, True).wrap(core.DamageSkillWrapper)    #미러 이미징에 의해 추가타 2개, 최종뎀 1.7배 무시
+        HiddenBlade = core.DamageSkill("히든 블레이드", 0, 140, 1.7).setV(vEhc, 5, 2, True).wrap(core.DamageSkillWrapper)
         
         Asura = core.DamageSkill("아수라", 0, 0, 0, cooltime = 60000).wrap(core.DamageSkillWrapper)
         AsuraTick = core.DamageSkill("아수라(틱)", 300, 420, 4, modifier =core.CharacterModifier(armor_ignore = 100)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)  #41타

--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -3,6 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import RuleSet, ConditionRule
 from . import globalSkill
 from .jobbranch import thieves
 #TODO : 5차 신스킬 적용
@@ -37,6 +38,14 @@ class JobGenerator(ck.JobGenerator):
         Mastery = core.InformedCharacterModifier("숙련도", pdamage_indep = -5)    #오더스 기본적용!   
         return [WeaponConstant, Mastery]
 
+    def get_ruleset(self):
+        def check_final_cut_time(final_cut):
+            return (final_cut.is_not_usable() and final_cut.is_cooltime_left(80*1000, 1)) # 파컷 직후 써레 1번만 쓰는게 더 효율적임
+
+        ruleset = RuleSet()
+        ruleset.add_rule(ConditionRule('써든레이드', '파이널 컷', check_final_cut_time), RuleSet.BASE)
+        return ruleset
+
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
         하이퍼 : 팬텀 블로우 - 리인포스, 이그노어 가드, 보너스 어택
@@ -63,12 +72,12 @@ class JobGenerator(ck.JobGenerator):
         
         DarkSight = core.BuffSkill("다크 사이트", 0, 1, cooltime = -1).wrap(core.BuffSkillWrapper)#, pdamage_indep = 20 + 10 + int(0.2*vEhc.getV(3,3))).wrap(core.BuffSkillWrapper)
         
-        PhantomBlow = core.DamageSkill("팬텀 블로우", 540, 315, 6+1, modifier = core.CharacterModifier(armor_ignore = 30+20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        PhantomBlow = core.DamageSkill("팬텀 블로우", 540, 315, 6+1, modifier = core.CharacterModifier(armor_ignore = 44, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         SuddenRaid = core.DamageSkill("써든레이드", 900, 1150, 3, cooltime = 30000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)    #파컷의 남은 쿨타임 20% 감소
         SuddenRaidDOT = core.DotSkill("써든레이드(도트)", 210/1.7, 10000).wrap(core.SummonSkillWrapper)
         
         FinalCut = core.DamageSkill("파이널 컷", 870, 2000, 1, cooltime = 90000).wrap(core.DamageSkillWrapper)
-        FinalCutBuff = core.BuffSkill("파이널 컷(버프)", 0, 60000, rem = True, pdamage_indep = 40).wrap(core.BuffSkillWrapper)
+        FinalCutBuff = core.BuffSkill("파이널 컷(버프)", 0, 60000, rem = True, cooltime = -1, pdamage_indep = 40).wrap(core.BuffSkillWrapper)
         
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
@@ -93,13 +102,13 @@ class JobGenerator(ck.JobGenerator):
         KarmaFury = core.DamageSkill("카르마 퓨리", 990, 750+30*vEhc.getV(1,1), 7 * 3, red = True, cooltime = 10000, modifier = core.CharacterModifier(armor_ignore = 30)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         BladeTornado = core.DamageSkill("블레이드 토네이도", 720, 600+24*vEhc.getV(2,2), 7, cooltime = 12000, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         #BladeTornadoFront = core.DamageSkill("블레이드 토네이도(전방)", 0, 600+24*vEhc.getV(2,2), 6, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)   #보통 1타
-        BladeTornadoSummon = core.SummonSkill("블레이드 토네이도(소환)", 0, 540, 450+18*vEhc.getV(2,2), 6, 3000, cooltime=-1, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.SummonSkillWrapper) #임의 딜레이, 미사용
+        BladeTornadoSummon = core.SummonSkill("블레이드 토네이도(소환)", 0, 3000/5, 450+18*vEhc.getV(2,2), 6, 3000-1, cooltime=-1, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.SummonSkillWrapper) #임의 딜레이, 미사용
         BladeTornadoSummonMirrorImaging = core.SummonSkill("블레이드 토네이도(소환)(미러이미징)", 0, 540, (450+18*vEhc.getV(2,2)) * 0.7, 6, 3000, cooltime=-1, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.SummonSkillWrapper) #임의 딜레이, 미사용
         
         ######   Skill Wrapper   ######
     
         SuddenRaid.onAfter(SuddenRaidDOT)
-        FinalCut.onAfter(FinalCutBuff)
+        FinalCut.onAfter(FinalCutBuff.controller(1))
         
         HiddenBladeOpt = core.OptionalElement(HiddenBladeBuff.is_active, HiddenBlade)
         

--- a/dpmModule/jobs/jobbranch/thieves.py
+++ b/dpmModule/jobs/jobbranch/thieves.py
@@ -20,5 +20,5 @@ def ReadyToDiePassiveWrapper(vEhc, num1, num2):
 def UltimateDarkSightWrapper(vEhc, num1, num2, aDS = 0):
     UltimateDarkSight = core.BuffSkill("얼티밋 다크 사이트", 750, 30000, 
                     cooltime = (220-vEhc.getV(num1, num2))*1000, 
-                    pdamage_indep= (10 + (vEhc.getV(num1, num2))//5) * (1+0.01*aDS) + aDS).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
+                    pdamage_indep= 10 + vEhc.getV(num1, num2)//5 + aDS).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     return UltimateDarkSight


### PR DESCRIPTION
https://github.com/oleneyl/maplestory_dpm_calc/issues/104

* 블토 1+6타 -> 1+5타
* 파컷 버프가 노쿨로 직접 발동되던것 수정
* 파컷 버프에 벞지 적용 안되는 현상 수정
* 팬블 하이퍼 방무 합연산 -> 곱연산
* 파컷 이후 써레 1번만 사용