### PR TITLE
BuffSkill에 modifier 입력기능 추가, 제로 알파베타 패시브 정리

### DIFF
--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -62,13 +62,16 @@ class JobGenerator(ck.JobGenerator):
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 2
 
+        self.Alpha = core.CharacterModifier(pdamage_indep = 34, crit = 40, att = 40, armor_ignore = 30, crit_damage = 50)
+        self.Beta = core.CharacterModifier(pdamage_indep = 49, crit = 15, boss_pdamage = 30, att = 80)
+
     def get_passive_skill_list(self):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
 
         ResolutionTime = core.InformedCharacterModifier("리졸브 타임",pdamage_indep = 25, stat_main = 50)
         
         # 무기상수 1.34
-        AlphaState = core.InformedCharacterModifier("상태-알파", pdamage_indep = 34, crit = 40, att = 40, armor_ignore = 30, crit_damage = 50)
+        AlphaState = core.InformedCharacterModifier("상태-알파") + self.Alpha
         #4카5앱 옵션을 직접 작성할 경우를 가정하여...
         #VellumHelm = core.InformedCharacterModifier("카오스 벨룸의 헬름(4카 5앱)",boss_pdamage = 30, armor_ignore = -10)
 
@@ -103,25 +106,10 @@ class JobGenerator(ck.JobGenerator):
         어파스 기준
         '''
         #### 마스터리 ####
-        AlphaMastery = core.CharacterModifier(pdamage_indep = 34) + \
-            core.CharacterModifier(att = 40, armor_ignore = 30) + \
-            core.CharacterModifier(crit = 40) + \
-            core.CharacterModifier(crit_damage = 50)
-        BetaMastery = core.CharacterModifier(pdamage_indep = 49) + \
-                    core.CharacterModifier(crit = 15, boss_pdamage = 30, att = 80)
 
-        AlphaBetaDiff = BetaMastery - AlphaMastery
-        
         # 알파: 크리티컬 바인드 크뎀 평균값 적용
-        AlphaState = core.BuffSkill("상태-알파", 0, 9999*10000, cooltime = -1, crit_damage = (20*4/35)).wrap(core.BuffSkillWrapper)
-        BetaState = core.BuffSkill("상태-베타", 0, 9999*10000, cooltime = -1,
-            pdamage_indep = AlphaBetaDiff.pdamage_indep,
-            crit = AlphaBetaDiff.crit,
-            boss_pdamage = AlphaBetaDiff.boss_pdamage,
-            att = AlphaBetaDiff.att,
-            armor_ignore = AlphaBetaDiff.armor_ignore,
-            crit_damage = AlphaBetaDiff.crit_damage
-        ).wrap(core.BuffSkillWrapper)
+        AlphaState = core.BuffSkill("상태-알파", 0, 9999*10000, cooltime = -1, modifier = self.Alpha, crit_damage = (20*4/35)).wrap(core.BuffSkillWrapper)
+        BetaState = core.BuffSkill("상태-베타", 0, 9999*10000, cooltime = -1, modifier = self.Beta - self.Alpha).wrap(core.BuffSkillWrapper)
 
         #### 알파 ####
         MoonStrike = core.DamageSkill("문 스트라이크", 390, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
@@ -219,7 +207,8 @@ class JobGenerator(ck.JobGenerator):
         
         LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*vEhc.getV(0,0), 5, modifier = beta_enrage(15, -1)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         # 리미트 브레이크 중에는 디바인 포스 사용 (공격력 20 증가)
-        LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+vEhc.getV(0,0)//2)*1000, pdamage_indep = (30+vEhc.getV(0,0)//5) *1.2 + 20, att = 20, cooltime = 240*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        # 막타로 들어가는 딜을 임시로 버프에 통합
+        LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+vEhc.getV(0,0)//2)*1000, modifier = (core.CharacterModifier(pdamage_indep = 30+vEhc.getV(0,0)//5) + core.CharacterModifier(pdamage_indep = 20)), att = 20, cooltime = 240*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         
         #LimitBreakFinal = core.DamageSkill("리미트 브레이크 (막타)", 0, '''지속시간 동안 가한 데미지의 20% / 15''', 15)
         # 베타로 사용함.

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -108,7 +108,7 @@ class JobGenerator(ck.JobGenerator):
         #### 마스터리 ####
 
         # 알파: 크리티컬 바인드 크뎀 평균값 적용
-        AlphaState = core.BuffSkill("상태-알파", 0, 9999*10000, cooltime = -1, modifier = self.Alpha, crit_damage = (20*4/35)).wrap(core.BuffSkillWrapper)
+        AlphaState = core.BuffSkill("상태-알파", 0, 9999*10000, cooltime = -1, crit_damage = (20*4/35)).wrap(core.BuffSkillWrapper)
         BetaState = core.BuffSkill("상태-베타", 0, 9999*10000, cooltime = -1, modifier = self.Beta - self.Alpha).wrap(core.BuffSkillWrapper)
 
         #### 알파 ####

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -62,8 +62,9 @@ class JobGenerator(ck.JobGenerator):
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 2
 
+        # 베타 상태일때 무기 공격력 +4
         self.Alpha = core.CharacterModifier(pdamage_indep = 34, crit = 40, att = 40, armor_ignore = 30, crit_damage = 50)
-        self.Beta = core.CharacterModifier(pdamage_indep = 49, crit = 15, boss_pdamage = 30, att = 80)
+        self.Beta = core.CharacterModifier(pdamage_indep = 49, crit = 15, boss_pdamage = 30, att = 80 + 4)
 
     def get_passive_skill_list(self):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -484,13 +484,14 @@ class BuffSkill(AbstractSkill):
       .get_modifier() : returns CharacterModifier for Character.
     
     '''
