### PR TITLE
링크 스킬 직업별로 다르게 적용 (Draft)

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -122,10 +122,10 @@ class JobGenerator():
     .vEnhanceNum : 5차 강화 스킬의 총 개수입니다.
     .vSkillNum : 5차 스킬의 총 개수입니다.
     
-    from . import globalSkill
+    from . import globalSkill, linkSkill
     self.preEmptiveSkills = 2
     globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster()
-    globalSkill.soul_contract()
+    linkSkill.soul_contract()
     
     미하일까지..
     '''
@@ -497,50 +497,6 @@ class Union():
         return (MDF(att = state[0]) + MDF(stat_main = 5 * state[1]) + \
                             MDF(boss_pdamage = state[2]) + MDF(armor_ignore = state[3]) + \
                             MDF(crit = state[4]) + MDF(crit_damage = state[5] * 0.5))
-        
-        
-class LinkSkill():
-    Mercedes = CharacterModifier()    #Exp
-    DemonSlayer = CharacterModifier(pdamage = 15)
-    DemonAvenger = CharacterModifier(pdamage = 10)
-    Luminous = CharacterModifier(armor_ignore = 15)
-    Phantom = CharacterModifier(crit = 15)
-    Zenon = CharacterModifier(pstat_main = 10, pstat_sub = 10)
-    Ark = CharacterModifier(pdamage = 11)
-    Ilium = CharacterModifier(pdamage = 12)
-    Cadena = CharacterModifier(pdamage = 6) #optional
-    Angelicbuster = CharacterModifier()   #Skill
-    Aran = CharacterModifier()    #Exp
-    Evan = CharacterModifier()    #Exp
-    Canonshooter = CharacterModifier(stat_main = 70, stat_sub = 70)
-    Enwool = CharacterModifier() #Util
-    Zero = CharacterModifier(armor_ignore = 10)
-    Kinesis = CharacterModifier(crit_damage = 4)
-    Michael = CharacterModifier() #Util skill
-    Kaiser = CharacterModifier() #HP
-    Cygnus = CharacterModifier() #Util
-    Registance = CharacterModifier()  #Util
-    AdventureMage = CharacterModifier(pdamage=9, armor_ignore=9)
-    AdventureArcher = CharacterModifier(crit=10)
-    AdventureRog = CharacterModifier(pdamage=18/2)
-
-    
-    '''Full Package
-    DS, DA, Luminous, Phantom, Zenon, Ark, 
-    Ilium, Cadena, Zero, Kinesis, (Angelicbuster), (Registance)
-    '''
-    # FullPackage = CharacterModifier(pdamage = 54, armor_ignore = 23.5, crit = 15, pstat_main = 10, pstat_sub = 10, crit_damage = 4)
-    # FullPackageExceptCadena = CharacterModifier(pdamage = 54 - 6, armor_ignore = 23.5, crit = 15, pstat_main = 10, pstat_sub = 10, crit_damage = 4)
-    @staticmethod
-    def get_full_link(cadena = False):
-        FullPackage = LinkSkill.AdventureMage + LinkSkill.AdventureRog + LinkSkill.Luminous + LinkSkill.Phantom + LinkSkill.DemonSlayer + LinkSkill.DemonAvenger + \
-            LinkSkill.Zenon + LinkSkill.Cadena + LinkSkill.Angelicbuster + LinkSkill.Zero + LinkSkill.Kinesis + LinkSkill.Ark
-    
-        FullPackageExceptCadena = FullPackage - LinkSkill.Cadena
-        if cadena :
-            return FullPackage.copy()
-        else:
-            return FullPackageExceptCadena.copy()
 
 class Card():
     '''

--- a/dpmModule/character/characterTemplate.py
+++ b/dpmModule/character/characterTemplate.py
@@ -1,5 +1,4 @@
 from .characterKernel import ItemedCharacter as ichar
-from .characterKernel import LinkSkill
 from ..item import Arcane, Absolab, Empress, RootAbyss, BossAccesory, Default, Else, Meister, Darkness
 from ..item.ItemKernel import CharacterModifier as MDF
 from ..item import ItemKernel as it

--- a/dpmModule/character/characterTemplateHigh.py
+++ b/dpmModule/character/characterTemplateHigh.py
@@ -1,5 +1,4 @@
 from .characterKernel import ItemedCharacter as ichar
-from .characterKernel import LinkSkill
 from .characterTemplate import AbstractTemplateGenerator, register_template_generator
 from ..item import Arcane, Absolab, Empress, RootAbyss, BossAccesory, Default, Else, Meister, Darkness
 from ..item.ItemKernel import CharacterModifier as MDF
@@ -60,9 +59,8 @@ def getUnionCharacter(_type, armor_pstat_ptnl = 6, acc_pstat_ptnl = 9, weaponSta
 
     #Temporal union object..
     unionModifier = MDF(att = 5, pdamage = 21, armor_ignore = 21, stat_main = 5)
-    link = LinkSkill.get_full_link()
     
-    template = ichar(modifierlist = [unionModifier, link])
+    template = ichar(modifierlist = [unionModifier])
 
     template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar))
     template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar))
@@ -110,9 +108,8 @@ def getU6000Character(_type, armor_pstat_ptnl = 15, acc_pstat_ptnl = 15, weaponS
     #Temporal union object..
     unionModifier = MDF(att = 5, pdamage = 21, armor_ignore = 21, stat_main = 5, crit_damage = 24)
     
-    link = LinkSkill.get_full_link()
     
-    template = ichar(modifierlist = [unionModifier, link])
+    template = ichar(modifierlist = [unionModifier])
 
     template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar))
     template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar))
