### PR TITLE
팬텀 스킬 수정

### DIFF
--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -114,7 +114,7 @@ class JobGenerator(ck.JobGenerator):
         
         CardStack = core.StackSkillWrapper(core.BuffSkill("카드 스택", 0, 99999999), 40, name = "느와르 카르트 스택")
         
-        AddCard = CardStack.stackController(min(chtr.get_modifier().crit/100,1), name = "스택 1 증가")
+        AddCard = CardStack.stackController(1, name = "스택 1 증가")
         Judgement = CarteNoir_
         Judgement.onAfter(CardStack.stackController(-9999, name = "스택 초기화"))
         


### PR DESCRIPTION
https://github.com/oleneyl/maplestory_dpm_calc/issues/116

* 조커에 느와르 사출되게 함
* 템오카 안쓰는게 더 세서 딜사이클에서 뺌
* 조커 버프 최종뎀 증가량 정확하게
* 파컷 벞지 적용되게 임시조치
* 느와르 타수 0.9로 적용되던것 수정
* 엔버링크가 마오팬 쿨을 기다리도록 딜사이클 최적화