### PR TITLE
키네시스 스킬 수정

### DIFF
--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -121,13 +121,13 @@ class JobGenerator(ck.JobGenerator):
         
         TeleKinesis = core.DamageSkill("텔레키네시스", 0, 350, 0.7).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         UltimateBPM = core.SummonSkill("얼티메이트-B.P.M.", 0, 600, 175, 7, 999999999).setV(vEhc, 0, 2, False).wrap(core.SummonSkillWrapper) #1
-        PsychicGrab2 = core.DamageSkill("싸이킥 그랩", 552, 470, 5,  modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #+2, 그랩 1번에 스매싱 5회 사용 가능 (510*5+210)/5
-        UltimatePsychic = core.DamageSkill("얼티메이트-싸이킥 샷", 1110, 300, 3*5*2*0.8,  modifier = core.CharacterModifier(crit_damage = 20, pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #5, 그랩 1번에 샷 1회 사용가능 (900+210)
+        PsychicGrab2 = core.DamageSkill("싸이킥 그랩", 576, 470, 5,  modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #+2, 그랩 1번에 스매싱 5회 사용 가능 (510*5+210)/5
+        UltimatePsychic = core.DamageSkill("얼티메이트-싸이킥 샷", 1080, 300, 3*5*2*0.8,  modifier = core.CharacterModifier(crit_damage = 20, pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #5, 그랩 1번에 샷 1회 사용가능 (900+210)
         UltimatePsychicBuff = core.BuffSkill("얼티메이트-싸이킥 샷(디버프)", 0, 10000, rem = True, armor_ignore = 15, cooltime = -1).wrap(core.BuffSkillWrapper)
         
         PsychicCharging = core.BuffSkill("싸이킥 차징", 0, 500, cooltime = 45000, red = True).wrap(core.BuffSkillWrapper) #남은포인트의 50%충전
         
-        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 630, 11999 / 17, 180, 6, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 600, 11999 / 17, 180, 6, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
 
         #하이퍼
         EverPsychic = core.DamageSkill("에버 싸이킥", 870, 400, 16, cooltime = 120000).wrap(core.DamageSkillWrapper) # 캔슬 통해 딜레 870ms
@@ -207,7 +207,6 @@ class JobGenerator(ck.JobGenerator):
         PsychicCharging.onConstraint(core.ConstraintElement("5포인트 이하", PsychicPoint, partial(PsychicPoint.judge,5,-1)))
         PsychicCharging.onAfter(PsychicPoint.chargeController())
 
-        UltimateTrain.onConstraint(core.ConstraintElement("싸이킥오버에서만", PsychicOver, PsychicOver.is_active))
         UltimateTrain.onConstraint(core.ConstraintElement("15포인트", PsychicPoint, partial(PsychicPoint.judge_ultimate,15)))
         UltimateTrain.onBefore(PsychicPoint.stackController(-15))
         

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -79,7 +79,7 @@ class JobGenerator(ck.JobGenerator):
         Booster = core.BuffSkill("부스터", 0, 180000).wrap(core.BuffSkillWrapper)
         PsychicShield = core.BuffSkill("사이킥 실드", 0, 180000).wrap(core.BuffSkillWrapper)
 
-        Ultimate_Material = core.DamageSkill("얼티메이트-메테리얼", 600, 700, 10, modifier = core.CharacterModifier(crit_damage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)#   7
+        Ultimate_Material = core.DamageSkill("얼티메이트-메테리얼", 630, 700, 10, modifier = core.CharacterModifier(crit_damage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)#   7
         PsychicDrain = core.SummonSkill("싸이킥 드레인", 510, 500, 150, 1, 10000, cooltime = 5000, rem = False).setV(vEhc, 4, 5, False).wrap(core.SummonSkillWrapper) # 1칸+
         
         PsychicForce3 = core.SummonSkill("싸이킥 포스3", 270, 1000, 75, 1, 20000, rem = False).wrap(core.SummonSkillWrapper)
@@ -90,13 +90,13 @@ class JobGenerator(ck.JobGenerator):
         
         TeleKinesis = core.DamageSkill("텔레키네시스", 0, 350, 0.7).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         UltimateBPM = core.SummonSkill("얼티메이트-B.P.M.", 0, 600, 175, 7, 999999999).setV(vEhc, 0, 2, False).wrap(core.SummonSkillWrapper) #1
-        PsychicGrab2 = core.DamageSkill("싸이킥 그랩", 486, 470, 5,  modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #+2, 그랩 1번에 스매싱 5회 사용 가능 (450*5+180)/5
-        UltimatePsychic = core.DamageSkill("얼티메이트-싸이킥 샷", 660, 300, 3*5*2*0.8,  modifier = core.CharacterModifier(crit_damage = 20, pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #5
+        PsychicGrab2 = core.DamageSkill("싸이킥 그랩", 552, 470, 5,  modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #+2, 그랩 1번에 스매싱 5회 사용 가능 (510*5+210)/5
+        UltimatePsychic = core.DamageSkill("얼티메이트-싸이킥 샷", 1110, 300, 3*5*2*0.8,  modifier = core.CharacterModifier(crit_damage = 20, pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #5, 그랩 1번에 샷 1회 사용가능 (900+210)
         UltimatePsychicBuff = core.BuffSkill("얼티메이트-싸이킥 샷(디버프)", 0, 10000, rem = True, armor_ignore = 15, cooltime = -1).wrap(core.BuffSkillWrapper)
         
         PsychicCharging = core.BuffSkill("싸이킥 차징", 0, 500, cooltime = 45000, red = True).wrap(core.BuffSkillWrapper) #남은포인트의 50%충전
         
-        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 600, 11999 / 17, 180, 6, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 630, 11999 / 17, 180, 6, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
 
         #하이퍼
         EverPsychic = core.DamageSkill("에버 싸이킥", 870, 400, 16, cooltime = 120000).wrap(core.DamageSkillWrapper) # 캔슬 통해 딜레 870ms
@@ -117,7 +117,7 @@ class JobGenerator(ck.JobGenerator):
         UltimateMovingMatter = core.SummonSkill("얼티메이트-무빙 매터", 480, 25000/64, 500+20*vEhc.getV(0,0), 5, 25000, cooltime = 90000, modifier = core.CharacterModifier(crit_damage=20)).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)# -10
         UltimateMovingMatterFinal = core.DamageSkill("얼티메이트-무빙 매터(최종)", 0, 700+28*vEhc.getV(0,0), 12).wrap(core.DamageSkillWrapper)
         
-        UltimatePsychicBullet = core.DamageSkill("얼티메이트-싸이킥 불릿", 600, 550 + 22*vEhc.getV(3,3), 6, modifier = core.CharacterModifier(crit_damage=20)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)# -2, 딜레이 420ms + 그랩 180ms
+        UltimatePsychicBullet = core.DamageSkill("얼티메이트-싸이킥 불릿", 630, 550 + 22*vEhc.getV(3,3), 6, modifier = core.CharacterModifier(crit_damage=20)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)# -2, 딜레이 420ms + 그랩 210ms
         UltimatePsychicBulletBlackhole = core.SummonSkill("얼티메이트-싸이킥 불릿(블랙홀)", 0, 500, 500+20*vEhc.getV(3,3), 3, 500*4, cooltime = -1).isV(vEhc,3,3).wrap(core.SummonSkillWrapper)# +1
         
         PsychicPoint = core.StackSkillWrapper(core.BuffSkill("싸이킥 포인트", 0, 999999999), 30 + 10) # Issue 43 ; maximum point may 40
@@ -193,7 +193,7 @@ class JobGenerator(ck.JobGenerator):
                     PsycoBreak, UltimatePsychicBuff, PsychicCharging, 
                     PsychicOver, OverloadMana, PsychicPoint,
                     globalSkill.soul_contract()] +\
-                [EverPsychic, UltimatePsychic] +\
+                [EverPsychic, Ultimate_Material, UltimatePsychic] +\
                 [PsychicDrain, PsychicForce3, UltimateBPM, PsychicOverSummon, PsychicTornado, UltimateMovingMatter] +\
-                [Ultimate_Material, UltimateTrain] +\
+                [UltimateTrain] +\
                 [PsychicGrab2])

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -144,7 +144,6 @@ class JobGenerator(ck.JobGenerator):
         
         
         ### Psychic point
-        Ultimate_Material.onConstraint(core.ConstraintElement("싸이킥오버에서만", PsychicOver, PsychicOver.is_active))
         Ultimate_Material.onConstraint(core.ConstraintElement("7포인트", PsychicPoint, partial(PsychicPoint.judge,7,1)))
         Ultimate_Material.onAfter(PsychicPoint.stackController(-7))
         Ultimate_Material.onAfter(core.OptionalElement(PsychicOver.is_active, PsychicPoint.stackController(4)))
@@ -157,6 +156,7 @@ class JobGenerator(ck.JobGenerator):
         
         UltimateBPM.onTick(PsychicPoint.stackController(-1))
         
+        UltimatePsychic.onConstraint(core.ConstraintElement("디버프 없을때만", UltimatePsychicBuff, UltimatePsychicBuff.is_not_active))
         UltimatePsychic.onConstraint(core.ConstraintElement("5포인트", PsychicPoint, partial(PsychicPoint.judge,5,1)))
         UltimatePsychic.onAfter(PsychicPoint.stackController(-5))
         UltimatePsychic.onAfter(core.OptionalElement(PsychicOver.is_active, PsychicPoint.stackController(3)))
@@ -193,7 +193,7 @@ class JobGenerator(ck.JobGenerator):
                     PsycoBreak, UltimatePsychicBuff, PsychicCharging, 
                     PsychicOver, OverloadMana, PsychicPoint,
                     globalSkill.soul_contract()] +\
-                [EverPsychic, Ultimate_Material, UltimatePsychic] +\
+                [EverPsychic, Ultimate_Material] +\
                 [PsychicDrain, PsychicForce3, UltimateBPM, PsychicOverSummon, PsychicTornado, UltimateMovingMatter] +\
                 [UltimateTrain] +\
                 [PsychicGrab2])

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -33,7 +33,7 @@ class JobGenerator(ck.JobGenerator):
         Inertia2 = core.InformedCharacterModifier("내재 2",att = 10)
         ESPMastery = core.InformedCharacterModifier("ESP 마스터리",crit = 10, stat_main = 40)
         
-        MindEnhance = core.InformedCharacterModifier("감정 강화",patt = 10)
+        MindEnhance = core.InformedCharacterModifier("정신 강화",patt = 10)
         Accurate = core.InformedCharacterModifier("정밀",crit = 20, crit_damage = 20)
         PsychicChargingPassive = core.InformedCharacterModifier("사이킥 차징(패시브)",boss_pdamage = 30)
         PsychicForce3Passive = core.InformedCharacterModifier("사이킥 포스 3(패시브)",att = 10)
@@ -69,6 +69,7 @@ class JobGenerator(ck.JobGenerator):
         BPM 메테리얼 그랩 드레인 트레인 텔레키네시스
         
         싸이킥 샷 히트율 80%, 타수2배 적용.
+        불릿 사용하지 않음.
         '''
         ######   Skill   ######
 
@@ -79,7 +80,7 @@ class JobGenerator(ck.JobGenerator):
         PsychicShield = core.BuffSkill("사이킥 실드", 0, 180000).wrap(core.BuffSkillWrapper)
 
         Ultimate_Material = core.DamageSkill("얼티메이트-메테리얼", 600, 700, 10, modifier = core.CharacterModifier(crit_damage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)#   7
-        PsychicDrain = core.SummonSkill("싸이킥 드레인", 690, 660, 150, 1, 10000, rem = False).setV(vEhc, 4, 5, False).wrap(core.SummonSkillWrapper) # 1칸+
+        PsychicDrain = core.SummonSkill("싸이킥 드레인", 510, 500, 150, 1, 10000, cooltime = 5000, rem = False).setV(vEhc, 4, 5, False).wrap(core.SummonSkillWrapper) # 1칸+
         
         PsychicForce3 = core.SummonSkill("싸이킥 포스3", 270, 1000, 75, 1, 20000, rem = False).wrap(core.SummonSkillWrapper)
         PsychicGround = core.BuffSkill("싸이킥 그라운드2", 270, 20000 + 10000, rem = False, armor_ignore = 10 + 6*1, pdamage_indep = 10 + 3*1).wrap(core.BuffSkillWrapper)
@@ -87,38 +88,36 @@ class JobGenerator(ck.JobGenerator):
         PsycoBreak = core.BuffSkill("싸이코 브레이크", 720, 30000, pdamage_indep = 5 * 2, rem = False).wrap(core.BuffSkillWrapper) #+1
         PsycoBreakDamage = core.DamageSkill("싸이코 브레이크(공격)", 0, 1000, 4).wrap(core.DamageSkillWrapper)
         
-        TeleKinesis = core.DamageSkill("텔레키네시스", 0, 350, 0.7).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
-        UltimateBPM = core.SummonSkill("얼티메이트-B.P.M.", 0, 660, 175, 7, 999999999).setV(vEhc, 0, 2, False).wrap(core.SummonSkillWrapper) #1
-        PsychicGrab2 = core.DamageSkill("싸이킥 그랩", 540, 470, 5,  modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #+2
+        TeleKinesis = core.DamageSkill("텔레키네시스", 0, 350, 0.7).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UltimateBPM = core.SummonSkill("얼티메이트-B.P.M.", 0, 600, 175, 7, 999999999).setV(vEhc, 0, 2, False).wrap(core.SummonSkillWrapper) #1
+        PsychicGrab2 = core.DamageSkill("싸이킥 그랩", 486, 470, 5,  modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #+2, 그랩 1번에 스매싱 5회 사용 가능 (450*5+180)/5
         UltimatePsychic = core.DamageSkill("얼티메이트-싸이킥 샷", 660, 300, 3*5*2*0.8,  modifier = core.CharacterModifier(crit_damage = 20, pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #5
         UltimatePsychicBuff = core.BuffSkill("얼티메이트-싸이킥 샷(디버프)", 0, 10000, rem = True, armor_ignore = 15, cooltime = -1).wrap(core.BuffSkillWrapper)
         
-        PsychicGrab2 = core.DamageSkill("싸이킥 그랩", 540, 470, 5,  modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #+2
-        
         PsychicCharging = core.BuffSkill("싸이킥 차징", 0, 500, cooltime = 45000, red = True).wrap(core.BuffSkillWrapper) #남은포인트의 50%충전
         
-        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 630, 11999 / 17, 180, 4, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 600, 11999 / 17, 220, 6, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
 
         #하이퍼
-        EverPsychic = core.DamageSkill("에버 싸이킥", 870, 400, 16, cooltime = 120000).wrap(core.DamageSkillWrapper) # +30, 캔슬 통해 딜레 870ms
+        EverPsychic = core.DamageSkill("에버 싸이킥", 870, 400, 16, cooltime = 120000).wrap(core.DamageSkillWrapper) # 캔슬 통해 딜레 870ms
         EverPsychicFinal = core.DamageSkill("에버 싸이킥(최종)", 0, 1500, 1,  modifier = core.CharacterModifier(armor_ignore = 50, crit = 100)).wrap(core.DamageSkillWrapper)
         #Psycometry = core.DamageSkill()
         PsychicOver = core.BuffSkill("싸이킥 오버", 0, 30000, cooltime = 210000).wrap(core.BuffSkillWrapper) # 소모량 절반 / 포인트 지속증가(초당 1)
-        PsychicOverSummon = core.SummonSkill("싸이킥 오버(소환)", 0, 1000, 0, 0, 30000, cooltime = -1).wrap(core.SummonSkillWrapper)
+        PsychicOverSummon = core.SummonSkill("싸이킥 오버(소환)", 0, 750, 0, 0, 30000, cooltime = -1).wrap(core.SummonSkillWrapper)
         try:
             OverloadMana = OverloadMana = magicians.OverloadManaWrapper(vEhc, 1, 1)
         except:
             print(vEhc)
             raise
 
-        PsychicTornado = core.SummonSkill("싸이킥 토네이도", 720, 1000, 500+20*vEhc.getV(2,2), 4, 20000, red = True, cooltime = 120000).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)# -15
+        PsychicTornado = core.SummonSkill("싸이킥 토네이도", 540, 1000, 500+20*vEhc.getV(2,2), 4, 20000, red = True, cooltime = 120000).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)# -15
         PsychicTornadoFinal_1 = core.DamageSkill("싸이킥 토네이도(1)", 0, (200+3*vEhc.getV(2,2))*3, 2).wrap(core.DamageSkillWrapper)
-        PsychicTornadoFinal_2 = core.DamageSkill("싸이킥 토네이도(2)", 0, (350+10*vEhc.getV(2,2))*3, 6*3).wrap(core.DamageSkillWrapper)
+        PsychicTornadoFinal_2 = core.DamageSkill("싸이킥 토네이도(2)", 0, (350+10*vEhc.getV(2,2))*3, 10*3).wrap(core.DamageSkillWrapper)
 
-        UltimateMovingMatter = core.SummonSkill("얼티메이트-무빙 매터", 630, 25000/64, 500+20*vEhc.getV(0,0), 5, 25000, cooltime = 90000, modifier = core.CharacterModifier(crit_damage=20)).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)# -10
+        UltimateMovingMatter = core.SummonSkill("얼티메이트-무빙 매터", 480, 25000/64, 500+20*vEhc.getV(0,0), 5, 25000, cooltime = 90000, modifier = core.CharacterModifier(crit_damage=20)).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)# -10
         UltimateMovingMatterFinal = core.DamageSkill("얼티메이트-무빙 매터(최종)", 0, 700+28*vEhc.getV(0,0), 12).wrap(core.DamageSkillWrapper)
         
-        UltimatePsychicBullet = core.DamageSkill("얼티메이트-싸이킥 불릿", 570, 550 + 22*vEhc.getV(3,3), 6, modifier = core.CharacterModifier(crit_damage=20)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)# -2
+        UltimatePsychicBullet = core.DamageSkill("얼티메이트-싸이킥 불릿", 600, 550 + 22*vEhc.getV(3,3), 6, modifier = core.CharacterModifier(crit_damage=20)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)# -2, 딜레이 420ms + 그랩 180ms
         UltimatePsychicBulletBlackhole = core.SummonSkill("얼티메이트-싸이킥 불릿(블랙홀)", 0, 500, 500+20*vEhc.getV(3,3), 3, 500*4, cooltime = -1).isV(vEhc,3,3).wrap(core.SummonSkillWrapper)# +1
         
         PsychicPoint = core.StackSkillWrapper(core.BuffSkill("싸이킥 포인트", 0, 999999999), 30 + 10) # Issue 43 ; maximum point may 40
@@ -145,8 +144,10 @@ class JobGenerator(ck.JobGenerator):
         
         
         ### Psychic point
+        Ultimate_Material.onConstraint(core.ConstraintElement("싸이킥오버에서만", PsychicOver, PsychicOver.is_active))
         Ultimate_Material.onConstraint(core.ConstraintElement("7포인트", PsychicPoint, partial(PsychicPoint.judge,7,1)))
         Ultimate_Material.onAfter(PsychicPoint.stackController(-7))
+        Ultimate_Material.onAfter(core.OptionalElement(PsychicOver.is_active, PsychicPoint.stackController(4)))
         
         PsychicForce3.onAfter(PsychicPoint.stackController(1))
         
@@ -193,6 +194,6 @@ class JobGenerator(ck.JobGenerator):
                     PsychicOver, OverloadMana, PsychicPoint,
                     globalSkill.soul_contract()] +\
                 [EverPsychic, UltimatePsychic] +\
-                [PsychicDrain, PsychicForce3, UltimateBPM, PsychicOverSummon, PsychicTornado, UltimateMovingMatter, UltimatePsychicBulletBlackhole] +\
-                [UltimateTrain] +\
+                [PsychicDrain, PsychicForce3, UltimateBPM, PsychicOverSummon, PsychicTornado, UltimateMovingMatter] +\
+                [Ultimate_Material, UltimateTrain] +\
                 [PsychicGrab2])

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -120,14 +120,14 @@ class JobGenerator(ck.JobGenerator):
         PsycoBreakDamage = core.DamageSkill("싸이코 브레이크(공격)", 0, 1000, 4).wrap(core.DamageSkillWrapper)
         
         TeleKinesis = core.DamageSkill("텔레키네시스", 0, 350, 0.7).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        UltimateBPM = core.SummonSkill("얼티메이트-B.P.M.", 0, 600, 175, 7, 999999999).setV(vEhc, 0, 2, False).wrap(core.SummonSkillWrapper) #1
+        UltimateBPM = core.SummonSkill("얼티메이트-B.P.M.", 0, 600, 175, 7, 999999999, modifier = core.CharacterModifier(crit_damage = 20)).setV(vEhc, 0, 2, False).wrap(core.SummonSkillWrapper) #1
         PsychicGrab2 = core.DamageSkill("싸이킥 그랩", 576, 470, 5,  modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #+2, 그랩 1번에 스매싱 5회 사용 가능 (510*5+210)/5
         UltimatePsychic = core.DamageSkill("얼티메이트-싸이킥 샷", 1080, 300, 3*5*2*0.8,  modifier = core.CharacterModifier(crit_damage = 20, pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) #5, 그랩 1번에 샷 1회 사용가능 (900+210)
         UltimatePsychicBuff = core.BuffSkill("얼티메이트-싸이킥 샷(디버프)", 0, 10000, rem = True, armor_ignore = 15, cooltime = -1).wrap(core.BuffSkillWrapper)
         
         PsychicCharging = core.BuffSkill("싸이킥 차징", 0, 500, cooltime = 45000, red = True).wrap(core.BuffSkillWrapper) #남은포인트의 50%충전
         
-        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 600, 11999 / 17, 180, 6, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 600, 11999 / 17, 180, 6, 12000, modifier = core.CharacterModifier(crit_damage = 20)).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
 
         #하이퍼
         EverPsychic = core.DamageSkill("에버 싸이킥", 870, 400, 16, cooltime = 120000).wrap(core.DamageSkillWrapper) # 캔슬 통해 딜레 870ms
@@ -174,6 +174,7 @@ class JobGenerator(ck.JobGenerator):
         
         ### Psychic point
         Ultimate_Material.onConstraint(core.ConstraintElement("7포인트", PsychicPoint, partial(PsychicPoint.judge_ultimate,7)))
+        Ultimate_Material.onConstraint(core.ConstraintElement("트레인 깔려있으면", UltimateTrain, partial(UltimateTrain.is_time_left, 0, 1)))
         Ultimate_Material.onBefore(PsychicPoint.stackController(-7))
         
         PsychicForce3.onBefore(PsychicPoint.stackController(1))

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -96,7 +96,7 @@ class JobGenerator(ck.JobGenerator):
         
         PsychicCharging = core.BuffSkill("싸이킥 차징", 0, 500, cooltime = 45000, red = True).wrap(core.BuffSkillWrapper) #남은포인트의 50%충전
         
-        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 600, 11999 / 17, 220, 6, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        UltimateTrain = core.SummonSkill("얼티메이트-트레인", 600, 11999 / 17, 180, 6, 12000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
 
         #하이퍼
         EverPsychic = core.DamageSkill("에버 싸이킥", 870, 400, 16, cooltime = 120000).wrap(core.DamageSkillWrapper) # 캔슬 통해 딜레 870ms


### PR DESCRIPTION
### 스킬 정보 관련

실측 기반으로 일괄 수정

* 싸이킥 드레인 시전딜레이, 공격주기 수정
* 싸이킥 그랩 공격주기 수정, 그랩으로 인한 지연 고려
* 불릿 딜레이 수정, 그랩으로 인한 지연 고려
* 얼티메이트-트레인 딜레이, 공격 횟수 수정
* BPM 공격주기 수정
* 싸이킥 오버 pp 차오르는 주기 수정
* 싸이킥 토네이도 딜레이 수정
* 싸이킥 토네이도 막타 타수 수정
* 싸이킥 토네이도 폭발이 20초 후 이뤄지도록 함
* 무빙매터 딜레이 수정
* 텔레키네시스 코강당 3% 증가로 수정
* 얼티메이트-BPM, 트레인에 크뎀 20퍼 빠진것 수정

### pp 관련

* 싸이킥 오버 상태에서의 메테리얼 pp소모 수정
* 싸이킥 오버 상태에서의 얼티메이트 스킬 사용 가능 여부 정확하게 판정
* pp 변동은 스킬의 딜레이가 끝난 후가 아닌 스킬 사용 시점이므로, onBefore으로 일괄 변경
* 싸이킥 차지의 충전량 정확하게 변경

### 딜사이클 관련

* 샷을 아예 안쓰고 메테리얼만 쓰는게 더 셈
* 트레인은 싸이킥 오버가 아닐때도 계속해서 쓰는게 더 셈
* 트레인을 곧 써야하면 메테리얼 안쓰고 기다림

### 기타

* 패시브 이름 수정
* 에버싸이킥 코드와 다른 주석 제거