@@ -155,9 +152,8 @@ def getDpmStdCharacterTemplate(_type, armor_pstat_ptnl = 15, acc_pstat_ptnl = 15
     etcAddPtnl = MDF(att = 10)
 
     #Temporal union object..
-    link = LinkSkill.get_full_link()
     
-    template = ichar(modifierlist = [link], level = 240)
+    template = ichar(modifierlist = [], level = 240)
 
     template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, additional_potential = etcAddPtnl, bonus = accBonus, star = accStar, enhance = 30))
     template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = etcAddPtnl, bonus = armorBonus, star = armorStar, enhance = 30))
@@ -207,9 +203,8 @@ def getEpicDpmStdCharacterTemplate(_type, armor_pstat_ptnl = 9, acc_pstat_ptnl =
     etcAddPtnl = MDF(att = 10)
 
     #Temporal union object..
-    link = LinkSkill.get_full_link()
     
-    template = ichar(modifierlist = [link], level = 230)
+    template = ichar(modifierlist = [], level = 230)
 
     template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, additional_potential = etcAddPtnl, bonus = accBonus, star = accStar))
     template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = etcAddPtnl, bonus = armorBonus, star = armorStar))
@@ -247,8 +242,7 @@ def getU4000CharacterTemplate(_type):
     카루타 + 여제 + 보장
     '''
     #Temporal union object..
-    link = LinkSkill.get_full_link()
-    template = ichar(modifierlist = [link], level = 215)
+    template = ichar(modifierlist = [], level = 215)
     
     template.add_summary("에디셔널 잠재능력: 없음")
 
@@ -302,8 +296,7 @@ def getU4000CharacterTemplate(_type):
 
 def getU5000CharacterTemplate(_type):
     #Temporal union object..
-    link = LinkSkill.get_full_link()
-    template = ichar(modifierlist = [link], level = 230)
+    template = ichar(modifierlist = [], level = 230)
 
     weaponAPtnl = MDF(att = 3)
     subAPtnl = MDF()
@@ -357,8 +350,7 @@ def getU5000CharacterTemplate(_type):
 
 def getU6000CharacterTemplate(_type):
     #Temporal union object..
-    link = LinkSkill.get_full_link()
-    template = ichar(modifierlist = [link], level = 240)
+    template = ichar(modifierlist = [], level = 240)
     
     template.add_summary("에디: 공10, 무기류 공6%")
 
@@ -418,8 +410,7 @@ def getU6000CharacterTemplate(_type):
 
 def getU7000CharacterTemplate(_type):
     #Temporal union object..
-    link = LinkSkill.get_full_link()
-    template = ichar(modifierlist = [link], level = 250)
+    template = ichar(modifierlist = [], level = 250)
     
     template.add_summary("에디: 2줄, 무기류 공21%")
 
@@ -502,8 +493,7 @@ def getU7000CharacterTemplate(_type):
 
 def getU8000CharacterTemplate(_type):
     #Temporal union object..
-    link = LinkSkill.get_full_link()
-    template = ichar(modifierlist = [link], level = 255)
+    template = ichar(modifierlist = [], level = 255)
     
     template.add_summary("에디: 2.5줄, 무기류 공15%")
 
@@ -589,8 +579,7 @@ def getU8000CharacterTemplate(_type):
     
 def getU8500CharacterTemplate(_type):
     #Temporal union object..
-    link = LinkSkill.get_full_link()
-    template = ichar(modifierlist = [link], level = 260)
+    template = ichar(modifierlist = [], level = 260)
     
     template.add_summary("에디: 레전 3줄, 무기류 공24%")
 

--- a/dpmModule/character/characterTemplateLow.py
+++ b/dpmModule/character/characterTemplateLow.py
@@ -1,5 +1,4 @@
 from .characterKernel import ItemedCharacter as ichar
-from .characterKernel import LinkSkill
 from ..item import Arcane, Absolab, Empress, RootAbyss, BossAccesory, Default, Else
 from ..item.ItemKernel import CharacterModifier as MDF
 # Define UnionCharacter : Character that is oftenly used for union.

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -32,8 +32,6 @@ class JobGenerator(ck.JobGenerator):
         
         MagicCircuit = core.InformedCharacterModifier("매직 서킷", att=WEAPON_ATT * 0.15)  #무기 마력의 25%, 최대치 가정.
         Pace = core.InformedCharacterModifier("패이스", crit_damage=10, patt=10)
-        # Link skill : ignored
-        # Nobless = core.InformedCharacterModifier("노블레스", boss_pdamage=4)
         Rudiment = core.InformedCharacterModifier("루디먼트", att=30)
         Mastery = core.InformedCharacterModifier("마스터리", att=30)
         Train = core.InformedCharacterModifier("트레인", stat_main=60)
@@ -42,7 +40,15 @@ class JobGenerator(ck.JobGenerator):
         Demolition = core.InformedCharacterModifier("데몰리션", pdamage_indep=30, armor_ignore=20)
         Attain = core.InformedCharacterModifier("어테인", att=30, boss_pdamage=10, crit=20)
 
-        return [MagicCircuit, Pace, Rudiment, Mastery, Train, Accent, Expert, Demolition, Attain]
+        # 링크스킬
+        LinkSkills = [
+            linkSkill.nobless(), linkSkill.spirit_of_freedom(),
+            linkSkill.deadly_instinct(), linkSkill.judgement(),
+            linkSkill.permeate(), linkSkill.rhinne_protection(),
+            linkSkill.empirical_knowledge(), linkSkill.wild_rage(), linkSkill.solus(), linkSkill.demons_fury(), linkSkill.thief_kerning(), linkSkill.intensive_insult()
+        ]
+
+        return [MagicCircuit, Pace, Rudiment, Mastery, Train, Accent, Expert, Demolition, Attain] + LinkSkills
 
     def get_not_implied_skill_list(self):
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 34)
@@ -71,6 +77,9 @@ class JobGenerator(ck.JobGenerator):
         디바이드 - 오더(그레이브) - 테리토리(트레드) - 블로섬(스콜) - 임페일(레조넌스/마커) - 크리에이션(게더링) - 샤드 - 레조넌스
         인피니트 - 리스토어 - 루인 - 매서풀 - 오라웨폰 - (바오스)
 
+        링크 스킬
+
+        아델(기본) / 레지 / 팬텀 / 키네 / 루미, 제로 / 데벤, 아크, 데슬, 모도, 카데나 / 제논 / 엔버
         '''
         GATHERING_HIT = 5
         BLOSSOM_HIT = 3

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule, InactiveRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 from .jobclass import cygnus
 from .jobclass import flora
