### PR TITLE
fix: 듀얼블레이드 보조무기에 방무보공 안들어가게

### DIFF
--- a/dpmModule/item/Absolab.py
+++ b/dpmModule/item/Absolab.py
@@ -90,10 +90,14 @@ class Factory():
         return package
     
     @staticmethod
-    def getWeapon(_type, star = 0, elist = [0,0,0,9], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusAttIndex = 0, bonusElse = it.CharacterModifier(), enable_blade=False):
+    def getWeapon(_type, star = 0, elist = [0,0,0,9], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusAttIndex = 0, bonusElse = it.CharacterModifier()):
         
-        return WeaponFactory.getWeapon(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusAttIndex = bonusAttIndex, bonusElse = bonusElse, enable_blade=enable_blade)
+        return WeaponFactory.getWeapon(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusAttIndex = bonusAttIndex, bonusElse = bonusElse)
 
+    @staticmethod
+    def getBlade(_type, star = 0, elist = [0,0,0,0], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusElse = it.CharacterModifier()):
+
+        return WeaponFactory.getBlade(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
     
     @staticmethod
     def getSetOption(rank):

--- a/dpmModule/item/Arcane.py
+++ b/dpmModule/item/Arcane.py
@@ -86,10 +86,14 @@ class Factory():
         return package
     
     @staticmethod
-    def getWeapon(_type, star = 0, elist = [0,0,0,9], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusAttIndex = 0, bonusElse = it.CharacterModifier(), enable_blade=False):
+    def getWeapon(_type, star = 0, elist = [0,0,0,9], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusAttIndex = 0, bonusElse = it.CharacterModifier()):
         
-        return WeaponFactory.getWeapon(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusAttIndex = bonusAttIndex, bonusElse = bonusElse, enable_blade=enable_blade)
+        return WeaponFactory.getWeapon(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusAttIndex = bonusAttIndex, bonusElse = bonusElse)
 
+    @staticmethod
+    def getBlade(_type, star = 0, elist = [0,0,0,0], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusElse = it.CharacterModifier()):
+
+        return WeaponFactory.getBlade(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
     
     @staticmethod
     def getSetOption(rank):

--- a/dpmModule/item/Default.py
+++ b/dpmModule/item/Default.py
@@ -24,7 +24,7 @@ def getEmblem(potential = it.CharacterModifier(), additional_potential = it.Char
     return item
 
 def get_subweapon_covering_exception(_type, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), factory_hook=None, star=17):
-    if _type != '블레이드':
-        return getSubweapon(potential=potential, additional_potential=additional_potential)
+    if _type == '블레이드':
+        return factory_hook.getBlade(_type, star=star, potential = potential, additional_potential = additional_potential)
     else:
-        return factory_hook.getWeapon(_type, bonusAttIndex=0, star=star, potential = potential, additional_potential = additional_potential, enable_blade=True)
+        return getSubweapon(potential=potential, additional_potential=additional_potential)

--- a/dpmModule/item/ItemKernel.py
+++ b/dpmModule/item/ItemKernel.py
@@ -351,16 +351,36 @@ class WeaponFactoryClass():
         self.valueMap = valueMap
         self.modifier = modifier
         
-    def getWeapon(self, _type, star = 0, elist = [0,0,0,0], potential = CharacterModifier(), additional_potential = CharacterModifier(), bonusAttIndex = 0, bonusElse = CharacterModifier(),
-    enable_blade=False):
+    def getWeapon(self, _type, star = 0, elist = [0,0,0,0], potential = CharacterModifier(), additional_potential = CharacterModifier(), bonusAttIndex = 0, bonusElse = CharacterModifier()):
         assert(_type in self.wholeType)
-        if _type == '블레이드' and not enable_blade:
+        if _type == '블레이드':
             _type = '단검'
         _att, _bonus = self.getMap(_type)
         item = Item(att = _att)
         item.add_main_option(self.modifier)
         item.add_main_option(EnhancerFactory.get_weapon_scroll_enhancement(self.level, elist))
         item.add_main_option(CharacterModifier(att = _bonus[-1*bonusAttIndex]))
+        item.add_main_option(EnhancerFactory.get_weapon_starforce_enhancement(item, self.level, star))
+        item.add_main_option(bonusElse)
+        item.set_potential(potential)
+        item.set_additional_potential(additional_potential)
+        return item
+
+    def getBlade(self, _type, star = 0, elist = [0,0,0,0], potential = CharacterModifier(), additional_potential = CharacterModifier(), bonusElse = CharacterModifier()):
+        assert(_type == '블레이드')
+        def get_blade_modifier():
+            if self.modifier.stat_main == 100:
+                return CharacterModifier(stat_main=65)
+            if self.modifier.stat_main == 60:
+                return CharacterModifier(stat_main=40)
+            if self.modifier.stat_main == 40:
+                return CharacterModifier(stat_main=30)
+            raise TypeError("Invalid blade, (Arcane, Absolab, RootAbyss) is allowed.")
+
+        _att, _bonus = self.getMap(_type)
+        item = Item(att = _att)
+        item.add_main_option(get_blade_modifier())
+        item.add_main_option(EnhancerFactory.get_weapon_scroll_enhancement(self.level, elist))
         item.add_main_option(EnhancerFactory.get_weapon_starforce_enhancement(item, self.level, star))
         item.add_main_option(bonusElse)
         item.set_potential(potential)

--- a/dpmModule/item/RootAbyss.py
+++ b/dpmModule/item/RootAbyss.py
@@ -78,9 +78,14 @@ class Factory():
         return package
     
     @staticmethod
-    def getWeapon(_type, star = 0, elist = [0,0,0,9], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusAttIndex = 0, bonusElse = it.CharacterModifier(), enable_blade=False):
+    def getWeapon(_type, star = 0, elist = [0,0,0,9], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusAttIndex = 0, bonusElse = it.CharacterModifier()):
         
-        return WeaponFactory.getWeapon(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusAttIndex = bonusAttIndex, bonusElse = bonusElse, enable_blade=enable_blade)
+        return WeaponFactory.getWeapon(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusAttIndex = bonusAttIndex, bonusElse = bonusElse)
+
+    @staticmethod
+    def getBlade(_type, star = 0, elist = [0,0,0,0], potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonusElse = it.CharacterModifier()):
+
+        return WeaponFactory.getBlade(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
 
     @staticmethod
     def getSetOption(rank):


### PR DESCRIPTION
* 기존에는 getWeapon 클래스를 블레이드 가져오는데 다시 활용해서, self.modifier가 블레이드에도 적용되고 있었음
* self.modifier에는 무기의 기본옵이 들어가는데, 여기에 있는 주스탯 방무 보공이 블레이드에도 다시 적용되고 있었음
* getBlade() 메소드를 분리해 블레이드 기본옵만 들어가도록 처리함
* 아케인/앱솔/카룻 여부를 알 수 없어 단순히 modifier 값으로 비교하는데, 주의 필요

fix https://github.com/oleneyl/maplestory_dpm_calc/issues/153