### PR TITLE
일리움 스킬 수정

### DIFF
--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from ..execution.rules import RuleSet, MutualRule
+from ..execution.rules import RuleSet, MutualRule, InactiveRule, ConcurrentRunRule
 from . import globalSkill
 from .jobbranch import magicians
 from . import jobutils
@@ -67,6 +67,9 @@ class JobGenerator(ck.JobGenerator):
     def get_ruleset(self):
         ruleset = RuleSet()
         ruleset.add_rule(MutualRule("패스트 차지", "크리스탈 이그니션(시전)"), RuleSet.BASE)
+        ruleset.add_rule(InactiveRule("패스트 차지", "글로리 윙(진입)"), RuleSet.BASE)
+        ruleset.add_rule(InactiveRule("크리스탈 이그니션(시전)", "글로리 윙(진입)"), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule("크리스탈 이그니션(시전)", "소울 오브 크리스탈"), RuleSet.BASE)
         return ruleset
         
     def get_passive_skill_list(self):
@@ -209,7 +212,6 @@ class JobGenerator(ck.JobGenerator):
         GloryWingUse.onAfter(SoulOfCrystal.turnOffController())
         
         SoulOfCrystal.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
-        FastCharge.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
         
         #기본공격 설정
         BasicAttack = core.OptionalElement(GloryWingUse.is_active, GloryWing_Craft_Javelin, Craft_Javelin_AfterOrb, name = "기본공격(글로리 윙 여부 판단)")

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -164,7 +164,6 @@ class JobGenerator(ck.JobGenerator):
         CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 10000/62, 750 + 30*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #75회
         Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼", 0, 1000+40*vEhc.getV(2,1), 5, cooltime = 1000, modifier = core.CharacterModifier(boss_pdamage = 20)).wrap(core.DamageSkillWrapper) #1초마다 시전됨.
  
-        # TODO:소오크 소모시 강화 반영필요
         SoulOfCrystal = SoulOfCrystalWrapper(core.BuffSkill("소울 오브 크리스탈", 660, 30*1000, cooltime=40*1000).isV(vEhc,1,0))
         SoulOfCrystalPassive = core.BuffSkill("소울 오브 크리스탈(패시브)", 0, 999999999, att = (5+vEhc.getV(1,0)*2)).isV(vEhc,1,0).wrap(core.BuffSkillWrapper)
 

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -72,6 +72,8 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(ConcurrentRunRule("크리스탈 이그니션(시전)", "소울 오브 크리스탈"), RuleSet.BASE)
         ruleset.add_rule(ReservationRule("그람홀더", "글로리 윙(진입)"), RuleSet.BASE)
         ruleset.add_rule(ConditionRule("글로리 윙(진입)", "그람홀더", lambda x:x.is_active() or x.is_not_usable()), RuleSet.BASE)
+        ruleset.add_rule(ReservationRule("데우스", "글로리 윙(진입)"), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule("글로리 윙(진입)", "데우스", lambda x:x.is_active() or x.is_not_usable()), RuleSet.BASE)
         return ruleset
         
     def get_passive_skill_list(self):
@@ -126,7 +128,7 @@ class JobGenerator(ck.JobGenerator):
         Machina = core.SummonSkill("마키나", 0, 1980, 250, 4, 180000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)    # 최초 사용 이후로는 항상 데우스 종료때 딜레이 없이 리필됨
         
         CrystalSkill_MortalSwing = core.DamageSkill("크리스탈 스킬:모탈스윙", 0, 600, 10, cooltime = -1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)    #30
