### PR TITLE
refactor: 퍼뎀*타수를 calculate_damage로 이동

### DIFF
--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -25,7 +25,7 @@ class FrostEffectWrapper(core.BuffSkillWrapper):
 
     def getFlow(self, diff, Type):
         self.flow(diff, Type)
-        return core.ResultObject(0, core.CharacterModifier(), 0, sname = 'Frost Effect', spec = 'frost effect control')
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = 'Frost Effect', spec = 'frost effect control')
 
     def getFlowHandler(self, diff, Type):
         return core.TaskHolder(core.Task(self, partial(self.getFlow, diff, Type)), "FrostEffect("+Type+")")

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -279,7 +279,7 @@ class JobGenerator(ck.JobGenerator):
         def MemoryOfSourceHandleSpector(spector_state, time):
             spector_state.timeLeft += time
             spector_state.cooltimeLeft += time
-            return core.ResultObject(0, core.CharacterModifier(), 0, sname = 'Graph Element', spec = 'graph control')
+            return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = 'Graph Element', spec = 'graph control')
             
         MemoryOfSource.onAfter(core.TaskHolder(core.Task(SpectorState, partial(MemoryOfSourceHandleSpector, SpectorState, 30*1000)), "30초 더 지속" ))
 

--- a/dpmModule/jobs/bishop.py
+++ b/dpmModule/jobs/bishop.py
@@ -28,7 +28,7 @@ class SacredMarkWrapper(core.BuffSkillWrapper):
     def getFlow(self, diff, bonus = 0):
         def retftn():
             self.flow(diff, bonus)
-            return core.ResultObject(0, core.CharacterModifier(), 0, sname = 'Sacred Mark', spec = 'frost effect control')
+            return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = 'Sacred Mark', spec = 'frost effect control')
         return core.Task(self, retftn)
         
     def getFlowHandler(self, diff, bonus):

--- a/dpmModule/jobs/cadena.py
+++ b/dpmModule/jobs/cadena.py
@@ -25,7 +25,7 @@ class WeaponVarietyStackWrapper(core.StackSkillWrapper):
         if stack and (target not in self.stackLog):
             self.stackLog.append(target)
         
-        res = core.ResultObject(0, core.CharacterModifier(), 0, sname = self.skill.name, spec = 'graph control')
+        res = core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
         if self.currentAttack != target:
             if self.currentAttackTime < 0:
                 res.cascade = [self.final_attack_task]

--- a/dpmModule/jobs/hero.py
+++ b/dpmModule/jobs/hero.py
@@ -32,7 +32,7 @@ class ComboAttackWrapper(core.StackSkillWrapper):
     
     def toggle(self, state):
         self.instinct = state
-        return core.ResultObject(0, core.CharacterModifier(), 0, sname = self.skill.name, spec = 'graph control')
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
         
     def toggleController(self, state):
         task = core.Task(self, partial(self.toggle, state))
@@ -43,7 +43,7 @@ class ComboAttackWrapper(core.StackSkillWrapper):
         if diff > 0 and not self.instinct : self.stack -= (diff * 0.2)
         if diff > 0 and self.instinct : self.stack -= (diff * 0.7)
         self.stack = max(min(10,self.stack),0)
-        return core.ResultObject(0, core.CharacterModifier(), 0, sname = self.skill.name, spec = 'graph control')
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
 
     def get_modifier(self):
         return core.CharacterModifier(pdamage = 2 * self.stack * (1 + self.instinct * 0.01 * (5 + 0.5*self.vEhc.getV(1,1))), 

--- a/dpmModule/jobs/jobclass/heroes.py
+++ b/dpmModule/jobs/jobclass/heroes.py
@@ -35,7 +35,7 @@ class FridWrapper(core.BuffSkillWrapper):
             self.available = False
         delay = self.skill.delay
         mdf = self.get_modifier()
-        return core.ResultObject(delay, mdf, 0, sname = self._id, spec = 'buff', kwargs = {"remain" : self.skill.remain * (1+0.01*rem*self.skill.rem)})
+        return core.ResultObject(delay, mdf, 0, 0, sname = self._id, spec = 'buff', kwargs = {"remain" : self.skill.remain * (1+0.01*rem*self.skill.rem)})
         #return delay, mdf, 0, self.cascade
 
 # 메용2는 모험가 파일에 맡김. 더 나은 방법 있으면 수정 필요.

--- a/dpmModule/jobs/kaiser.py
+++ b/dpmModule/jobs/kaiser.py
@@ -18,7 +18,7 @@ class MorphGaugeWrapper(core.StackSkillWrapper):
         if not self.is_active() or d<0:
             return super(MorphGaugeWrapper, self).vary(d)
         else:
-            return core.ResultObject(0, core.CharacterModifier(), 0, sname = self._id, spec = 'graph control')
+            return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self._id, spec = 'graph control')
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -45,7 +45,7 @@ class LuminousStateController(core.BuffSkillWrapper):
             self.remain = 17 * (1 + 0.01* self.buff_rem) * 1000  #오더스?
             self.equalCallback()
             