@@ -147,7 +147,7 @@ class JobGenerator(ck.JobGenerator):
         return(Divide,
                 [globalSkill.maple_heros(chtr.level), ResonanceStack, GraveDebuff, WraithOfGod, Restore,
                     AuraWeaponBuff, AuraWeaponCooltimeDummy, MagicCircuitFullDrive, 
-                    globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()] +\
+                    globalSkill.useful_sharp_eyes(), linkSkill.soul_contract()] +\
                 [Resonance, Grave, Blossom, Marker, Ruin] +\
                 [Order, Shard, Territory, Infinite, RuinFirstTick, RuinSecondTick, RestoreTick, OrderRestore, Creation] +\
                 [] +\

--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import pirates
 from . import jobutils
 

--- a/dpmModule/jobs/aran.py
+++ b/dpmModule/jobs/aran.py
@@ -7,7 +7,7 @@ from ..kernel.graph import DynamicVariableOperation
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import heroes
 from .jobbranch import warriors
 from ..execution.rules import RuleSet, InactiveRule, ConditionRule
@@ -232,7 +232,7 @@ class JobGenerator(ck.JobGenerator):
                     BlessingMaha, AdrenalineBoost, AdrenalineBoostEndDummy,
                     AdrenalineGenerator, 
                     Frid, InstallMaha, Combo, AuraWeaponCooltimeDummy, AuraWeaponBuff,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [SmashSwingHolder, BrandishMaha, BoostEndHuntersTargeting] +\
                 [MahaRegion] +\
                 [BasicAttack])

--- a/dpmModule/jobs/archmageFb.py
+++ b/dpmModule/jobs/archmageFb.py
@@ -39,9 +39,18 @@ class JobGenerator(ck.JobGenerator):
         
         MasterMagic = core.InformedCharacterModifier("마스터 매직", att = 30)
         ArcaneAim = core.InformedCharacterModifier("아케인 에임", armor_ignore = 20)
+
+        # 링크스킬
+        LinkSkills = [
+            linkSkill.empirical_knowledge(), linkSkill.spirit_of_freedom(),
+            linkSkill.deadly_instinct(), linkSkill.judgement(),
+            linkSkill.permeate(), 
+            linkSkill.wild_rage(), linkSkill.solus(), linkSkill.demons_fury(), linkSkill.thief_kerning(), linkSkill.intensive_insult(),
+            linkSkill.hybrid_logic()
+        ]
         
         return [HighWisdom, SpellMastery, MagicCritical, ElementalReset, 
-                                    MasterMagic, ElementAmplication, ArcaneAim]
+                                    MasterMagic, ElementAmplication, ArcaneAim] + LinkSkills
 
     def get_not_implied_skill_list(self):
         WeaponConstant = core.InformedCharacterModifier("무기상수", pdamage_indep = 20)
@@ -65,10 +74,15 @@ class JobGenerator(ck.JobGenerator):
         언스테이블 메모라이즈를 사용하지 않음
         
         극딜형 스킬은 쿨마다 사용함