-        CrystalSkill_Deus = core.SummonSkill("데우스", 0, 4800, 500, 5+1, 30*1000, cooltime = -1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)   #90, 7타
+        CrystalSkill_Deus = core.SummonSkill("데우스", 30, 4800, 500, 5+1, 30*1000, cooltime = -1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)   #90, 7타
         CrystalSkill_Deus_Satelite = core.SummonSkill("데우스(위성)", 0, 500, 240, 1+1, 30*1000, cooltime = -1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
         
         LonginusZone = core.DamageSkill("롱기누스 존", 690, 1500, 12, cooltime = 180*1000)    #안씀

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -43,6 +43,19 @@ class IliumStackWrapper(core.StackSkillWrapper):
                     
         return result
 
+class SoulOfCrystalWrapper(core.BuffSkillWrapper):
+    def __init__(self, skill, name = None):
+        super().__init__(skill, name)
+
+    def turnOff(self):
+        self.timeLeft = 0
+        self.onoff = False
+        return self._disabledResultobjectCache
+
+    def turnOffController(self):
+        task = core.Task(self, self.turnOff)
+        return core.TaskHolder(task, name = "소오크 흡수")
+
 class JobGenerator(ck.JobGenerator):
     def __init__(self, vEhc = None):
         super(JobGenerator, self).__init__(vEhc = vEhc)
@@ -128,31 +141,31 @@ class JobGenerator(ck.JobGenerator):
         #글로리 윙
         GloryWingStackSkill = core.BuffSkill("글로링 윙(스택)", 0, 9999999)
         
-        GloryWingUse = core.BuffSkill("글로리 윙(진입)", 30, 20000, pdamage_indep = 25, boss_pdamage = 30, cooltime = -1).wrap(core.BuffSkillWrapper) #150
+        GloryWingUse = core.BuffSkill("글로리 윙(진입)", 30, 20000, pdamage_indep = 25, pdamage = 70, boss_pdamage = 30, cooltime = -1).wrap(core.BuffSkillWrapper) # 소오크 2개에 항상 맞춰 사용
         
         GloryWing_MortalWingbit = core.DamageSkill("글로리 윙(모탈 윙비트)", 0, 2000, 8, cooltime = -1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)  #1회
         
-        GloryWing_Craft_Javelin = core.DamageSkill("크래프트:자벨린(글로리 윙)", 390, 465, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, pdamage_indep=40)).setV(vEhc, 0, 0, True).wrap(core.DamageSkillWrapper)
+        GloryWing_Craft_Javelin = core.DamageSkill("크래프트:자벨린(글로리 윙)", 390, 465, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, pdamage_indep = 40)).setV(vEhc, 0, 0, True).wrap(core.DamageSkillWrapper)
         GloryWing_Craft_Javelin_Fragment = core.DamageSkill("크래프트:자벨린(글로리 윙)(파편)", 0, 200+100, 3*3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 0, True).wrap(core.DamageSkillWrapper)
 
         #5차 스킬들
         OverloadMana = OverloadMana = magicians.OverloadManaWrapper(vEhc, 0, 3)
-        GramHolder = core.SummonSkill("그람홀더", 900, 3000, 1000+25*vEhc.getV(4,3), 6, 40000, cooltime = 180000).isV(vEhc,4,3).wrap(core.SummonSkillWrapper)   #임의딜레이 900
+        GramHolder = core.SummonSkill("그람홀더", 900, 3000, 1000+25*vEhc.getV(4,3), 6, 40000, cooltime = 180000, modifier = core.CharacterModifier(pdamage_indep = 100)).isV(vEhc,4,3).wrap(core.SummonSkillWrapper)   #임의딜레이 900
         
         MagicCircuitFullDrive = core.BuffSkill("매직 서킷 풀드라이브", 720, (30+vEhc.getV(3,2))*1000, pdamage = (20 + vEhc.getV(3,2)), cooltime = 200*1000).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
         MagicCircuitFullDriveStorm = core.SummonSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 4000, 500+20*vEhc.getV(3,2), 3, (30+vEhc.getV(3,2))*1000, cooltime = -1).wrap(core.SummonSkillWrapper)
         
         CrystalIgnitionInit = core.DamageSkill("크리스탈 이그니션(시전)", 960, 0, 0, cooltime = 180*1000).wrap(core.DamageSkillWrapper)
         CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 270, 750 + 25*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #75회
-        Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼", 0, 1000+40*vEhc.getV(2,1), 5, cooltime = 1000).wrap(core.DamageSkillWrapper) #1초마다 시전됨.
+        Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼", 0, 1000+40*vEhc.getV(2,1), 5, cooltime = 1000, modifier = core.CharacterModifier(boss_pdamage = 20)).wrap(core.DamageSkillWrapper) #1초마다 시전됨.
  
         # TODO:소오크 소모시 강화 반영필요
