### PR TITLE
스트라이커 태풍 연계시 최종뎀 20% 반영

### DIFF
--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -134,7 +134,7 @@ class JobGenerator(ck.JobGenerator):
         ThunderConcat.onAfter(DestroyConcat)
         
         for skill in [Destroy, Thunder, DestroyConcat, ThunderConcat, HuricaneConcat, GioaTan, NoiShinChanGeuk]:
-            contrib.create_auxilary_attack(skill, CHOOKROI)
+            contrib.create_auxilary_attack(skill, CHOOKROI, "(축뢰)")
 
         for skill in [Destroy, Thunder, DestroyConcat, ThunderConcat, NoiShinChanGeuk]:
             skill.onAfter(LightningStack.stackController(1))

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -75,7 +75,8 @@ class JobGenerator(ck.JobGenerator):
         천지개벽 ON: 태풍 - 섬멸
         천지개벽 OFF: 벽력 - 섬멸
         
-        벽섬 : 1080ms (420 / 660)
+        벽섬 : 1020ms
+        태섬 : 900ms
         
         팔랑크스의 타수를 2/3만 적용되도록 함
         모든 스킬은 쿨타임마다 사용
@@ -122,8 +123,8 @@ class JobGenerator(ck.JobGenerator):
         GioaTan = core.DamageSkill("교아탄", 480, 1000+40*vEhc.getV(2,1), 7, cooltime = 8000, modifier = core.CharacterModifier(pdamage_indep = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #  교아탄-벽력 콤보 사용함
 
         NoiShinChanGeuk = core.DamageSkill("뇌신창격", 0, 150+6*vEhc.getV(0,0), 6, cooltime = 7000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
-        NoiShinChanGeukAttack = core.SummonSkill("뇌신창격(공격)", 0, 1000, 200 + 8*vEhc.getV(0,0), 7, 3999, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)    #4번 발동
-        NoiShinChanGeukAttack_ChookRoi = core.DamageSkill("뇌신창격(축뢰)", 0, (200 + 8*vEhc.getV(0,0)) * CHOOKROI, 7).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        NoiShinChanGeukAttack = core.SummonSkill("뇌신창격(후속타)", 0, 1000, 200 + 8*vEhc.getV(0,0), 7, 3999, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)    #4번 발동
+        NoiShinChanGeukAttack_ChookRoi = core.DamageSkill("뇌신창격(후속타)(축뢰)", 0, (200 + 8*vEhc.getV(0,0)) * CHOOKROI, 7).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         #섬멸 연계
 
         BasicAttack = core.OptionalElement(SkyOpen.is_active, HuricaneConcat, ThunderConcat)

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -92,8 +92,7 @@ class JobGenerator(ck.JobGenerator):
     
         LightningStack = LightningWrapper(core.BuffSkill("엘리멘탈 : 라이트닝", 0, 99999999))
 
-        # 5차 강화에 포함해야 할 수도 있음
-        HuricaneConcat = core.DamageSkill("태풍(연계)", 420, 390, 5+1).setV(vEhc, 0, 2).wrap(core.DamageSkillWrapper)
+        HuricaneConcat = core.DamageSkill("태풍(연계)", 420, 390, 5+1, modifier = core.CharacterModifier(pdamage_indep = 20)).setV(vEhc, 0, 2).wrap(core.DamageSkillWrapper)
         
         Destroy = core.DamageSkill("섬멸", 480, 350, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         Thunder = core.DamageSkill("벽력", 540, 320, 5 + 1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)


### PR DESCRIPTION
스커 패시브에 연계시 최종뎀 20%가 있는데 이게 벽력 섬멸 교아탄에만 적용되고 태풍에 빠져있었습니다.

태풍에 코강이 적용중인지에 대한 질문이 있었는데, 적용중인것 같으나 한번 확인 부탁드립니다.
  * 적용중입니다.