+
+        링크 스킬
+
+        모법(기본) / 미하일, 레지 / 팬텀 / 키네 / 루미 / 데벤, 아크, 데슬, 모도, 카데나 / 제논 / 엔버
         
         '''
         #Buff skills
         Meditation = core.BuffSkill("메디테이션", 0, 240000, att = 30, rem = True, red = True).wrap(core.BuffSkillWrapper)
+        KnightsWatch = linkSkill.knights_watch()
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         OverloadMana = magicians.OverloadManaWrapper(vEhc, 1, 5)
         
@@ -126,7 +140,7 @@ class JobGenerator(ck.JobGenerator):
         #SoulContract.set_disabled_and_time_left(30000)       
 
         return (Paralyze, 
-                [Infinity, Meditation, EpicAdventure, OverloadMana.ensure(vEhc,1,5),
+                [Infinity, Meditation, KnightsWatch, EpicAdventure, OverloadMana.ensure(vEhc,1,5),
                 globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                 SoulContract] +\
                 [DotPunisher.ensure(vEhc,0,0), Meteor, MegidoFlame, FlameHeize, PoisonNova.ensure(vEhc,2,1)] +\

--- a/dpmModule/jobs/archmageFb.py
+++ b/dpmModule/jobs/archmageFb.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, SynchronizeRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import adventurer
 from .jobbranch import magicians
 #TODO : 도트데미지 적용 / 포이즌노바 / 퓨리오브 이프리트
@@ -122,7 +122,7 @@ class JobGenerator(ck.JobGenerator):
         PoisonNova.onAfter(PoisonNovaDOT.controller(1))
 
         # 극딜기 싱크로
-        SoulContract = globalSkill.soul_contract()
+        SoulContract = linkSkill.soul_contract()
         #SoulContract.set_disabled_and_time_left(30000)       
 
         return (Paralyze, 

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, SynchronizeRule, ConcurrentRunRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import adventurer
 from .jobbranch import magicians
 
@@ -196,7 +196,7 @@ class JobGenerator(ck.JobGenerator):
         Elquiness.onTick(BlizzardPassive)
         IceAura.onTick(FrostIncrement)
         
-        SoulContract = globalSkill.soul_contract()
+        SoulContract = linkSkill.soul_contract()
 
         return(ChainLightening,
                 [Infinity, Meditation, EpicAdventure, OverloadMana, FrostEffect,

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, MutualRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import pirates
 from . import jobutils
 

--- a/dpmModule/jobs/battlemage.py
+++ b/dpmModule/jobs/battlemage.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import resistance
 from .jobbranch import magicians
 # TODO: 오버로드 마나를 정말 안쓰는 것인지 확인필요
@@ -138,7 +138,7 @@ class JobGenerator(ck.JobGenerator):
         return(FinishBlowEndpoint,
                 [Booster, WillOfLiberty, MasterOfDeath, UnionAura,
                 globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), #globalSkill.useful_wind_booster(),
-                globalSkill.soul_contract()] +\
+                linkSkill.soul_contract()] +\
                 [DarkGenesis, BattlekingBar] +\
                 [RegistanceLineInfantry, Death, DeathAfterMOD, BlackMagicAlter, GrimReaper] +\
                 [] +\

--- a/dpmModule/jobs/bishop.py
+++ b/dpmModule/jobs/bishop.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, SynchronizeRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from functools import partial
 from .jobclass import adventurer
 from .jobbranch import magicians
@@ -155,7 +155,7 @@ class JobGenerator(ck.JobGenerator):
         MainAttackWrapped = core.DamageSkill('기본공격',0,0,0).wrap(core.DamageSkillWrapper)
         MainAttackWrapped.onAfter(MainAttack)
 
-        SoulContract = globalSkill.soul_contract()
+        SoulContract = linkSkill.soul_contract()
         
         return(MainAttackWrapped, 
                 [Booster, SacredMark, Infinity, PeaceMakerFinalBuff, Pray, EpicAdventure, OverloadMana,

--- a/dpmModule/jobs/blaster.py
+++ b/dpmModule/jobs/blaster.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, InactiveRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 from .jobclass import resistance
 #TODO : 5차 신스킬 적용
@@ -147,7 +147,7 @@ class JobGenerator(ck.JobGenerator):
         return(Mag_Pang,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
                     Booster, MaximizeCannon, WillOfLiberty, AuraWeaponBuff, BunkerBuster,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [ReleaseHammer, BurningBreaker] +\
                 [RegistanceLineInfantry, HammerSmashWave] +\
                 [AuraWeaponCooltimeDummy] +\

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import bowmen
 
 #TODO : 5차 신스킬 적용
@@ -113,7 +113,7 @@ class JobGenerator(ck.JobGenerator):
         return(ArrowOfStorm,
                 [globalSkill.maple_heros(chtr.level),
                     SoulArrow, AdvancedQuibber, Preparation, EpicAdventure, ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff, 
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [] +\
                 [Evolve, ArrowFlatter, ArrowRain, Pheonix, GuidedArrow, QuibberFullBurst, ImageArrow] +\
                 [] +\

--- a/dpmModule/jobs/cadena.py
+++ b/dpmModule/jobs/cadena.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import thieves
 
 #TODO : 5차 신스킬 적용
@@ -285,7 +285,7 @@ class JobGenerator(ck.JobGenerator):
                     WeaponVarietyAttack, Booster, SpecialPotion, ProfessionalAgent,
                     ReadyToDie, ChainArts_Fury, 
                     SummonSlachingKnife_Horror, SummonBeatingNeedlebat_Honmy, VenomBurst_Poison, ChainArts_maelstorm_slow,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [AD_Odnunce_Final,
                     WingDaggerBatCombo, BommBrickCombo, ShootgunClawCombo, SimiterChaseCombo, KnifeCombo] +\
                 [SummonThrowingWingdaggerInit, VenomBurst, AD_Odnunce, ChainArts_maelstorm] +\

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
 from . import jobutils
@@ -110,7 +110,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Booster, MonkeyWaveBuff, MonkeyFuriousBuff, OakRulet, MonkeyMagic,
                     EpicAdventure, LuckyDice, Overdrive, OverdrivePenalty, PirateFlag,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [MonkeyWave, MonkeyFurious, ICBM] +\
                 [OakRuletDOT, SupportMonkeyTwins, RollingCanonRainbow, BFGCannonball, ICBMDOT, SpecialMonkeyEscort_Boom, SpecialMonkeyEscort_Canon] +\
                 [] +\

--- a/dpmModule/jobs/captain.py
+++ b/dpmModule/jobs/captain.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
 from . import jobutils
@@ -161,7 +161,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     SummonCrewBuff, PirateStyle, Booster, InfiniteBullet, LuckyDice, UnwierdingNectar, EpicAdventure, PirateFlag, Overdrive, OverdrivePenalty,
                     BattleshipBomber_1_ON, BattleshipBomber_2_ON, QuickDraw,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [BattleshipBomber, Headshot, Nautilus, DeadEye] +\
                 [OctaQuaterdeck, BattleshipBomber_1, BattleshipBomber_2, NautillusAssult, NautillusAssult_2, SummonCrew] +\
                 [BulletParty] +\

--- a/dpmModule/jobs/darknight.py
+++ b/dpmModule/jobs/darknight.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 
 #TODO : 5차 신스킬 적용
@@ -109,7 +109,7 @@ class JobGenerator(ck.JobGenerator):
         return(BasicAttackWrapped, 
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Booster, CrossoverChain, Sacrifice, Reincarnation,EpicAdventure, DarkThurst, AuraWeaponBuff,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [BiholderShock, GoungnilDescent, DarkSpear, PierceCyclone] +\
                 [BiholderDominant, BiholderImpact] +\
                 [AuraWeaponCooltimeDummy] +\

--- a/dpmModule/jobs/demonavenger.py
+++ b/dpmModule/jobs/demonavenger.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 from .jobclass import demon
 
@@ -155,7 +155,7 @@ class JobGenerator(ck.JobGenerator):
         return(BasicAttackWrapper,
                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Booster, DevilCryBuff, InfinityForce, Metamorphosis, BlueBlood, DemonFortitude, AuraWeaponBuff, DemonAwakning,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [Execution, Cerberus, DevilCry, SpiritOfRageEnd] +\
                 [MetamorphosisSummon, CallMastema, DemonAwakningSummon, SpiritOfRage, Orthros, Orthros_] +\
                 [AuraWeaponCooltimeDummy] +\

--- a/dpmModule/jobs/demonslayer.py
+++ b/dpmModule/jobs/demonslayer.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 ######   Passive Skill   ######
 
@@ -136,7 +136,7 @@ class JobGenerator(ck.JobGenerator):
         return(BasicAttackWrapper,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Booster, DevilCryBuff, InfinityForce, Metamorphosis, BlueBlood, DemonFortitude, AuraWeaponBuff, DemonAwakning,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [Cerberus, DevilCry, SpiritOfRageEnd] +\
                 [MetamorphosisSummon, CallMastema, DemonAwakningSummon, SpiritOfRage, Orthros, Orthros_] +\
                 [AuraWeaponCooltimeDummy] +\

--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConditionRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import thieves
 #TODO : 5차 신스킬 적용
 
@@ -134,7 +134,7 @@ class JobGenerator(ck.JobGenerator):
         return(PhantomBlow,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Booster, DarkSight, FinalCutBuff, EpicAdventure, FlashBangDebuff, HiddenBladeBuff, UltimateDarksight, ReadyToDie,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [FinalCut, FlashBang, BladeTornado, SuddenRaid, KarmaFury, BladeStorm, Asura] +\
                 [SuddenRaidDOT, Venom, BladeTornadoSummon, BladeTornadoSummonMirrorImaging] +\
                 [] +\

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import heroes
 from .jobbranch import pirates
 from . import jobutils
@@ -154,7 +154,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     EnhanceSpiritLinkSummon_J_Buff, EnhanceSpiritLink, LuckyDice, HerosOath, Frid, 
                     Overdrive, OverdrivePenalty, SoulConcentrate, DoubleBody, SoulTrapBuff,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [] +\
                 [EnhanceSpiritLinkSummon_S, EnhanceSpiritLinkSummon_J_Init, EnhanceSpiritLinkSummon_J, SoulTrap, SoulConcentrateSummon] +\
                 [RealSoulAttackCounter, DoubleBodyRegistance] +\

--- a/dpmModule/jobs/evan.py
+++ b/dpmModule/jobs/evan.py
@@ -4,7 +4,7 @@ from ..kernel.core import CharacterModifier as MDF
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import heroes
 
 # TODO : 조디악 커맨드 수정
@@ -214,7 +214,7 @@ class JobGenerator(ck.JobGenerator):
         return(CircleOfMana,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     OverloadMana, Booster, OnixBless, Frid, HerosOath, SwiftBack, ElementalBlastBuff,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [ZodiakRayInit, DragonBreak, MagicParticle] +\
                 [BreathBack, SummonOnixDragon, ZodiakRay, ImperialBreath, SwiftOfThunder, DiveOfEarth, BreathOfWind, BreathOfWindZodiak] +\
                 [MirBuff] +\

--- a/dpmModule/jobs/flamewizard.py
+++ b/dpmModule/jobs/flamewizard.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import cygnus
 from .jobbranch import magicians
 
@@ -105,7 +105,7 @@ class JobGenerator(ck.JobGenerator):
         return (OrbitalFlame,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     WordOfFire, FiresOfCreation, BurningRegion, GloryOfGuardians, OverloadMana,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [CygnusPalanks, BlazingOrbital, DragonSlaveInit, SavageFlame, InfinityFlameCircleInit, 
                     InfernoRize] +\
                 [IgnitionDOT] +\

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -17,11 +17,6 @@ def useful_hyper_body_zenon(slevel = 1):
     UsefulHyperBody = core.BuffSkill("쓸만한 하이퍼 바디", 600, (180 + slevel * 3)*1000, stat_main = passiveStat(slevel), stat_sub = passiveStat(slevel), rem = False).wrap(core.BuffSkillWrapper)
     return UsefulHyperBody
 
-# 기본 90초, 직업별 딜사이클에 따라 쿨타임 조절가능
-def soul_contract(Cool = 90*1000):
-    SoulContract = core.BuffSkill("소울 컨트랙트", 900, 10*1000, cooltime = Cool, pdamage = 45, rem = True, red = True).wrap(core.BuffSkillWrapper)
-    return SoulContract
-
 # 쓸컴뱃 = 1, 팔라딘 = 2
 def maple_heros(level, combat_level = 0):
     MapleHeros = core.BuffSkill("메이플 용사", 0, (900+15*combat_level)*1000, stat_main = (0.15 + 0.005 * combat_level)*(25 + level * 5), rem = True).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/hero.py
+++ b/dpmModule/jobs/hero.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, InactiveRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 
 #TODO : 5차 신스킬 적용
@@ -151,7 +151,7 @@ class JobGenerator(ck.JobGenerator):
                     ComboAttack, Fury, EpicAdventure, Valhalla, 
                     InsizingBuff, AuraWeaponBuff, ComboDesfortBuff, 
                     ComboInstinct, ComboInstinctOff, PanicBuff,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [Panic, Insizing, ComboDesfort] +\
                 [SwordOfBurningSoul] +\
                 [AuraWeaponCooltimeDummy] +\

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import magicians
 from . import jobutils
 
@@ -213,7 +213,7 @@ class JobGenerator(ck.JobGenerator):
                     Booster, FastCharge, WraithOfGod, MagicCircuitFullDrive, SoulOfCrystal,
                     Craft_Javelin_EnhanceBuff, CrystalCharge, GloryWingUse,
                     OverloadMana, BlessMark, CurseMark,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [CrystalSkill_MortalSwing, GloryWing_MortalWingbit, CrystalIgnitionInit] +\
                 [Riyo, Machina, CrystalSkill_Deus, 
                     GramHolder, MagicCircuitFullDriveStorm, Reaction_Spectrum, SoulOfCrystal_Reaction_Spectrum] +\

--- a/dpmModule/jobs/kaiser.py
+++ b/dpmModule/jobs/kaiser.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 
 #Combo Instinct - generated sub deal
@@ -193,7 +193,7 @@ class JobGenerator(ck.JobGenerator):
         return(BasicAttackWrapper,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     RegainStrenth, BlazeUp, FinalFiguration, MajestyOfKaiser, FinalTrance, AuraWeaponBuff, AuraWeaponCooltimeDummy,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [AdvancedWillOfSword] +\
                 [Wingbit_1, Wingbit_2, GuardianOfNova_1, GuardianOfNova_2, GuardianOfNova_3] +\
                 [WillOfSwordStrikeJudge, DrakeSlasher_Dummy] +\

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -8,7 +8,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import magicians
 
 class JobGenerator(ck.JobGenerator):
@@ -191,7 +191,7 @@ class JobGenerator(ck.JobGenerator):
                     Booster, PsychicShield, PsychicGround, 
                     PsycoBreak, UltimatePsychicBuff, PsychicCharging, 
                     PsychicOver, OverloadMana, PsychicPoint,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [EverPsychic, UltimatePsychic] +\
                 [PsychicDrain, PsychicForce3, UltimateBPM, PsychicOverSummon, PsychicTornado, UltimateMovingMatter, UltimatePsychicBulletBlackhole] +\
                 [UltimateTrain] +\

--- a/dpmModule/jobs/linkSkill.py
+++ b/dpmModule/jobs/linkSkill.py
@@ -1,0 +1,101 @@
+from ..kernel import core
+
+# 모법
+def empirical_knowledge():
+    EmpiricalKnowledge = core.InformedCharacterModifier("임피리컬 널리지", pdamage=9, armor_ignore=9)
+    return EmpiricalKnowledge
+    
+# 모궁
+def adventurer_curious():
+    AdventurerCurious = core.InformedCharacterModifier("어드벤처러 큐리어스", crit=10)
+    return AdventurerCurious
+
+# 모도
+def thief_kerning():
+    ThiefKerning = core.InformedCharacterModifier("시프 커닝", pdamage=18/2)
+    return ThiefKerning
+
+# 시그
+def cygnus_bless():
+    CygnusBless = core.InformedCharacterModifier("시그너스 블레스", att=25)
+    return CygnusBless
+    
+# 미하일
+def knights_watch():
+    KnightsWatch = core.BuffSkill("빛의 수호", 900, 110 * 1000, cooltime = 180 * 1000, rem = True, red = True).wrap(core.BuffSkillWrapper)
+    return KnightsWatch
+
+# 레지
+def spirit_of_freedom():
+    SpiritOfFreedom = core.InformedCharacterModifier("스피릿 오브 프리덤")
+    return SpiritOfFreedom
+
+# 제논
+def hybrid_logic():
+    HybridLogic = core.InformedCharacterModifier("하이브리드 로직", pstat_main=10, pstat_sub=10)
+    return HybridLogic
+
+# 데슬
+def demons_fury():
+    DemonsFury = core.InformedCharacterModifier("데몬스 퓨리", boss_pdamage=15)
+    return DemonsFury
+
+# 데벤
+def wild_rage():
+    WildRage = core.InformedCharacterModifier("와일드 레이지", pdamage=10)
+    return WildRage
+
+# 루미
+def permeate():
+    Permeate = core.InformedCharacterModifier("퍼미에이트", armor_ignore=15)
+    return Permeate
+
+# 팬텀
+def deadly_instinct():
+    DeadlyInstinct = core.InformedCharacterModifier("데들리 인스팅트", crit=15)
+    return DeadlyInstinct
+
+# 카이저
+def iron_will(): # 데벤만 사용할것!!
+    IronWill = core.InformedCharacterModifier("아이언 윌", pstat_main=15)
+    return IronWill
+
+# 카데나
+def intensive_insult():
+    IntensiveInsult = core.InformedCharacterModifier("인텐시브 인썰트", pdamage=12)
+    return IntensiveInsult
+
+# 엔버, 기본 90초, 직업별 딜사이클에 따라 쿨타임 조절가능
+def soul_contract(Cool = 90*1000):
+    SoulContract = core.BuffSkill("소울 컨트랙트", 900, 10*1000, cooltime = Cool, pdamage = 45, rem = True, red = True).wrap(core.BuffSkillWrapper)
+    return SoulContract
+
+# 아델
+def nobless(party_count = 1):
+    Nobless = core.InformedCharacterModifier("노블레스", pdamage=min(8, party_count * 2), boss_pdamage=4)
+    return Nobless
+
+# 일리움
+def tide_of_battle():
+    TideOfBattle = core.InformedCharacterModifier("전투의 흐름", pdamage=12)
+    return TideOfBattle
+
+# 아크
+def solus():
+    Solus = core.InformedCharacterModifier("무아", pdamage=11)
+    return Solus
+
+# 제로
+def rhinne_protection():
+    RhinneProtection = core.InformedCharacterModifier("륀느의 가호", armor_ignore=10)
+    return RhinneProtection
+
+# 키네
+def judgement():
+    Judgement = core.InformedCharacterModifier("판단", crit_damage=4)
+    return Judgement
+
+# 호영
+def bravado():
+    Bravado = core.InformedCharacterModifier("자신감", armor_ignore=10)
+    return Bravado

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import heroes
 from .jobbranch import magicians
 '''아포 22회
