### PR TITLE
fix: 섀도어 스킬

### DIFF
--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -11,13 +11,13 @@ class MesoStack(core.DamageSkillWrapper, core.StackSkillWrapper):
     # 메익 리인포스 미적용 기준
     def __init__(self, vEhc):
         self.vEhc = vEhc
-        skill = core.DamageSkill("메소 익스플로전", 0, 100, 2).setV(vEhc, 2, 3, False)
+        skill = core.DamageSkill("메소 익스플로전", 0, 120, 2).setV(vEhc, 2, 3, False)
         super(core.DamageSkillWrapper, self).__init__(skill, 20)
         self.modifierInvariantFlag = False
         
     def _use(self, rem = 0, red = 0):
         mdf = self.skill.get_modifier()
-        dmg = 100
+        dmg = 120
         stack = self.stack
         self.stack = 0
         # 확인 필요
@@ -90,11 +90,10 @@ class JobGenerator(ck.JobGenerator):
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 200*1000).wrap(core.BuffSkillWrapper)
         FlipTheCoin = core.BuffSkill("플립 더 코인", 0, 24000, pdamage = 5*5, crit = 10*5).wrap(core.BuffSkillWrapper)
-        ShadowerInstinct = core.BuffSkill("섀도어 인스팅트", 0, 200*1000, rem = True, att = 40+30).wrap(core.BuffSkillWrapper)
+        ShadowerInstinct = core.BuffSkill("섀도어 인스팅트", 900, 200*1000, rem = True, att = 40+30).wrap(core.BuffSkillWrapper)
         #StealPotion = core.BuffSkill("스틸 (포션)", 0, 180000, cooltime = -1, att = 30).wrap(core.BuffSkillWrapper)
         
-        # 더미 데이터
-        ShadowPartner = core.BuffSkill("섀도우 파트너", 1000, 2000*1000, rem = True).wrap(core.BuffSkillWrapper)
+        ShadowPartner = core.BuffSkill("섀도우 파트너", 0, 2000*1000, rem = True).wrap(core.BuffSkillWrapper)
         
         #킬포3개 사용시 최종뎀 100% 증가.
         Assasinate1 = core.DamageSkill("암살(1타)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타")   #쉐파
@@ -103,11 +102,11 @@ class JobGenerator(ck.JobGenerator):
         Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
         Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 420, 350, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
         