-        SoulOfCrystal = core.BuffSkill("소울 오브 크리스탈", 660, 30*1000, cooltime=40*1000).isV(vEhc,1,0).wrap(core.BuffSkillWrapper)
+        SoulOfCrystal = SoulOfCrystalWrapper(core.BuffSkill("소울 오브 크리스탈", 660, 30*1000, cooltime=40*1000).isV(vEhc,1,0))
         SoulOfCrystalPassive = core.BuffSkill("소울 오브 크리스탈(패시브)", 0, 999999999, att = (5+vEhc.getV(1,0)*2)).isV(vEhc,1,0).wrap(core.BuffSkillWrapper)
 
         SoulOfCrystal_Reaction_Domination = core.DamageSkill("리액션:도미네이션(소오크)", 0, 550 * 0.01 * (50 + vEhc.getV(1,0)), 2*2).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         SoulOfCrystal_Reaction_Destruction = core.DamageSkill("리액션:디스트럭션(소오크)", 0, 550 * 0.01 * (50 + vEhc.getV(1,0)), 4*2*2, modifier = core.CharacterModifier(boss_pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        SoulOfCrystal_Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼(소오크)", 0, 1000+40*vEhc.getV(2,1), 5*2).wrap(core.DamageSkillWrapper)
+        SoulOfCrystal_Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼(소오크)", 0, 1000+40*vEhc.getV(2,1), 5*2, modifier = core.CharacterModifier(boss_pdamage = 20)).wrap(core.DamageSkillWrapper)
         
         #스킬간 연결
 
@@ -191,7 +204,11 @@ class JobGenerator(ck.JobGenerator):
         CrystalCharge.addTrigger(CrystalSkill_MortalSwing.controller(1), 30)
         CrystalCharge.addTrigger(CrystalSkill_Deus.controller(1), 90)
         CrystalCharge.addTrigger(GloryWingUse.controller(1), 150, isLast = True)
+
+        GloryWingUse.onConstraint(core.ConstraintElement("소오크 가동중", SoulOfCrystal, SoulOfCrystal.is_active))
+        GloryWingUse.onAfter(SoulOfCrystal.turnOffController())
         
+        SoulOfCrystal.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
         FastCharge.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
         
         #기본공격 설정

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -122,36 +122,28 @@ class JobGenerator(ck.JobGenerator):
         
         Craft_Longinus = core.DamageSkill("크래프트:롱기누스", 1053, 950, 8, cooltime = 15000).wrap(core.DamageSkillWrapper)
         
-        Riyo = core.SummonSkill("리요", 900, 500, 140, 1, 180000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper) #임의딜레이 900
-        Machina = core.SummonSkill("마키나", 900, 1980, 350, 4, 180000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)    #임의딜레이 900
+        Riyo = core.SummonSkill("리요", 0, 500, 240, 1, 180000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper) # 최초 사용 이후로는 항상 데우스 종료때 딜레이 없이 리필됨
+        Machina = core.SummonSkill("마키나", 0, 1980, 250, 4, 180000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)    # 최초 사용 이후로는 항상 데우스 종료때 딜레이 없이 리필됨
         
         CrystalSkill_MortalSwing = core.DamageSkill("크리스탈 스킬:모탈스윙", 0, 600, 10, cooltime = -1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)    #30
-        CrystalSkill_Deus = core.SummonSkill("데우스", 0, 4800, 315, 5, 30*1000, cooltime = -1).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)   #90, 7타
+        CrystalSkill_Deus = core.SummonSkill("데우스", 0, 4800, 500, 5+1, 30*1000, cooltime = -1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)   #90, 7타
+        CrystalSkill_Deus_Satelite = core.SummonSkill("데우스(위성)", 0, 500, 240, 1+1, 30*1000, cooltime = -1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
         
         LonginusZone = core.DamageSkill("롱기누스 존", 690, 1500, 12, cooltime = 180*1000)    #안씀
         
         BlessMark = core.BuffSkill("블레스 마크", 0, 99999999, att = 46).wrap(core.BuffSkillWrapper)
         CurseMark = core.BuffSkill("커스 마크", 0, 99999999, armor_ignore = 20).wrap(core.BuffSkillWrapper)
         CurseMarkFinalAttack = core.DamageSkill("커스 마크(추가타)", 0, 200, 1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        '''
-        
-        데우스 리인포스 / 보택 찍기.
-        
-        ( 500 * 5 * 7 + 39 * 140 ) / 30 => 1초당 765
-        
-        280+170=450
-        데우스 공격력 : 315
-        '''
         
         #글로리 윙
         GloryWingStackSkill = core.BuffSkill("글로리 윙(스택)", 0, 9999999)
         
-        GloryWingUse = core.BuffSkill("글로리 윙(진입)", 30, 20000, pdamage_indep = 25, pdamage = 70, boss_pdamage = 30, cooltime = -1).wrap(core.BuffSkillWrapper) # 소오크 2개에 항상 맞춰 사용
+        GloryWingUse = core.BuffSkill("글로리 윙(진입)", 30, 20000, pdamage_indep = 25, pdamage = (vEhc.getV(1,0) + 5) * 2, boss_pdamage = 30, cooltime = -1).wrap(core.BuffSkillWrapper) # 소오크 2개에 항상 맞춰 사용
         
-        GloryWing_MortalWingbit = core.DamageSkill("글로리 윙(모탈 윙비트)", 0, 2000, 8, cooltime = -1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)  #1회
+        GloryWing_MortalWingbit = core.DamageSkill("글로리 윙(모탈 윙비트)", 630, 2000, 8, cooltime = -1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)  #1회
         
-        GloryWing_Craft_Javelin = core.DamageSkill("크래프트:자벨린(글로리 윙)", 390, 465, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, pdamage_indep = 40)).setV(vEhc, 0, 0, True).wrap(core.DamageSkillWrapper)
-        GloryWing_Craft_Javelin_Fragment = core.DamageSkill("크래프트:자벨린(글로리 윙)(파편)", 0, 200+100, 3*3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 0, True).wrap(core.DamageSkillWrapper)
+        GloryWing_Craft_Javelin = core.DamageSkill("크래프트:자벨린(글로리 윙)", 420, 465, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, pdamage_indep = 40)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        GloryWing_Craft_Javelin_Fragment = core.DamageSkill("크래프트:자벨린(글로리 윙)(파편)", 0, 250, 3*3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
 
         #5차 스킬들
         OverloadMana = OverloadMana = magicians.OverloadManaWrapper(vEhc, 0, 3)
@@ -197,6 +189,10 @@ class JobGenerator(ck.JobGenerator):
         
         CrystalIgnitionInit.onAfter(core.RepeatElement(CrystalIgnition, 62))
         CrystalIgnition.onAfter(Reaction_Spectrum_Trigger)
+
+        CrystalSkill_Deus.onAfter(CrystalSkill_Deus_Satelite)
+        CrystalSkill_Deus.onAfter(Riyo.controller(30000, type_="set_disabled_and_time_left"))
+        CrystalSkill_Deus.onAfter(Machina.controller(30000, type_="set_disabled_and_time_left"))
         
         MagicCircuitFullDrive.onAfter(MagicCircuitFullDriveStorm)
         
@@ -214,6 +210,7 @@ class JobGenerator(ck.JobGenerator):
         GloryWingUse.onAfter(SoulOfCrystal.turnOffController())
         
         SoulOfCrystal.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
+        Machina.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
         
         #기본공격 설정
         BasicAttack = core.OptionalElement(GloryWingUse.is_active, GloryWing_Craft_Javelin, Craft_Javelin_AfterOrb, name = "기본공격(글로리 윙 여부 판단)")
@@ -241,7 +238,7 @@ class JobGenerator(ck.JobGenerator):
                     OverloadMana, BlessMark, CurseMark,
                     globalSkill.soul_contract()] +\
                 [CrystalSkill_MortalSwing, GloryWing_MortalWingbit, CrystalIgnitionInit] +\
-                [Riyo, Machina, CrystalSkill_Deus, 
+                [Riyo, Machina, CrystalSkill_Deus, CrystalSkill_Deus_Satelite,
                     GramHolder, MagicCircuitFullDriveStorm] +\
                 [Reaction_Domination, Reaction_Destruction, Reaction_Spectrum] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -3,6 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import RuleSet, MutualRule
 from . import globalSkill
 from .jobbranch import magicians
 from . import jobutils
@@ -51,6 +52,11 @@ class JobGenerator(ck.JobGenerator):
         self.vEnhanceNum = 12
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+
+    def get_ruleset(self):
+        ruleset = RuleSet()
+        ruleset.add_rule(MutualRule("패스트 차지", "크리스탈 이그니션(시전)"), RuleSet.BASE)
+        return ruleset
         
     def get_passive_skill_list(self):
         vEhc = self.vEhc
@@ -88,12 +94,12 @@ class JobGenerator(ck.JobGenerator):
         FastCharge = core.BuffSkill("패스트 차지", 600, 10000, cooltime = 120000).wrap(core.BuffSkillWrapper) #임의딜레이 600
         WraithOfGod = core.BuffSkill("레이스 오브 갓", 0, 60000, pdamage = 10, cooltime = 120000).wrap(core.BuffSkillWrapper)
         
-        Craft_Orb = core.DamageSkill("크래프트:오브", 510, 300, 1).wrap(core.DamageSkillWrapper)
+        Craft_Orb = core.DamageSkill("크래프트:오브", 390, 300, 1).wrap(core.DamageSkillWrapper)
         Reaction_Domination = core.DamageSkill("리액션:도미네이션", 0, 550, 2, cooltime = 4000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         Craft_Javelin_EnhanceBuff = core.BuffSkill("크래프트:오브(자벨린 강화버프)", 0, 2000, cooltime = -1).wrap(core.BuffSkillWrapper)
         
-        Craft_Javelin = core.DamageSkill("크래프트:자벨린", 510, 375, 4 * 3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        Craft_Javelin_AfterOrb = core.DamageSkill("크래프트:자벨린(오브 이후)", 510, 405, 4 * 3, modifier = core.CharacterModifier(pdamage = 20 + 15, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        Craft_Javelin = core.DamageSkill("크래프트:자벨린", 390, 375, 4 * 3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        Craft_Javelin_AfterOrb = core.DamageSkill("크래프트:자벨린(오브 이후)", 390, 375, 4 * 3, modifier = core.CharacterModifier(pdamage = 20 + 15, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         
         Craft_Javelin_Fragment = core.DamageSkill("크래프트:자벨린(파편)", 0, 130, 2 * 3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         Reaction_Destruction = core.DamageSkill("리액션:디스트럭션", 0, 550, 4*2, modifier = core.CharacterModifier(boss_pdamage = 20), cooltime = 4000).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -68,12 +68,18 @@ class JobGenerator(ck.JobGenerator):
         ruleset = RuleSet()
         ruleset.add_rule(MutualRule("패스트 차지", "크리스탈 이그니션(시전)"), RuleSet.BASE)
         ruleset.add_rule(InactiveRule("패스트 차지", "글로리 윙(진입)"), RuleSet.BASE)
-        ruleset.add_rule(InactiveRule("크리스탈 이그니션(시전)", "글로리 윙(진입)"), RuleSet.BASE)
-        ruleset.add_rule(ConcurrentRunRule("크리스탈 이그니션(시전)", "소울 오브 크리스탈"), RuleSet.BASE)
         ruleset.add_rule(ReservationRule("그람홀더", "글로리 윙(진입)"), RuleSet.BASE)
         ruleset.add_rule(ConditionRule("글로리 윙(진입)", "그람홀더", lambda x:x.is_active() or x.is_not_usable()), RuleSet.BASE)
         ruleset.add_rule(ReservationRule("데우스", "글로리 윙(진입)"), RuleSet.BASE)
         ruleset.add_rule(ConditionRule("글로리 윙(진입)", "데우스", lambda x:x.is_active() or x.is_not_usable()), RuleSet.BASE)
+
+        # 이그니션과 글로리 윙 따로 사용하는 딜사이클
+        ruleset.add_rule(InactiveRule("크리스탈 이그니션(시전)", "글로리 윙(진입)"), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule("크리스탈 이그니션(시전)", "소울 오브 크리스탈"), RuleSet.BASE)
+
+        # 함께 사용하게 하려면 위 2개 주석처리하고 아래 2개 Rule을 사용
+        # ruleset.add_rule(ConcurrentRunRule("크리스탈 이그니션(시전)", "글로리 윙(진입)"), RuleSet.BASE)
+        # ruleset.add_rule(ConditionRule("글로리 윙(진입)", "크리스탈 이그니션(시전)", lambda x:x.is_cooltime_left(20000, 1) or x.is_cooltime_left(10000, -1)), RuleSet.BASE)
         return ruleset
         
     def get_passive_skill_list(self):
@@ -142,10 +148,10 @@ class JobGenerator(ck.JobGenerator):
         
         GloryWingUse = core.BuffSkill("글로리 윙(진입)", 30, 20000, pdamage_indep = 25, pdamage = (vEhc.getV(1,0) + 5) * 2, boss_pdamage = 30, cooltime = -1).wrap(core.BuffSkillWrapper) # 소오크 2개에 항상 맞춰 사용
         
-        GloryWing_MortalWingbit = core.DamageSkill("글로리 윙(모탈 윙비트)", 630, 2000, 8, cooltime = -1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)  #1회
+        GloryWing_MortalWingbit = core.DamageSkill("글로리 윙:모탈 윙비트", 630, 2000, 8, cooltime = -1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)  #1회
         
-        GloryWing_Craft_Javelin = core.DamageSkill("크래프트:자벨린(글로리 윙)", 420, 465, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, pdamage_indep = 40)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        GloryWing_Craft_Javelin_Fragment = core.DamageSkill("크래프트:자벨린(글로리 윙)(파편)", 0, 250, 3*3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        GloryWing_Craft_Javelin = core.DamageSkill("글로리 윙:자벨린", 420, 465, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, pdamage_indep = 40)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        GloryWing_Craft_Javelin_Fragment = core.DamageSkill("글로리 윙:자벨린(매직 미사일)", 0, 250, 3*3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
 
         #5차 스킬들
         OverloadMana = OverloadMana = magicians.OverloadManaWrapper(vEhc, 0, 3)

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -161,7 +161,7 @@ class JobGenerator(ck.JobGenerator):
         MagicCircuitFullDriveStorm = core.SummonSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 4000, 500+20*vEhc.getV(3,2), 3, (30+vEhc.getV(3,2))*1000, cooltime = -1).wrap(core.SummonSkillWrapper)
         
         CrystalIgnitionInit = core.DamageSkill("크리스탈 이그니션(시전)", 960, 0, 0, cooltime = 180*1000).wrap(core.DamageSkillWrapper)
-        CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 270, 750 + 25*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #75회
+        CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 10000/62, 750 + 25*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #62회
         Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼", 0, 1000+40*vEhc.getV(2,1), 5, cooltime = 1000, modifier = core.CharacterModifier(boss_pdamage = 20)).wrap(core.DamageSkillWrapper) #1초마다 시전됨.
  
         # TODO:소오크 소모시 강화 반영필요
@@ -195,7 +195,7 @@ class JobGenerator(ck.JobGenerator):
         
         GloryWing_Craft_Javelin.onAfter(GloryWing_Craft_Javelin_Fragment)
         
-        CrystalIgnitionInit.onAfter(core.RepeatElement(CrystalIgnition, 75))
+        CrystalIgnitionInit.onAfter(core.RepeatElement(CrystalIgnition, 62))
         CrystalIgnition.onAfter(Reaction_Spectrum_Trigger)
         
         MagicCircuitFullDrive.onAfter(MagicCircuitFullDriveStorm)

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -43,8 +43,6 @@ class IliumStackWrapper(core.StackSkillWrapper):
                     
         return result
 
-
-
 class JobGenerator(ck.JobGenerator):
     def __init__(self, vEhc = None):
         super(JobGenerator, self).__init__(vEhc = vEhc)
@@ -136,6 +134,7 @@ class JobGenerator(ck.JobGenerator):
         
         GloryWing_Craft_Javelin = core.DamageSkill("크래프트:자벨린(글로리 윙)", 390, 465, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, pdamage_indep=40)).setV(vEhc, 0, 0, True).wrap(core.DamageSkillWrapper)
         GloryWing_Craft_Javelin_Fragment = core.DamageSkill("크래프트:자벨린(글로리 윙)(파편)", 0, 200+100, 3*3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 0, True).wrap(core.DamageSkillWrapper)
+
         #5차 스킬들
         OverloadMana = OverloadMana = magicians.OverloadManaWrapper(vEhc, 0, 3)
         GramHolder = core.SummonSkill("그람홀더", 900, 3000, 1000+25*vEhc.getV(4,3), 6, 40000, cooltime = 180000).isV(vEhc,4,3).wrap(core.SummonSkillWrapper)   #임의딜레이 900
@@ -145,16 +144,15 @@ class JobGenerator(ck.JobGenerator):
         
         CrystalIgnitionInit = core.DamageSkill("크리스탈 이그니션(시전)", 960, 0, 0, cooltime = 180*1000).wrap(core.DamageSkillWrapper)
         CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 270, 750 + 25*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #75회
-        
-        Reaction_Spectrum = core.SummonSkill("리액션:스펙트럼", 0, 1000, 1000+40*vEhc.getV(2,1), 5, 10000, cooltime = -1).wrap(core.SummonSkillWrapper) #1초마다 시전됨.
+        Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼", 0, 1000+40*vEhc.getV(2,1), 5, cooltime = 1000).wrap(core.DamageSkillWrapper) #1초마다 시전됨.
  
         # TODO:소오크 소모시 강화 반영필요
-        SoulOfCrystal = core.BuffSkill("소울 오브 크리스탈", 660, 30*1000, cooltime = 40*1000).isV(vEhc,1,0).wrap(core.BuffSkillWrapper)
+        SoulOfCrystal = core.BuffSkill("소울 오브 크리스탈", 660, 30*1000, cooltime=40*1000).isV(vEhc,1,0).wrap(core.BuffSkillWrapper)
         SoulOfCrystalPassive = core.BuffSkill("소울 오브 크리스탈(패시브)", 0, 999999999, att = (5+vEhc.getV(1,0)*2)).isV(vEhc,1,0).wrap(core.BuffSkillWrapper)
-        SoulOfCrystal_Reaction_Domination = core.DamageSkill("리액션 : 도미네이션(소오크)", 0, 550 * 0.01 * (50 + vEhc.getV(1,0)) * 2, 2).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        SoulOfCrystal_Reaction_Destruction = core.DamageSkill("리액션 : 디스트럭션(소오크)", 0, 550* 0.01 * (50 + vEhc.getV(1,0)) * 2, 4*2, modifier = core.CharacterModifier(boss_pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        
-        SoulOfCrystal_Reaction_Spectrum = core.SummonSkill("리액션:스펙트럼(소오크)", 0, 1000, 1000+40*vEhc.getV(2,1) * 2, 5, 10000, cooltime = -1).wrap(core.SummonSkillWrapper)
+
+        SoulOfCrystal_Reaction_Domination = core.DamageSkill("리액션:도미네이션(소오크)", 0, 550 * 0.01 * (50 + vEhc.getV(1,0)), 2*2).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        SoulOfCrystal_Reaction_Destruction = core.DamageSkill("리액션:디스트럭션(소오크)", 0, 550 * 0.01 * (50 + vEhc.getV(1,0)), 4*2*2, modifier = core.CharacterModifier(boss_pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        SoulOfCrystal_Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼(소오크)", 0, 1000+40*vEhc.getV(2,1), 5*2).wrap(core.DamageSkillWrapper)
         
         #스킬간 연결
 
@@ -168,7 +166,7 @@ class JobGenerator(ck.JobGenerator):
                 
         Reaction_Domination_Trigger = core.OptionalElement(lambda:Reaction_Domination.available, Reaction_Domination, name = "리액션:도미네이션")
         Reaction_Destruction_Trigger = core.OptionalElement(lambda:Reaction_Destruction.available, Reaction_Destruction, name = "리액션:디스트럭션")
-        Reaction_Spectrum_Trigger = core.OptionalElement(Reaction_Spectrum.is_usable, Reaction_Spectrum, name = "리액션:스펙트럼")
+        Reaction_Spectrum_Trigger = core.OptionalElement(lambda:Reaction_Spectrum.available, Reaction_Spectrum, name = "리액션:스펙트럼")
         
         Craft_Orb.onAfter(Reaction_Domination_Trigger)
         Craft_Javelin.onAfter(Reaction_Destruction_Trigger)
@@ -180,7 +178,7 @@ class JobGenerator(ck.JobGenerator):
         GloryWing_Craft_Javelin.onAfter(GloryWing_Craft_Javelin_Fragment)
         
         CrystalIgnitionInit.onAfter(core.RepeatElement(CrystalIgnition, 75))
-        CrystalIgnitionInit.onAfter(Reaction_Spectrum_Trigger)
+        CrystalIgnition.onAfter(Reaction_Spectrum_Trigger)
         
         MagicCircuitFullDrive.onAfter(MagicCircuitFullDriveStorm)
         
@@ -194,7 +192,7 @@ class JobGenerator(ck.JobGenerator):
         CrystalCharge.addTrigger(CrystalSkill_Deus.controller(1), 90)
         CrystalCharge.addTrigger(GloryWingUse.controller(1), 150, isLast = True)
         
-        FastCharge.onConstraint( core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active ) )
+        FastCharge.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
         
         #기본공격 설정
         BasicAttack = core.OptionalElement(GloryWingUse.is_active, GloryWing_Craft_Javelin, Craft_Javelin_AfterOrb, name = "기본공격(글로리 윙 여부 판단)")
@@ -213,6 +211,7 @@ class JobGenerator(ck.JobGenerator):
 
         Reaction_Domination.protect_from_running()
         Reaction_Destruction.protect_from_running()
+        Reaction_Spectrum.protect_from_running()
 
         return(BasicAttackWrapper,
                 [SoulOfCrystalPassive, globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
@@ -222,6 +221,6 @@ class JobGenerator(ck.JobGenerator):
                     globalSkill.soul_contract()] +\
                 [CrystalSkill_MortalSwing, GloryWing_MortalWingbit, CrystalIgnitionInit] +\
                 [Riyo, Machina, CrystalSkill_Deus, 
-                    GramHolder, MagicCircuitFullDriveStorm, Reaction_Spectrum, SoulOfCrystal_Reaction_Spectrum] +\
-                [Reaction_Domination, Reaction_Destruction] +\
+                    GramHolder, MagicCircuitFullDriveStorm] +\
+                [Reaction_Domination, Reaction_Destruction, Reaction_Spectrum] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -3,7 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from ..execution.rules import RuleSet, MutualRule, InactiveRule, ConcurrentRunRule
+from ..execution.rules import RuleSet, MutualRule, InactiveRule, ConcurrentRunRule, ReservationRule, ConditionRule
 from . import globalSkill
 from .jobbranch import magicians
 from . import jobutils
@@ -70,6 +70,8 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(InactiveRule("패스트 차지", "글로리 윙(진입)"), RuleSet.BASE)
         ruleset.add_rule(InactiveRule("크리스탈 이그니션(시전)", "글로리 윙(진입)"), RuleSet.BASE)
         ruleset.add_rule(ConcurrentRunRule("크리스탈 이그니션(시전)", "소울 오브 크리스탈"), RuleSet.BASE)
+        ruleset.add_rule(ReservationRule("그람홀더", "글로리 윙(진입)"), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule("글로리 윙(진입)", "그람홀더", lambda x:x.is_active() or x.is_not_usable()), RuleSet.BASE)
         return ruleset
         
     def get_passive_skill_list(self):
@@ -142,7 +144,7 @@ class JobGenerator(ck.JobGenerator):
         '''
         
         #글로리 윙
-        GloryWingStackSkill = core.BuffSkill("글로링 윙(스택)", 0, 9999999)
+        GloryWingStackSkill = core.BuffSkill("글로리 윙(스택)", 0, 9999999)
         
         GloryWingUse = core.BuffSkill("글로리 윙(진입)", 30, 20000, pdamage_indep = 25, pdamage = 70, boss_pdamage = 30, cooltime = -1).wrap(core.BuffSkillWrapper) # 소오크 2개에 항상 맞춰 사용
         

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -91,7 +91,7 @@ class JobGenerator(ck.JobGenerator):
         
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 200*1000).wrap(core.BuffSkillWrapper)
-        FastCharge = core.BuffSkill("패스트 차지", 600, 10000, cooltime = 120000).wrap(core.BuffSkillWrapper) #임의딜레이 600
+        FastCharge = core.BuffSkill("패스트 차지", 600, 10000, cooltime = 120000, rem=True).wrap(core.BuffSkillWrapper) #임의딜레이 600
         WraithOfGod = core.BuffSkill("레이스 오브 갓", 0, 60000, pdamage = 10, cooltime = 120000).wrap(core.BuffSkillWrapper)
         
         Craft_Orb = core.DamageSkill("크래프트:오브", 390, 300, 1).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -161,7 +161,7 @@ class JobGenerator(ck.JobGenerator):
         MagicCircuitFullDriveStorm = core.SummonSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 4000, 500+20*vEhc.getV(3,2), 3, (30+vEhc.getV(3,2))*1000, cooltime = -1).wrap(core.SummonSkillWrapper)
         
         CrystalIgnitionInit = core.DamageSkill("크리스탈 이그니션(시전)", 960, 0, 0, cooltime = 180*1000).wrap(core.DamageSkillWrapper)
-        CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 10000/62, 750 + 25*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #62회
+        CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 10000/62, 750 + 30*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #75회
         Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼", 0, 1000+40*vEhc.getV(2,1), 5, cooltime = 1000, modifier = core.CharacterModifier(boss_pdamage = 20)).wrap(core.DamageSkillWrapper) #1초마다 시전됨.
  
         # TODO:소오크 소모시 강화 반영필요


### PR DESCRIPTION
* 자벨린-오브 연계 딜레이 수정 (510 -> 390)
* 자벨린 퍼뎀 수정 (405 -> 375)
* 패스트 차지에 벞지 적용
* 리액션:스펙트럼이 발동 안되는것 수정
* 추가 발동되는 리액션 스킬이 타수가 아닌 퍼뎀에 곱해지던 것 수정
* 글로리 윙 사용시 소오크 흡수 구현
* 그람홀더의 조건부 최종뎀 적용 (글로리 윙과 무조건 맞춰 씀)
* 리액션:스펙트럼에 빠져있던 보공 추가
* 글로리윙 도중에 소오크 사용불가
* 딜사이클
  * 이그니션은 글로리 윙과 따로 사용
  * 이그니션은 소오크와 함께 사용
  * 패스트 차지는 이그니션이 사용 가능하면 안쓰고 대기
  * 패스트 차지는 글로리윙 OFF일때 사용
  * 그람홀더를 글로리 윙 진입 직전에 사용
* 스택스킬 오타 수정
* 이그니션이 20초간 75회 반복으로 되어있었으나 15초간 62회 반복임
* 이그니션 퍼뎀 수정
* 글로리윙:자벨린과 그 파편에 코강 적용되게 수정
* 데우스+리요+마키나 평균으로 처리하던 것을 합체/분리 되도록 구현
* 데우스의 패시브 +100%p가 마키나에 들어가던것을 리요가 받도록 수정
* 데우스에 합쳐진 위성 데미지 분리, 리요 퍼뎀 따라가도록
* 데우스-리인포스, 보너스 어택 적용
* 글로리윙:자벨린의 딜레이 390 -> 420 수정
* 글로리윙:자벨린의 파편 퍼뎀 300 -> 250 수정
* 글로리윙:모탈 윙비트에 빠져있던 딜레이 추가
* 마키나가 글로리윙 도중에 나타나지 않도록 함
* 데우스 딜레이 추가
* 데우스를 글로리윙 진입 직전에 사용

https://github.com/oleneyl/maplestory_dpm_calc/issues/154