@@ -197,7 +197,7 @@ class JobGenerator(ck.JobGenerator):
         
         Memorize.onConstraint(core.ConstraintElement('이퀄일때는 사용하지 않음', LuminousState, LuminousState.isNotEqual ) ) 
 
-        SoulContract = globalSkill.soul_contract()
+        SoulContract = linkSkill.soul_contract()
 
         return(Attack, 
                 [LuminousState, globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -7,7 +7,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule, ReservationRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import resistance
 from .jobbranch import pirates
 from . import jobutils
@@ -149,7 +149,7 @@ class JobGenerator(ck.JobGenerator):
         return(MassiveFire,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Booster, WillOfLiberty, LuckyDice, SupportWaverBuff, RobolauncherBuff, RoboFactoryBuff, BomberTime, Overdrive, OverdrivePenalty,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [MicroMissle, BusterCallInit] +\
                 [HommingMissleHolder, RegistanceLineInfantry, SupportWaver, Robolauncher, RoboFactory, DistortionField, MultipleOptionGattling, MultipleOptionMissle] +\
                 [BusterCallBuff] +\

--- a/dpmModule/jobs/mercedes.py
+++ b/dpmModule/jobs/mercedes.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ReservationRule, ConcurrentRunRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import heroes
 from .jobbranch import bowmen
 
@@ -143,7 +143,7 @@ class JobGenerator(ck.JobGenerator):
         IrkilaBreathInit.onAfter(IrkilaBreath)
         
         # 극딜기 몰아서 사용하기
-        SoulContract = globalSkill.soul_contract()
+        SoulContract = linkSkill.soul_contract()
             
         for wrp in [UnicornSpike, AdvanceStrikeDualShot, RegendrySpear, WrathOfEllil]:
             wrp.onAfter(AdvancedFinalAttackSlow)

--- a/dpmModule/jobs/michael.py
+++ b/dpmModule/jobs/michael.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import cygnus
 from .jobbranch import warriors
 
@@ -131,7 +131,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     GuardOfLight, LoyalGuardBuff, SoulAttack, Booster, Invigorate, SacredCube, 
                     DeadlyChargeBuff, QueenOfTomorrow, AuraWeaponBuff, RoIias, SwordOfSoullight,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [CygnusPalanks, LoyalGuard_5, ShiningCross, DeadlyCharge, ClauSolis] +\
                 [ShiningCrossInstall, ClauSolisSummon] +\
                 [AuraWeaponCooltimeDummy] +\

--- a/dpmModule/jobs/nightlord.py
+++ b/dpmModule/jobs/nightlord.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import thieves
 #TODO : 5차 신스킬 적용
 
@@ -108,7 +108,7 @@ class JobGenerator(ck.JobGenerator):
             [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     ShadowPartner, SpiritJavelin, PurgeArea, BleedingToxin, EpicAdventure, 
                     UltimateDarksight, ReadyToDie, SpreadThrowInit,
-                    globalSkill.soul_contract()] + \
+                    linkSkill.soul_contract()] + \
                 [ArcaneOfDarklordFinal] + \
                 [Pungma, ArcaneOfDarklord, BleedingToxinDot, FatalVenom] +\
                 [] + [QuarupleThrow])

--- a/dpmModule/jobs/nightwalker.py
+++ b/dpmModule/jobs/nightwalker.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import cygnus
 from .jobbranch import thieves
 #TODO : 5차 신스킬 적용
@@ -140,7 +140,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     ElementalDarkness, Heist, Booster, ShadowServent, SpiritThrowing, 
                     ShadowElusion, ReadyToDie, Dominion, GloryOfGuardians, ShadowSpear, ShadowServentExtend, ShadowBiteBuff,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [CygnusPalanks] +\
                 [ElementalDarknessDOT, ShadowSpearLarge] +\
                 [] +\

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 
 #TODO : 5차 신스킬 적용
@@ -99,7 +99,7 @@ class JobGenerator(ck.JobGenerator):
         return(Blast,
                 [globalSkill.maple_heros(chtr.level, combat_level = 2), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Threat, BlessingArmor, ElementalForce, EpicAdventure, HolyUnity, AuraWeaponBuff,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [LighteningCharge, DivineCharge, GrandCross] +\
                 [BlessedHammer, BlessedHammerActive] +\
                 [AuraWeaponCooltimeDummy] +\

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import bowmen
 #TODO : 5차 신스킬 적용
 
@@ -303,7 +303,7 @@ class JobGenerator(ck.JobGenerator):
                     AncientBowBooster, CurseTolerance, CurseTransition, SharpEyes,
                     RelicEvolution, EpicAdventure,
                     AncientGuidanceBuff, AdditionalTransition, CriticalReinforce,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [CardinalTransition_ForceUse, 
                     AncientAstraHolder, TripleImpact, EdgeOfResonance, 
                         ComboAssultHolder, UltimateBlast] +\

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import heroes
 from .jobbranch import thieves
 
@@ -149,7 +149,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     TalentOfPhantomII, TalentOfPhantomIII, FinalCutBuff, BoolsEye,
                     JudgementBuff, Booster, PrieredAria, HerosOath, ReadyToDie, JokerBuff, Frid,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [FinalCut, JokerInit, TempestOfCardInit, MarkOfPhantom, BlackJackFinal] +\
                 [BlackJack] +\
                 [MileAiguillesInit] +\

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import thieves
 
 class MesoStack(core.DamageSkillWrapper, core.StackSkillWrapper):
@@ -182,7 +182,7 @@ class JobGenerator(ck.JobGenerator):
         return(BasicAttackWrapper, 
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Booster, FlipTheCoin, ShadowerInstinct, ShadowPartner, Smoke, AdvancedDarkSight, EpicAdventure, UltimateDarksight, 
-                        ReadyToDie, globalSkill.soul_contract()] +\
+                        ReadyToDie, linkSkill.soul_contract()] +\
                 [Eviscerate, SonicBlow, BailOfShadow]+\
                 [Venom]+\
                 []+\

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, MutualRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import bowmen
 #TODO : 5차 신스킬 적용    
 
@@ -111,7 +111,7 @@ class JobGenerator(ck.JobGenerator):
         return(Snipping,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_wind_booster(),
                     SoulArrow, ElusionStep, SharpEyes, BoolsEye, EpicAdventure, CriticalReinforce, SplitArrowBuff,
-                        globalSkill.soul_contract()] +\
+                        linkSkill.soul_contract()] +\
                 [TrueSnipping, ChargedArrowUse, ChargedArrow] +\
                 [Evolve,Freezer, GuidedArrow] +\
                 [] +\

--- a/dpmModule/jobs/soulmaster.py
+++ b/dpmModule/jobs/soulmaster.py
@@ -4,7 +4,7 @@ from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule, InactiveRule
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import cygnus
 from .jobbranch import warriors
 
@@ -113,7 +113,7 @@ class JobGenerator(ck.JobGenerator):
         return(NormalAttack,
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     NimbleFinger, TrueSight, SolunaTime, SoulForge, 
-                    GloryOfGuardians, AuraWeaponBuff, globalSkill.soul_contract(), ElisionBuff, SelestialDanceInit, 
+                    GloryOfGuardians, AuraWeaponBuff, linkSkill.soul_contract(), ElisionBuff, SelestialDanceInit, 
                     ] +\
                 [CygnusPalanks, SolunaDivide] +\
                 [SelestialDanceSummon, SoulEclipse] +\

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from . import contrib
 from .jobbranch import pirates
 from .jobclass import cygnus
@@ -138,7 +138,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Lightening, Booster, ChookRoi, WindBooster, LuckyDice,
                     HuricaneBuff, GloryOfGuardians, SkyOpen, Overdrive, OverdrivePenalty, ShinNoiHapL,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [GioaTan, CygnusPalanks, NoiShinChanGeuk] +\
                 [ShinNoiHapLAttack, NoiShinChanGeukAttack] +\
                 [] +\

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
 from . import jobutils
@@ -179,7 +179,7 @@ class JobGenerator(ck.JobGenerator):
             [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
             LuckyDice, Viposition, Stimulate, EpicAdventure, PirateFlag, Overdrive, Transform, NautilusBuff,
             UnityOfPowerBuff, OverdrivePenalty, DragonStrikeBuff, EnergyCharge,
-            SerpentScrewTrackingBuff, globalSkill.soul_contract()] +\
+            SerpentScrewTrackingBuff, linkSkill.soul_contract()] +\
             [UnityOfPower, Nautilus, DragonStrike, FuriousCharge] +\
             [SerpentScrew, SerpentScrewDummy, StimulateSummon] +\
             [] +\

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobclass import resistance
 from .jobbranch import bowmen
 # TODO: 재규어 맥시멈, 드릴 컨테이너 추가