-    def __init__(self, name, delay, remain,  cooltime = 0, crit = 0, crit_damage = 0, pdamage = 0, stat_main = 0, stat_sub = 0, pstat_main = 0, pstat_sub = 0, boss_pdamage = 0, pdamage_indep = 0, armor_ignore = 0, patt = 0, att = 0, stat_main_fixed = 0, stat_sub_fixed = 0, rem = False, red = False):
+    def __init__(self, name, delay, remain,  cooltime = 0, crit = 0, crit_damage = 0, pdamage = 0, stat_main = 0, stat_sub = 0, pstat_main = 0, pstat_sub = 0, boss_pdamage = 0, pdamage_indep = 0, armor_ignore = 0, patt = 0, att = 0, stat_main_fixed = 0, stat_sub_fixed = 0, rem = False, red = False, modifier = CharacterModifier()):
         super(BuffSkill, self).__init__(name, delay, cooltime = cooltime, rem = rem, red = red)
         with self.dynamic_range():
             self.spec = "buff"
             self.remain = remain
             #Build StaticModifier from given arguments
             self.static_character_modifier = CharacterModifier(crit = crit, crit_damage = crit_damage, pdamage = pdamage, pdamage_indep = pdamage_indep, stat_main = stat_main, stat_sub = stat_sub, pstat_main = pstat_main, pstat_sub = pstat_sub, boss_pdamage = boss_pdamage, armor_ignore = armor_ignore, patt = patt, att = att, stat_main_fixed = stat_main_fixed, stat_sub_fixed = stat_sub_fixed)
+            self.static_character_modifier += modifier
 
     def _get_explanation_internal(self, detail = False, lang = "ko", expl_level = 2):
         if lang == "ko":


### PR DESCRIPTION
"상태-알파"와 "상태-베타"를 시작할 때 정의해놓고 필요할 때 갖다 쓰는 방식으로 바꿨습니다.

기존의 BuffSkill에 CharacterModifier를 직접 집어넣는 게 불가능해서 이번에 고치면서 추가했습니다. 이중으로 계산해야 되는 버프들의 코드를 단순화시킬 수 있을 것입니다.