-        return core.ResultObject(0, core.CharacterModifier(),  0, '루미너스 스택 변경')     
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, '루미너스 스택 변경')     
     
     def memorize(self):
         if self.state != LuminousStateController.EQUAL:

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -53,7 +53,7 @@ class LuminousStateController(core.BuffSkillWrapper):
         self.remain = 17*1000
         self.state = LuminousStateController.EQUAL
         self.equalCallback()
-        return core.ResultObject(0, core.CharacterModifier(), 0, sname = '메모라이즈', spec = 'graph control')
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = '메모라이즈', spec = 'graph control')
         
     def memorizeNode(self):
         task = core.Task(self, self.memorize)
@@ -102,7 +102,7 @@ class LightAndDarknessWrapper(core.DamageSkillWrapper):
         if self.stack <= 0:
             self.cooltimeLeft = 0
             self.available = True
-        return core.ResultObject(0, core.CharacterModifier(), 0, sname = '빛과 어둠의 세례 스택 증가', spec = 'graph control')            
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = '빛과 어둠의 세례 스택 증가', spec = 'graph control')            
             
     def reduceStackNode(self):
         return core.TaskHolder(core.Task(self, self.reduceStack))

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -21,7 +21,7 @@ class MesoStack(core.DamageSkillWrapper, core.StackSkillWrapper):
         stack = self.stack
         self.stack = 0
         # 확인 필요
-        return core.ResultObject(0, mdf.copy(),  dmg * (2 * stack), sname = self._id, spec = 'deal', hit = 2 * stack)
+        return core.ResultObject(0, mdf.copy(),  dmg, 2 * stack, sname = self._id, spec = 'deal')
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -27,7 +27,7 @@ class EnergyChargeWrapper(core.StackSkillWrapper):
             self.turnOff()
         elif (not self._st) and self.stack >= 10000:
             self.turnOn()
-        return core.ResultObject(0, core.CharacterModifier(), 0, sname = self.skill.name, spec = 'graph control')
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
             
     def turnOn(self):
         self.stack = 10000

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -20,12 +20,12 @@ class JaguerStack(core.DamageSkillWrapper, core.TimeStackSkillWrapper):
             vary_ = 1
         else: vary_ = vary
         self.queue.append([vary_, left])
-        return core.ResultObject(0, core.CharacterModifier(), 0, sname = self._id, spec = 'graph control')        
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self._id, spec = 'graph control')        
         
     def _use(self, rem = 0, red = 0):
         mdf = self.get_modifier()
         dmg = 60*self.getStack() + int(self.level/3)
-        return core.ResultObject(0, mdf,  dmg, sname = self._id, spec = 'deal')
+        return core.ResultObject(0, mdf, dmg, 1, sname = self._id, spec = 'deal')
 
     def is_usable(self):
         return False


### PR DESCRIPTION
* 기존에는 Skill 각각이 퍼뎀\*타수를 계산해두고 상위 모듈로 (퍼뎀\*타수, 타수)를 전달하고 있었음
* 이런 구조가 데미지 계산 부분을 해석하는데 혼란을 준다고 판단해 리팩토링을 진행
* Skill과 SkillWrapper는 (퍼뎀, 타수)만 전달하고, 계산은 calculate_damage에 일임함
* ResultObject의 hit이 default 1로 되어있는것이 위험하다고 판단, 필수 parameter로 변경

fix https://github.com/oleneyl/maplestory_dpm_calc/issues/202