@@ -152,7 +152,7 @@ class JobGenerator(ck.JobGenerator):
         return(WildBalkan,
                 [globalSkill.maple_heros(chtr.level),
                     CriticalReinforce, SoulArrow, Booster, Hauling, BeastForm, SharpEyes, SilentRampage, JaguerStorm,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [Normal, ClawCut, Crossroad, SonicBoom, JaguarSoul, RampageAsOne] +\
                 [HuntingUnit, GuidedArrow, RegistanceLineInfantry, WildGrenade] +\
                 [AnotherBite] +\

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import bowmen
 from .jobclass import cygnus
 #TODO : 5차 신스킬 적용
@@ -92,7 +92,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), 
                     Storm, SylphsAid, Albatross, SharpEyes, GloryOfGuardians, StormBringerDummy, CriticalReinforce,
                     PinPointPierceDebuff,
-                    globalSkill.soul_contract()] +\
+                    linkSkill.soul_contract()] +\
                 [Mercilesswind]+\
                 [GuidedArrow, HowlingGail, WindWall, MercilesswindDOT, CygnusPalanks, PinPointPierce]+\
                 []+\

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from . import globalSkill
+from . import globalSkill, linkSkill
 from .jobbranch import warriors
 
 # TODO: 4카 5앱 적용, 리미트 막타 추가
@@ -204,7 +204,7 @@ class JobGenerator(ck.JobGenerator):
         # 딜레이 확인필요, 딜사이클에 포함되는 스킬인지 확인필요
         ShadowRain = core.DamageSkill("쉐도우 레인", 0, 1400, 14, cooltime = 300*1000).wrap(core.DamageSkillWrapper)
         
-        SoulContract = globalSkill.soul_contract()
+        SoulContract = linkSkill.soul_contract()
 
         #### 5차 스킬 ####
         #5차스킬들 마스터리 알파/베타 구분해서 적용할것.


### PR DESCRIPTION
LinkSkill 객체를 날려버리고, 각 직업별로 링크스킬을 가져와서 패시브로 적용하도록 변경

스펙 수준에 따라 방무 링크의 효율이 달라지는 문제가 있음

https://github.com/oleneyl/maplestory_dpm_calc/issues/115