-        BailOfShadow = core.SummonSkill("베일 오브 섀도우", 1080, 12000 / 14, 800, 1, 12*1000, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
+        BailOfShadow = core.SummonSkill("베일 오브 섀도우", 1080 + 100, 12000 / 14, 800, 1, 12*1000, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper) # 다크 사이트 딜레이 합산
 
         DarkFlare = core.SummonSkill("다크 플레어", 600, 60000 / 62, 360, 1, 60*1000, cooltime = 60000).setV(vEhc, 1, 3, False).wrap(core.SummonSkillWrapper)
     
-        Smoke = core.BuffSkill("연막탄", 1080, 30000, cooltime = 150000, crit_damage = 20).wrap(core.BuffSkillWrapper)
+        Smoke = core.BuffSkill("연막탄", 1080 + 100, 30000, cooltime = 150000, crit_damage = 20).wrap(core.BuffSkillWrapper) # 다크 사이트 딜레이 합산
         Venom = core.DotSkill("페이탈 베놈", 480, 89999 * 1000).wrap(core.SummonSkillWrapper)
         
         AdvancedDarkSight = core.BuffSkill("어드밴스드 다크 사이트", 0, 10000, cooltime = -1, pdamage_indep = 5).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -104,7 +104,7 @@ class JobGenerator(ck.JobGenerator):
         Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
         Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 630+30, 350, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
         
-        BailOfShadow = core.DamageSkill("베일 오브 섀도우", 810, 800, 15, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        BailOfShadow = core.SummonSkill("베일 오브 섀도우", 810, 12000 / 14, 800, 1, 12*1000, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
         
     
         Smoke = core.BuffSkill("연막탄", 1080, 30000, cooltime = 150000, crit_damage = 20).wrap(core.BuffSkillWrapper)
@@ -159,7 +159,7 @@ class JobGenerator(ck.JobGenerator):
         UltimateDarksight.onAfter(AdvancedDarkSight.controller(30000,"set_enabled_and_time_left" ))
         
         SonicBlowTick.onAfter(MesoExplosion.stackController(14*2*0.4, name = "메소 생성"))
-        SonicBlow.onAfter(core.RepeatElement(SonicBlowTick, 20))
+        SonicBlow.onAfter(core.RepeatElement(SonicBlowTick, 15))
         
         Eviscerate.onAfter(MesoExplosion.stackController(14*2*0.4, name = "메소 생성"))
         

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -74,7 +74,7 @@ class JobGenerator(ck.JobGenerator):
         하이퍼 : 메익 인핸스, 암살 리인포스 / 보킬 / 이그노어 가드.
         
         킬링 포인트 3스택 확률 1타 94.6% / 2타 100%
-        암살-부스-익플-배오섀
+        암살-닼플-메익-배오섀
         '''
         
         ######   Skill   ######
@@ -103,8 +103,9 @@ class JobGenerator(ck.JobGenerator):
         Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
         Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 420, 350, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
         
-        BailOfShadow = core.SummonSkill("베일 오브 섀도우", 810, 12000 / 14, 800, 1, 12*1000, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
-        
+        BailOfShadow = core.SummonSkill("베일 오브 섀도우", 1080, 12000 / 14, 800, 1, 12*1000, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
+
+        DarkFlare = core.SummonSkill("다크 플레어", 600, 60000 / 62, 360, 1, 60*1000, cooltime = 60000).setV(vEhc, 1, 3, False).wrap(core.SummonSkillWrapper)
     
         Smoke = core.BuffSkill("연막탄", 1080, 30000, cooltime = 150000, crit_damage = 20).wrap(core.BuffSkillWrapper)
         Venom = core.DotSkill("페이탈 베놈", 480, 89999 * 1000).wrap(core.SummonSkillWrapper)
@@ -176,7 +177,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
                     Booster, FlipTheCoin, ShadowerInstinct, ShadowPartner, Smoke, AdvancedDarkSight, EpicAdventure, UltimateDarksight, 
                         ReadyToDie, globalSkill.soul_contract()] +\
-                [Eviscerate, SonicBlow, BailOfShadow]+\
+                [Eviscerate, SonicBlow, BailOfShadow, DarkFlare]+\
                 [Venom]+\
                 []+\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -102,11 +102,11 @@ class JobGenerator(ck.JobGenerator):
         Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
         Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 420, 350, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
         
-        BailOfShadow = core.SummonSkill("베일 오브 섀도우", 1080 + 100, 12000 / 14, 800, 1, 12*1000, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper) # 다크 사이트 딜레이 합산
+        BailOfShadow = core.SummonSkill("베일 오브 섀도우", 1080 + 120, 12000 / 14, 800, 1, 12*1000, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper) # 다크 사이트 딜레이 합산
 
         DarkFlare = core.SummonSkill("다크 플레어", 600, 60000 / 62, 360, 1, 60*1000, cooltime = 60000).setV(vEhc, 1, 3, False).wrap(core.SummonSkillWrapper)
     
-        Smoke = core.BuffSkill("연막탄", 1080 + 100, 30000, cooltime = 150000, crit_damage = 20).wrap(core.BuffSkillWrapper) # 다크 사이트 딜레이 합산
+        Smoke = core.BuffSkill("연막탄", 1080 + 120, 30000, cooltime = 150000, crit_damage = 20).wrap(core.BuffSkillWrapper) # 다크 사이트 딜레이 합산
         Venom = core.DotSkill("페이탈 베놈", 480, 89999 * 1000).wrap(core.SummonSkillWrapper)
         
         AdvancedDarkSight = core.BuffSkill("어드밴스드 다크 사이트", 0, 10000, cooltime = -1, pdamage_indep = 5).wrap(core.BuffSkillWrapper)
@@ -125,7 +125,7 @@ class JobGenerator(ck.JobGenerator):
 
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 2, 2)
         
-        Eviscerate = core.DamageSkill("절개", 570, 1900+76*vEhc.getV(0,0), 7, modifier = core.CharacterModifier(crit=100, armor_ignore=100), cooltime = 14000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        Eviscerate = core.DamageSkill("절개", 570, 1900+76*vEhc.getV(0,0), 7, modifier = core.CharacterModifier(crit=100, armor_ignore=100), cooltime = 14000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 720ms - 150ms(암살 2타연계)
 		
 		# 1.2.324 패치 적용
         SonicBlow = core.DamageSkill("소닉 블로우", 900, 0, 0, cooltime = 80 * 1000).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -45,7 +45,7 @@ class JobGenerator(ck.JobGenerator):
         Grid = core.InformedCharacterModifier("그리드",att = 5)
         
         PrimaCriticalPassive = core.InformedCharacterModifier("프리마 크리티컬(패시브)",stat_main = 10, crit_damage = 20)
-        PrimaCritical = core.InformedCharacterModifier("프리마 크리티컬",crit = 53.8 / 4, crit_damage = 8.8) #스택식으로도 계산 가능.
+        PrimaCritical = core.InformedCharacterModifier("프리마 크리티컬", crit_damage = 8.8) #스택식으로도 계산 가능.
         
         BoomerangStepPassive = core.InformedCharacterModifier("부메랑 스텝(패시브)",pdamage_indep = 25)
         
@@ -68,8 +68,7 @@ class JobGenerator(ck.JobGenerator):
         '''
         일반 다크사이트는 깡으로 사용하지 않음.
         
-        프리마 크리티컬 : 6/12/18/24/30/36/42/48/... / 96/100 -> 53.8
-        크뎀 : 8.8
+        프리마 크리티컬 크뎀 : 8.8%
         쉐도우 파트너는 절개, 암살, 소닉 블로우에만 적용.
         
         하이퍼 : 메익 인핸스, 암살 리인포스 / 보킬 / 이그노어 가드.
@@ -152,7 +151,7 @@ class JobGenerator(ck.JobGenerator):
         Assasinate1_D.onAfter(Assasinate2_D)
         
         BailOfShadow.onConstraint(DarkSightTurnedOn)
-        BailOfShadow.onAfter(MesoExplosion.stackController(15*2*0.4, name = "메소 생성"))
+        BailOfShadow.onTick(MesoExplosion.stackController(0.4, name = "메소 생성"))
         BailOfShadow.onAfter(AdvancedDarkSight.controller(12000, "set_enabled_and_time_left"))
         
         Smoke.onConstraint(DarkSightTurnedOn)
@@ -161,10 +160,10 @@ class JobGenerator(ck.JobGenerator):
         UltimateDarksight.onConstraint(DarkSightTurnedOn)
         UltimateDarksight.onAfter(AdvancedDarkSight.controller(30000,"set_enabled_and_time_left" ))
         
-        SonicBlowTick.onAfter(MesoExplosion.stackController(14*2*0.4, name = "메소 생성"))
+        SonicBlowTick.onAfter(MesoExplosion.stackController(7*2*0.4, name = "메소 생성"))
         SonicBlow.onAfter(core.RepeatElement(SonicBlowTick, 15))
         
-        Eviscerate.onAfter(MesoExplosion.stackController(14*2*0.4, name = "메소 생성"))
+        Eviscerate.onAfter(MesoExplosion.stackController(7*2*0.4, name = "메소 생성"))
         
         Assasinate = core.OptionalElement(AdvancedDarkSight.is_active, Assasinate1_D, Assasinate1, name = "닼사 여부")
         BasicAttackWrapper = core.DamageSkill('기본 공격',0,0,0).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -70,11 +70,11 @@ class JobGenerator(ck.JobGenerator):
         
         프리마 크리티컬 : 6/12/18/24/30/36/42/48/... / 96/100 -> 53.8
         크뎀 : 8.8
-        쉐도우 파트너는 절개와 암살에만 적용.
+        쉐도우 파트너는 절개, 암살, 소닉 블로우에만 적용.
         
         하이퍼 : 메익 인핸스, 암살 리인포스 / 보킬 / 이그노어 가드.
         
-        암살 1타 3스택 19% / 2타 80%
+        킬링 포인트 3스택 확률 1타 94.6% / 2타 100%
         암살-부스-익플-배오섀
         '''
         
@@ -99,10 +99,10 @@ class JobGenerator(ck.JobGenerator):
         
         #킬포3개 사용시 최종뎀 100% 증가.
         Assasinate1 = core.DamageSkill("암살(1타)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타")   #쉐파
-        Assasinate2 = core.DamageSkill("암살(2타)", 630+30, 350, 6, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타")   #쉐파
+        Assasinate2 = core.DamageSkill("암살(2타)", 420, 350, 6, modifier = core.CharacterModifier(pdamage=20, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타")   #쉐파
         
         Assasinate1_D = core.DamageSkill("암살(1타)(다크사이트)", 630, 275, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK1RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 1타(닼사)")   #쉐파
-        Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 630+30, 350, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
+        Assasinate2_D = core.DamageSkill("암살(2타)(다크사이트)", 420, 350, 6, modifier = core.CharacterModifier(pdamage=20+150, boss_pdamage = 20, armor_ignore = 10, pdamage_indep = STACK2RATE)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper, name = "암살 2타(닼사)")   #쉐파
         
         BailOfShadow = core.SummonSkill("베일 오브 섀도우", 810, 12000 / 14, 800, 1, 12*1000, cooltime = 60000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
         
@@ -119,15 +119,18 @@ class JobGenerator(ck.JobGenerator):
         '''
         #_VenomBurst = core.DamageSkill("베놈 버스트", ??) ## 패시브 50%확률로 10초간 160+6*vlevel dot. 사용시 도트뎀 모두 피해 + (500+20*vlevel) * 5. 어차피 안쓰는 스킬이므로 작성X
         
-        UltimateDarksight = thieves.UltimateDarkSightWrapper(vEhc, 3, 3, 5)
-        #UltimateDarksight = core.BuffSkill("얼티밋 다크사이트", 750, 30000, cooltime = (220-vEhc.getV(3,3))*1000, pdamage_indep = (10 + int(0.2*vEhc.getV(3,3))/1.05 )).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
+        UltimateDarksight = core.BuffSkill("얼티밋 다크 사이트", 750, 30000,
+            cooltime = (220-vEhc.getV(3, 3))*1000,
+            pdamage_indep= (100 + 10 + 5 + vEhc.getV(3, 3)//5) / (100 + 5) * 100 - 100 # (얼닼사 + 어닼사) - (어닼사) 최종뎀 연산
+        ).isV(vEhc, 3, 3).wrap(core.BuffSkillWrapper)
+
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 2, 2)
         
         Eviscerate = core.DamageSkill("절개", 570, 1900+76*vEhc.getV(0,0), 7, modifier = core.CharacterModifier(crit=100, armor_ignore=100), cooltime = 14000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
 		
 		# 1.2.324 패치 적용
         SonicBlow = core.DamageSkill("소닉 블로우", 900, 0, 0, cooltime = 80 * 1000).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
-        SonicBlowTick = core.DamageSkill("소닉 블로우(틱)", 125, 500+20*vEhc.getV(1,1), 7, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper, name = "소닉 블로우(사용)")#20타
+        SonicBlowTick = core.DamageSkill("소닉 블로우(틱)", 107, 500+20*vEhc.getV(1,1), 7, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper, name = "소닉 블로우(사용)") # 7 * 15
         
         ### build graph relationships
         def isNotDarkSight():


### PR DESCRIPTION
* 소블 7\*2\*20타에서 7\*2\*15타로 수정
* 배오섀 14타로 적용, 소환 스킬로 변경
* 암살 2타 딜레이 클라와 맞게 변경
* 얼닼사 최종뎀이 어닼사와 합연산 정확히 되도록 함
* 소닉 블로우가 준비 딜레이를 포함해 2.5초가 되도록 조정
* docstring 현 로직과 동일하게 수정
* 픽파킷 개수 스킬 타수와 쉐파 고려해 정확히 적용
* 프리마 크리티컬의 크확을 생각해 크확100 안맞추는 경우는 없을 것이므로 크확 제거
* 배오섀 시전 딜레이 수정 (공속 영향 안받음)
* 딜사이클에 다크 플레어 추가
* 쉐파는 펫버프로 사용, 인스팅트는 직접 발동
* 배오섀, 연막탄은 닼사를 이어서 사용하므로 닼사 딜레이 합산
* 메익 퍼뎀이 그리드 패시브로 인해 120%*2로 되는것 반영
* 다크 사이트 딜레이 120ms로 수정

fix https://github.com/oleneyl/maplestory_dpm_calc/issues/170