### PR TITLE
아이템 전면수정

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -403,6 +403,11 @@ class ItemedCharacter(AbstractCharacter):
             item = self.itemlist[itemOrder[i]].copy()
             item.set_potential(ptnl)
             self.add_item_with_id(itemOrder[i], item)
+
+    def print_items(self):
+        for item in self.itemlist:
+            print("==="+item+"===")
+            print(self.itemlist[item].log())
             
 class Union():
     peoples = [0, 9, 10, 11, 12, 13, 

--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -90,17 +90,20 @@ class AbstractCharacter():
     def add_item_modifier(self, item):
         basic, ptnl = item.get_modifier()
         self.potential_modifier = self.potential_modifier + ptnl
-        self.static_character_modifier = self.static_character_modifier + basic        
-        
-    def add_item_with_id(self, _id, item):
-        if _id in self.itemlist:
-            self.remove_item_modifier(self.itemlist[_id])
-        self.itemlist[_id] = item            
-        self.add_item_modifier(self.itemlist[_id])
-        
-    def add_items_with_id(self, _dict):
-        for _id in _dict:
-            self.add_item_with_id(_id, _dict[_id])
+        self.static_character_modifier = self.static_character_modifier + basic      
+
+    def set_items(self, dict):
+        keys = ["head", "glove", "top", "bottom", "shoes", "cloak",
+                "eye", "face", "ear", "belt", "ring1", "ring2", "ring3", "ring4",
+                "shoulder", "pendant1", "pendant2", "pocket", "badge",
+                "weapon", "subweapon", "emblem", "medal", "heart", "title", "pet"]
+
+        for key in keys:
+            item = dict[key]
+            if item == None:
+                raise TypeError(key + " item is missing")
+            self.itemlist[key] = dict[key]            
+            self.add_item_modifier(dict[key])
 
 
 
@@ -400,9 +403,7 @@ class ItemedCharacter(AbstractCharacter):
             for j in range((len(li) - i - 1) // 3):
                 ptnl  = ptnl + li[i+j*3]
                 
-            item = self.itemlist[itemOrder[i]].copy()
-            item.set_potential(ptnl)
-            self.add_item_with_id(itemOrder[i], item)
+            self.itemlist[itemOrder[i]].set_potential(ptnl)
 
     def print_items(self):
         for item in self.itemlist:

--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -92,18 +92,18 @@ class AbstractCharacter():
         self.potential_modifier = self.potential_modifier + ptnl
         self.static_character_modifier = self.static_character_modifier + basic      
 
-    def set_items(self, dict):
+    def set_items(self, item_dict):
         keys = ["head", "glove", "top", "bottom", "shoes", "cloak",
                 "eye", "face", "ear", "belt", "ring1", "ring2", "ring3", "ring4",
                 "shoulder", "pendant1", "pendant2", "pocket", "badge",
                 "weapon", "subweapon", "emblem", "medal", "heart", "title", "pet"]
 
         for key in keys:
-            item = dict[key]
+            item = item_dict[key]
             if item == None:
                 raise TypeError(key + " item is missing")
-            self.itemlist[key] = dict[key]            
-            self.add_item_modifier(dict[key])
+            self.itemlist[key] = item_dict[key]            
+            self.add_item_modifier(item_dict[key])
 
 
 

--- a/dpmModule/character/characterTemplateHigh.py
+++ b/dpmModule/character/characterTemplateHigh.py
@@ -471,7 +471,7 @@ def getU8500CharacterTemplate(_type):
     weaponStar = 22
     bonusAttIndex = 1
 
-    template.add_summary("장신구: 칠흑셋")
+    template.add_summary("장신구: 칠흑셋, 칠요")
     template.add_summary("방어구 : 아케인6셋, 카루타 2셋")
 
     RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
@@ -505,7 +505,7 @@ def getU8500CharacterTemplate(_type):
     
     WeeklySet = Else.get_weekly_set()
 
-    template.add_summary("기타: 핑아, 공마10훈장, 하트 공160, 펫공 120")
+    template.add_summary("기타: 핑아, 하트 공160, 펫공 120")
     
     template.set_items({
         "head": ArcaneSet["head"],

--- a/dpmModule/character/characterTemplateHigh.py
+++ b/dpmModule/character/characterTemplateHigh.py
@@ -429,12 +429,12 @@ def getU7000CharacterTemplate(_type):
 
     template.add_summary("방어구/장신구: 유닉21%, 추옵 110급, 스타포스 18성")
     template.add_summary("장갑: 크뎀1줄")
-    armorAPtnl = MDF(att = 21)
+    armorAPtnl = MDF(att = 11, pstat_main = 4)
     armorPtnl = MDF(pstat_main = 21)
     armorBonus = MDF(pstat_main = 5, pstat_sub = 5, stat_main = 60)
     armorStar = 18
     
-    accAPtnl = MDF(att = 10, pstat_main = 4)
+    accAPtnl = MDF(att = 11, pstat_main = 4)
     accPtnl = MDF(pstat_main = 21)
     accBonus = MDF(stat_main = 110)
     accStar = 18
@@ -513,12 +513,12 @@ def getU8000CharacterTemplate(_type):
 
     template.add_summary("방어구/장신구: 레전27%, 추옵 120급, 스타포스 22성")
     template.add_summary("장갑: 크뎀2줄")
-    armorAPtnl = MDF(att = 11, pstat_main = 7)
+    armorAPtnl = MDF(att = 10, pstat_main = 6)
     armorPtnl = MDF(pstat_main = 27)
     armorBonus = MDF(pstat_main = 6, pstat_sub = 6, stat_main = 60)
     armorStar = 22
     
-    accAPtnl = MDF(att = 11, pstat_main = 7)
+    accAPtnl = MDF(att = 10, pstat_main = 6)
     accPtnl = MDF(pstat_main = 27)
     accBonus = MDF(stat_main = 120)
     accStar = 22
@@ -600,12 +600,12 @@ def getU8500CharacterTemplate(_type):
 
     template.add_summary("방어구/장신구: 레전33%, 추옵 130급, 스타포스 22성")
     template.add_summary("장갑: 크뎀2.5줄")
-    armorAPtnl = MDF(att = 14, pstat_main = 7)
+    armorAPtnl = MDF(att = 12, pstat_main = 12)
     armorPtnl = MDF(pstat_main = 33)
     armorBonus = MDF(pstat_main = 6, pstat_sub = 6, stat_main = 70)
     armorStar = 22
     
-    accAPtnl = MDF(att = 14, pstat_main = 7)
+    accAPtnl = MDF(att = 12, pstat_main = 12)
     accPtnl = MDF(pstat_main = 33)
     accBonus = MDF(stat_main = 130)
     accStar = 22

--- a/dpmModule/character/characterTemplateHigh.py
+++ b/dpmModule/character/characterTemplateHigh.py
@@ -398,7 +398,7 @@ def getU8000CharacterTemplate(_type):
     MeisterSet["ear"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
     MeisterSet["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
     
-    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
+    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
     AbsolabSet["glove"].set_potential(MDF(crit_damage = 16))
 
     WeeklySet = Else.get_weekly_set()
@@ -500,7 +500,7 @@ def getU8500CharacterTemplate(_type):
                                                     enhancer = it.CharacterModifier(att = 6)
                                                     )
     
-    ArcaneSet = Arcane.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
+    ArcaneSet = Arcane.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
     ArcaneSet["glove"].set_potential(MDF(crit_damage = 16, stat_main = 9))
     
     WeeklySet = Else.get_weekly_set()

--- a/dpmModule/character/characterTemplateHigh.py
+++ b/dpmModule/character/characterTemplateHigh.py
@@ -140,7 +140,7 @@ def getU5000CharacterTemplate(_type):
     BossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, enhance = 30, additional_potential = accAPtnl)
     RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30, additional_potential = armorAPtnl)
     
-    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30)
+    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30, additional_potential = armorAPtnl)
 
     template.add_summary("기타: 킹오루, 우르스 격파왕, 하트 공30, 펫공 30")
 
@@ -196,12 +196,12 @@ def getU6000CharacterTemplate(_type):
     template.add_summary("방어구/장신구: 유니크15%, 추옵 90급, 스타포스 17성")    
     template.add_summary("장갑: 크뎀1줄")
     armorAPtnl = MDF(att = 10)
-    armorPtnl = MDF(pstat_main = 12)
+    armorPtnl = MDF(pstat_main = 15)
     armorBonus = MDF(pstat_main = 5, pstat_sub = 5, stat_main = 40)
     armorStar = 17
     
     accAPtnl = MDF(att = 10)
-    accPtnl = MDF(pstat_main = 12)
+    accPtnl = MDF(pstat_main = 15)
     accBonus = MDF(stat_main = 90)
     accStar = 17
     
@@ -214,7 +214,7 @@ def getU6000CharacterTemplate(_type):
     BossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, enhance = 30, star = accStar, additional_potential = accAPtnl)
     RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, enhance = 30, star = armorStar, additional_potential = armorAPtnl)
     
-    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, enhance = 30, bonus = armorBonus, star = armorStar)
+    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, enhance = 30, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
     AbsolabSet["glove"].set_potential(MDF(crit_damage = 8))
 
     template.add_summary("기타: 핑아, 우르스 격파왕, 하트 공50, 펫공 40")

--- a/dpmModule/character/characterTemplateHigh.py
+++ b/dpmModule/character/characterTemplateHigh.py
@@ -8,9 +8,6 @@ from ..item import ItemKernel as it
 '''
 캐릭터 템플릿
 
-- U2000
-  에픽6%, 무기류 유니크 1줄, 유니온 2000, 레벨 210, 추옵 50급, 무기 2추, 카루타+여제, 에디없음
-
 - U4000
   에픽9%, 무기류 유니크 2줄, 유니온 4000, 레벨 220, 추옵 70급, 무기 1추, 카루타+여제 에디없음
 
@@ -36,205 +33,6 @@ from ..item import ItemKernel as it
   레전33%, 무기류 레전3줄, 유니온 8500, 레벨 255, 추옵 130급, 무기 1추, 카루타+아케인, 에디 레전3줄
   
 '''
-
-def getUnionCharacter(_type, armor_pstat_ptnl = 6, acc_pstat_ptnl = 9, weaponStar = 12):
-    ''' Explanation TODO..
-    '''
-    weaponPtnl = MDF(pdamage = 30, patt = 6)
-    weaponAPtnl = MDF()
-    
-    subPtnl = MDF(armor_ignore = 30, patt = 6)
-    subAPtnl = MDF()
-    emblemPtnl = MDF(patt = 6, armor_ignore = 30)
-    emblemAPtnl = MDF()
-    
-    armorPtnl = MDF(pstat_main = armor_pstat_ptnl)  #6%
-    armorBonus = MDF(pstat_main = 6, pstat_sub = 6)
-    armorStar = 10
-    
-    accPtnl = MDF(pstat_main = acc_pstat_ptnl)  #9%
-    accBonus = MDF(stat_main = 50)
-    accStar = 10
-    
-    bonusAttIndex = 2
-
-    #Temporal union object..
-    unionModifier = MDF(att = 5, pdamage = 21, armor_ignore = 21, stat_main = 5)
-    link = LinkSkill.get_full_link()
-    
-    template = ichar(modifierlist = [unionModifier, link])
-
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar))
-    
-    empressSet = Empress.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
-    template.add_item_with_id("glove", empressSet["glove"])
-    template.add_item_with_id("cloak", empressSet["cloak"])
-    template.add_item_with_id("shoes", empressSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.getSubweapon(potential = subPtnl))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = emblemPtnl))
-    
-    template.add_item_with_id("weapon", RootAbyss.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = weaponPtnl, additional_potential = weaponAPtnl ))
-
-    template.apply_modifiers([RootAbyss.Factory.getSetOption(4)])
-    return template
-    
-def getTestCharacter():
-    setting = MDF(boss_pdamage = 150, pdamage = 63, armor_ignore = 100, stat_main = 27244, att = 1620, stat_sub=2527, crit = 100, crit_damage = 30)
-    template = ichar(modifierlist = [setting])
-    return template
-    
-def getU6000Character(_type, armor_pstat_ptnl = 15, acc_pstat_ptnl = 15, weaponStar = 17):
-    ''' Explanation TODO..
-    '''
-    weaponPtnl = MDF(pdamage = 70, armor_ignore = 30)
-    weaponAPtnl = MDF(patt = 6)
-    
-    subPtnl = MDF(armor_ignore = 40, patt = 9)
-    subAPtnl = MDF(patt = 6)
-    emblemPtnl = MDF(boss_pdamage = 70)
-    emblemAPtnl = MDF(patt = 6)
-    
-    armorPtnl = MDF(pstat_main = armor_pstat_ptnl)
-    armorBonus = MDF(pstat_main = 6, pstat_sub = 6, stat_main = 30)
-    armorStar = 17
-    
-    accPtnl = MDF(pstat_main = acc_pstat_ptnl)
-    accBonus = MDF(stat_main = 50, pstat_main = 4, pstat_sub = 4)
-    accStar = 17
-    
-    bonusAttIndex = 2
-
-    #Temporal union object..
-    unionModifier = MDF(att = 5, pdamage = 21, armor_ignore = 21, stat_main = 5, crit_damage = 24)
-    
-    link = LinkSkill.get_full_link()
-    
-    template = ichar(modifierlist = [unionModifier, link])
-
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar))
-    
-    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
-    template.add_item_with_id("glove", absolabSet["glove"])
-    template.add_item_with_id("cloak", absolabSet["cloak"])
-    template.add_item_with_id("shoulder", absolabSet["shoulder"])
-    template.add_item_with_id("shoes", absolabSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = emblemPtnl, additional_potential = emblemAPtnl))
-    
-    template.add_item_with_id("weapon", Absolab.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = weaponPtnl, additional_potential = weaponAPtnl ))
-    
-    template.apply_modifiers([Absolab.Factory.getSetOption(5), RootAbyss.Factory.getSetOption(3)])
-    return template
-    
-
-def getDpmStdCharacterTemplate(_type, armor_pstat_ptnl = 15, acc_pstat_ptnl = 15, weaponStar = 17):
-    ''' CharacterTemplate : set items w/o weapon-type potentials.
-    '''
-    weaponAPtnl = MDF(patt = 6)
-    
-    subAPtnl = MDF(patt = 6)
-    
-    emblemAPtnl = MDF(patt = 6)
-    
-    armorPtnl = MDF(pstat_main = armor_pstat_ptnl)
-    armorBonus = MDF(pstat_main = 5, pstat_sub = 5, stat_main = 40)
-    armorStar = 17
-    
-    accPtnl = MDF(pstat_main = acc_pstat_ptnl)
-    accBonus = MDF(stat_main = 40, pstat_main = 5, pstat_sub = 5)
-    accStar = 17
-    
-    bonusAttIndex = 1
-
-    etcAddPtnl = MDF(att = 10)
-
-    #Temporal union object..
-    link = LinkSkill.get_full_link()
-    
-    template = ichar(modifierlist = [link], level = 240)
-
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, additional_potential = etcAddPtnl, bonus = accBonus, star = accStar, enhance = 30))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = etcAddPtnl, bonus = armorBonus, star = armorStar, enhance = 30))
-    
-    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = etcAddPtnl, bonus = armorBonus, star = armorStar, enhance = 30)
-    template.add_item_with_id("glove", absolabSet["glove"])
-    template.add_item_with_id("cloak", absolabSet["cloak"])
-    template.add_item_with_id("shoulder", absolabSet["shoulder"])
-    template.add_item_with_id("shoes", absolabSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl))
-    
-    template.add_item_with_id("weapon", Absolab.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl, elist = [0,0,0,9] ))
-    #print(template.itemlist["weapon"].att)
-    
-    #포스뻥
-    template.apply_modifiers([MDF(stat_main_fixed = 96*100)])
-    #반감
-    template.apply_modifiers([MDF(pdamage_indep = -50)])
-
-    template.apply_modifiers([Absolab.Factory.getSetOption(5), RootAbyss.Factory.getSetOption(3), BossAccesory.Factory.getSetOption(9)])
-    
-    return template
-    
-def getEpicDpmStdCharacterTemplate(_type, armor_pstat_ptnl = 9, acc_pstat_ptnl = 9, weaponStar = 12):
-    ''' CharacterTemplate : set items w/o weapon-type potentials.
-    '''
-
-    weaponAPtnl = MDF(patt = 0)
-    
-    subAPtnl = MDF(patt = 0)
-    
-    emblemAPtnl = MDF(patt = 0)
-
-    armorPtnl = MDF(pstat_main = armor_pstat_ptnl)
-    armorBonus = MDF(pstat_main = 5, pstat_sub = 5, stat_main = 20)
-    armorStar = 10
-    
-    accPtnl = MDF(pstat_main = acc_pstat_ptnl)
-    accBonus = MDF(stat_main = 20, pstat_main = 5, pstat_sub = 5)
-    accStar = 10
-    
-    bonusAttIndex = 2
-
-    etcAddPtnl = MDF(att = 10)
-
-    #Temporal union object..
-    link = LinkSkill.get_full_link()
-    
-    template = ichar(modifierlist = [link], level = 230)
-
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, additional_potential = etcAddPtnl, bonus = accBonus, star = accStar))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = etcAddPtnl, bonus = armorBonus, star = armorStar))
-    
-    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = etcAddPtnl, bonus = armorBonus, star = armorStar)
-    template.add_item_with_id("glove", absolabSet["glove"])
-    template.add_item_with_id("cloak", absolabSet["cloak"])
-    template.add_item_with_id("shoulder", absolabSet["shoulder"])
-    template.add_item_with_id("shoes", absolabSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl))
-    
-    template.add_item_with_id("weapon", Absolab.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ))
-    #print(template.itemlist["weapon"].att)
-    
-    #포스뻥
-    template.apply_modifiers([MDF(stat_main_fixed = 60*100)])
-    #반감
-    template.apply_modifiers([MDF(pdamage_indep = -50)])
-
-    template.apply_modifiers([Absolab.Factory.getSetOption(5), RootAbyss.Factory.getSetOption(3), BossAccesory.Factory.getSetOption(9)])
-    
-    return template    
 
 '''
 Pre - generated characters
@@ -270,30 +68,44 @@ def getU4000CharacterTemplate(_type):
     bonusAttIndex = 3
 
     template.add_summary("장신구: 보장9셋")
-    template.add_summary("방어구: 여제4셋, 카루타 4셋")
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar))
+    template.add_summary("방어구: 여제5셋, 카루타 4셋")
+    BossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar)
+    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
     
-    empressSet = Empress.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
-    template.add_item_with_id("glove", empressSet["glove"])
-    template.add_item_with_id("cloak", empressSet["cloak"])
-    template.add_item_with_id("shoulder", empressSet["shoulder"])
-    template.add_item_with_id("shoes", empressSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=RootAbyss.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl))
+    EmpressSet = Empress.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
     
-    template.add_item_with_id("weapon", RootAbyss.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ))
-    #print(template.itemlist["weapon"].att)
+    template.add_summary("기타: 킹오루, 우르스 격파왕, 하트X, 펫공 X")
+
+    template.set_items({
+        "head": EmpressSet["head"],
+        "glove": EmpressSet["glove"],
+        "top": RootAbyssSet["top"],
+        "bottom": RootAbyssSet["bottom"],
+        "shoes": EmpressSet["shoes"],
+        "cloak": EmpressSet["cloak"],
+        "eye": BossAccesorySet["eye"],
+        "face": BossAccesorySet["face"],
+        "ear": BossAccesorySet["ear"],
+        "belt": BossAccesorySet["belt"],
+        "ring1": BossAccesorySet["ring1"],
+        "ring2": BossAccesorySet["ring2"],
+        "ring3": Default.getEventRing(potential = accPtnl),
+        "ring4": Default.getEventRing(potential = accPtnl),
+        "shoulder": EmpressSet["shoulder"],
+        "pendant1": BossAccesorySet["pendant1"],
+        "pendant2": BossAccesorySet["pendant2"],
+        "pocket": BossAccesorySet["pocket"],
+        "badge": BossAccesorySet["badge"],
+        "weapon": RootAbyss.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
+        "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=RootAbyss.Factory),
+        "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
+        "medal": Else.get_medal(7),
+        "heart": it.Item(),
+        "title": Else.KingOfRootAbyss.copy(),
+        "pet": it.Item(),
+    })
     
-    template.add_summary("기타: 킹오루, 공마3훈장, 하트X, 펫공 X")
-    template.add_item_with_id("medal", Else.get_medal(3))
-    template.add_item_with_id("title", Else.KingOfRootAbyss.copy())
-    #template.add_item_with_id("heart", Else.get_heart())
-    #template.add_item_with_id("pet", Else.get_pet())
-    
-    template.apply_modifiers([Empress.Factory.getSetOption(4), RootAbyss.Factory.getSetOption(4), BossAccesory.Factory.getSetOption(9)])
+    template.apply_modifiers([Empress.Factory.getSetOption(5), RootAbyss.Factory.getSetOption(4), BossAccesory.Factory.getSetOption(9)])
     
     template.add_summary("아케인포스: 240")
     template.apply_modifiers([MDF(stat_main_fixed = 2400)])
@@ -325,27 +137,41 @@ def getU5000CharacterTemplate(_type):
     bonusAttIndex = 2
     template.add_summary("장신구: 보장9셋")
     template.add_summary("방어구: 앱솔5셋, 카루타 3셋")
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, enhance = 30, additional_potential = accAPtnl))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30, additional_potential = armorAPtnl))
+    BossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, enhance = 30, additional_potential = accAPtnl)
+    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30, additional_potential = armorAPtnl)
     
-    empressSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30)
-    template.add_item_with_id("glove", empressSet["glove"])
-    template.add_item_with_id("cloak", empressSet["cloak"])
-    template.add_item_with_id("shoulder", empressSet["shoulder"])
-    template.add_item_with_id("shoes", empressSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl))
-    
-    template.add_item_with_id("weapon", Absolab.Factory.getWeapon(_type, elist = [0,0,0,9], bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ))
-    #print(template.itemlist["weapon"].att)
+    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30)
 
-    template.add_summary("기타: 킹오루, 공마7훈장, 하트 공30, 펫공 30")
-    template.add_item_with_id("medal", Else.get_medal(7))
-    template.add_item_with_id("title", Else.KingOfRootAbyss.copy())
-    template.add_item_with_id("heart", Else.get_heart(30))
-    template.add_item_with_id("pet", Else.get_pet(30))
+    template.add_summary("기타: 킹오루, 우르스 격파왕, 하트 공30, 펫공 30")
+
+    template.set_items({
+        "head": AbsolabSet["head"],
+        "glove": AbsolabSet["glove"],
+        "top": RootAbyssSet["top"],
+        "bottom": RootAbyssSet["bottom"],
+        "shoes": AbsolabSet["shoes"],
+        "cloak": AbsolabSet["cloak"],
+        "eye": BossAccesorySet["eye"],
+        "face": BossAccesorySet["face"],
+        "ear": BossAccesorySet["ear"],
+        "belt": BossAccesorySet["belt"],
+        "ring1": BossAccesorySet["ring1"],
+        "ring2": BossAccesorySet["ring2"],
+        "ring3": Default.getEventRing(potential = accPtnl),
+        "ring4": Default.getEventRing(potential = accPtnl),
+        "shoulder": AbsolabSet["shoulder"],
+        "pendant1": BossAccesorySet["pendant1"],
+        "pendant2": BossAccesorySet["pendant2"],
+        "pocket": BossAccesorySet["pocket"],
+        "badge": BossAccesorySet["badge"],
+        "weapon": Absolab.Factory.getWeapon(_type, elist = [0,0,0,9], bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
+        "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory),
+        "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
+        "medal": Else.get_medal(7),
+        "heart": Else.get_heart(30),
+        "title": Else.KingOfRootAbyss.copy(),
+        "pet": Else.get_pet(30),
+    })
     
     template.apply_modifiers([Absolab.Factory.getSetOption(5), RootAbyss.Factory.getSetOption(3), BossAccesory.Factory.getSetOption(9)])
 
@@ -385,28 +211,42 @@ def getU6000CharacterTemplate(_type):
 
     template.add_summary("장신구: 보장9셋")
     template.add_summary("방어구: 앱솔5셋, 카루타 3셋")
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, enhance = 30, star = accStar, additional_potential = accAPtnl))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, enhance = 30, star = armorStar, additional_potential = armorAPtnl))
+    BossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, enhance = 30, star = accStar, additional_potential = accAPtnl)
+    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, enhance = 30, star = armorStar, additional_potential = armorAPtnl)
     
-    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, enhance = 30, bonus = armorBonus, star = armorStar)
-    absolabSet["glove"].set_potential(MDF(crit_damage = 8))
-    template.add_item_with_id("glove", absolabSet["glove"])
-    template.add_item_with_id("cloak", absolabSet["cloak"])
-    template.add_item_with_id("shoulder", absolabSet["shoulder"])
-    template.add_item_with_id("shoes", absolabSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl))
-    
-    template.add_item_with_id("weapon", Absolab.Factory.getWeapon(_type, elist = [0,0,0,9], bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ))
-    #print(template.itemlist["weapon"].att)
+    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, enhance = 30, bonus = armorBonus, star = armorStar)
+    AbsolabSet["glove"].set_potential(MDF(crit_damage = 8))
 
-    template.add_summary("기타: 핑아, 공마3훈장, 하트 공50, 펫공 40")
-    template.add_item_with_id("medal", Else.get_medal(3))
-    template.add_item_with_id("title", Else.PingkbinAndMe.copy())
-    template.add_item_with_id("heart", Else.get_heart(50))
-    template.add_item_with_id("pet", Else.get_pet(40))
+    template.add_summary("기타: 핑아, 우르스 격파왕, 하트 공50, 펫공 40")
+
+    template.set_items({
+        "head": AbsolabSet["head"],
+        "glove": AbsolabSet["glove"],
+        "top": RootAbyssSet["top"],
+        "bottom": RootAbyssSet["bottom"],
+        "shoes": AbsolabSet["shoes"],
+        "cloak": AbsolabSet["cloak"],
+        "eye": BossAccesorySet["eye"],
+        "face": BossAccesorySet["face"],
+        "ear": BossAccesorySet["ear"],
+        "belt": BossAccesorySet["belt"],
+        "ring1": BossAccesorySet["ring1"],
+        "ring2": BossAccesorySet["ring2"],
+        "ring3": Default.getEventRing(potential = accPtnl),
+        "ring4": Default.getEventRing(potential = accPtnl),
+        "shoulder": AbsolabSet["shoulder"],
+        "pendant1": BossAccesorySet["pendant1"],
+        "pendant2": BossAccesorySet["pendant2"],
+        "pocket": BossAccesorySet["pocket"],
+        "badge": BossAccesorySet["badge"],
+        "weapon": Absolab.Factory.getWeapon(_type, elist = [0,0,0,9], bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
+        "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory),
+        "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
+        "medal": Else.get_medal(7),
+        "heart": Else.get_heart(50),
+        "title": Else.PingkbinAndMe.copy(),
+        "pet": Else.get_pet(40),
+    })
     
     template.apply_modifiers([Absolab.Factory.getSetOption(5), RootAbyss.Factory.getSetOption(3), BossAccesory.Factory.getSetOption(9)])
 
@@ -445,8 +285,8 @@ def getU7000CharacterTemplate(_type):
 
     template.add_summary("장신구: 보장7셋, 마이, 칠요")
     template.add_summary("방어구: 앱솔5셋, 카루타 2셋, 1아케인(무기)")
-    template.add_items_with_id(BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl))
+    BossAccesorySet = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl)
+    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
     
     BossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
                                                                 bonus = accBonus, 
@@ -456,40 +296,48 @@ def getU7000CharacterTemplate(_type):
     BossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
     BossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
     
-    
-    
     MeisterSet = Meister.Factory.getAccesoryDict(3, potential = accPtnl,  
                                                         bonus = accBonus,
                                                         additional_potential = accAPtnl,
                                                         star = 0)
     MeisterSet["ring3"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-                                                        
-                                                        
-    template.add_item_with_id("ring3", MeisterSet["ring3"])
-    template.add_item_with_id("pendant1", BossAccesorySurprise["pendant1"])
-    template.add_item_with_id("pendant2", BossAccesorySurprise["pendant2"])
-    
 
-    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = armorAPtnl, 
+    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = armorAPtnl, 
                                                         bonus = armorBonus, star = armorStar)
-    absolabSet["glove"].set_potential(MDF(crit_damage = 8))
-    template.add_item_with_id("glove", absolabSet["glove"])
-    template.add_item_with_id("cloak", absolabSet["cloak"])
-    template.add_item_with_id("shoulder", absolabSet["shoulder"])
-    template.add_item_with_id("shoes", absolabSet["shoes"])
-    template.add_item_with_id("head", absolabSet["head"])
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl))
+    AbsolabSet["glove"].set_potential(MDF(crit_damage = 8))
     
-    template.add_item_with_id("weapon", Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ))
-    #print(template.itemlist["weapon"].att)
+    WeeklySet = Else.get_weekly_set()
+    
+    template.add_summary("기타: 핑아, 하트 공95, 펫공 80")
 
-    template.add_summary("기타: 핑아, 공마5훈장, 하트 공95, 펫공 80")
-    template.add_item_with_id("medal", Else.get_medal(5))
-    template.add_item_with_id("title", Else.PingkbinAndMe.copy())
-    template.add_item_with_id("heart", Else.get_heart(95, accPtnl, accAPtnl))
-    template.add_item_with_id("pet", Else.get_pet(80))
+    template.set_items({
+        "head": AbsolabSet["head"],
+        "glove": AbsolabSet["glove"],
+        "top": RootAbyssSet["top"],
+        "bottom": RootAbyssSet["bottom"],
+        "shoes": AbsolabSet["shoes"],
+        "cloak": AbsolabSet["cloak"],
+        "eye": BossAccesorySet["eye"],
+        "face": BossAccesorySet["face"],
+        "ear": BossAccesorySet["ear"],
+        "belt": BossAccesorySet["belt"],
+        "ring1": BossAccesorySet["ring1"],
+        "ring2": BossAccesorySet["ring2"],
+        "ring3": MeisterSet["ring3"],
+        "ring4": Default.getEventRing(potential = accPtnl),
+        "shoulder": AbsolabSet["shoulder"],
+        "pendant1": BossAccesorySurprise["pendant1"],
+        "pendant2": BossAccesorySurprise["pendant2"],
+        "pocket": BossAccesorySet["pocket"],
+        "badge": WeeklySet["badge"],
+        "weapon": Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
+        "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory),
+        "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
+        "medal": WeeklySet["medal"],
+        "heart": Else.get_heart(95, accPtnl, accAPtnl),
+        "title": Else.PingkbinAndMe.copy(),
+        "pet": Else.get_pet(80),
+    })
     
     template.apply_modifiers([Absolab.Factory.getSetOption(5), RootAbyss.Factory.getSetOption(2), BossAccesory.Factory.getSetOption(7)])
 
@@ -527,11 +375,10 @@ def getU8000CharacterTemplate(_type):
     weaponStar = 22
     bonusAttIndex = 1
 
-    template.add_summary("장신구: 보장5셋")
-    template.add_summary("방어구: 방어구 : 앱솔5셋, 카루타 2셋, 아케인셰이드")
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl))
-    
+    template.add_summary("장신구: 보장5셋, 마이, 칠요")
+    template.add_summary("방어구: 앱솔5셋, 카루타 2셋, 아케인셰이드")
+    BossAccesorySet = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl)
+    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
     
     ## 놀장 적용
     BossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
@@ -541,42 +388,52 @@ def getU8000CharacterTemplate(_type):
     
     BossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
     BossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-    BossAccesorySurprise["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(120, 10))
+    BossAccesorySurprise["ring1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(110, 10))
     
     
-    MeisterSet = Meister.Factory.getAccesoryDict(3, potential = accPtnl,  
+    MeisterSet = Meister.Factory.getAccesoryDict(2, potential = accPtnl,  
                                                         bonus = accBonus,
                                                         additional_potential = accAPtnl,
                                                         star = 0)
-    MeisterSet["ring3"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-                                                        
-    template.add_item_with_id("ring2", BossAccesorySurprise["ring2"])
-    template.add_item_with_id("ring3", MeisterSet["ring3"])
-    template.add_item_with_id("pendant1", BossAccesorySurprise["pendant1"])
-    template.add_item_with_id("pendant2", BossAccesorySurprise["pendant2"])
+    MeisterSet["ear"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    MeisterSet["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    
+    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
+    AbsolabSet["glove"].set_potential(MDF(crit_damage = 16))
 
-    
-    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
-    absolabSet["glove"].set_potential(MDF(crit_damage = 16))
-    template.add_item_with_id("head", absolabSet["head"])
-    template.add_item_with_id("glove", absolabSet["glove"])
-    template.add_item_with_id("cloak", absolabSet["cloak"])
-    template.add_item_with_id("shoulder", absolabSet["shoulder"])
-    template.add_item_with_id("shoes", absolabSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl))
-    
-    template.add_item_with_id("weapon", Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ))
-    #print(template.itemlist["weapon"].att)
+    WeeklySet = Else.get_weekly_set()
 
-    template.add_summary("기타: 핑아, 칠요, 하트 공120, 펫공 120")
+    template.add_summary("기타: 핑아, 하트 공120, 펫공 120")
     
-    template.add_items_with_id( Else.get_weekly_set() )
-    template.add_item_with_id("title", Else.PingkbinAndMe.copy())
-    template.add_item_with_id("heart", Else.get_heart(120, accPtnl, accAPtnl))
-    template.add_item_with_id("pet", Else.get_pet(120))
+
+    template.set_items({
+        "head": AbsolabSet["head"],
+        "glove": AbsolabSet["glove"],
+        "top": RootAbyssSet["top"],
+        "bottom": RootAbyssSet["bottom"],
+        "shoes": AbsolabSet["shoes"],
+        "cloak": AbsolabSet["cloak"],
+        "eye": BossAccesorySet["eye"],
+        "face": BossAccesorySet["face"],
+        "ear": MeisterSet["ear"],
+        "belt": BossAccesorySet["belt"],
+        "ring1": BossAccesorySurprise["ring1"],
+        "ring2": MeisterSet["ring2"],
+        "ring3": Default.getEventRing(potential = accPtnl),
+        "ring4": Default.getEventRing(potential = accPtnl),
+        "shoulder": AbsolabSet["shoulder"],
+        "pendant1": BossAccesorySurprise["pendant1"],
+        "pendant2": BossAccesorySurprise["pendant2"],
+        "pocket": BossAccesorySet["pocket"],
+        "badge": WeeklySet["badge"],
+        "weapon": Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
+        "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory),
+        "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
+        "medal": WeeklySet["medal"],
+        "heart": Else.get_heart(120, accPtnl, accAPtnl),
+        "title": Else.PingkbinAndMe.copy(),
+        "pet": Else.get_pet(120),
+    })
     
     template.apply_modifiers([Absolab.Factory.getSetOption(5), 
                                 RootAbyss.Factory.getSetOption(2), 
@@ -616,10 +473,8 @@ def getU8500CharacterTemplate(_type):
 
     template.add_summary("장신구: 칠흑셋")
     template.add_summary("방어구 : 아케인6셋, 카루타 2셋")
-    template.add_items_with_id(BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl))
-    template.add_items_with_id(RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl))
 
-
+    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
 
     ## 놀장 적용
     BossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
@@ -629,48 +484,57 @@ def getU8500CharacterTemplate(_type):
     
     BossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
     BossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-    BossAccesorySurprise["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(120, 10))
+    BossAccesorySurprise["ring1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(110, 10))
     
-    
-    MeisterSet = Meister.Factory.getAccesoryDict(3, potential = accPtnl,  
+    MeisterSet = Meister.Factory.getAccesoryDict(2, potential = accPtnl,  
                                                         bonus = accBonus,
                                                         additional_potential = accAPtnl,
                                                         star = 0)
-    MeisterSet["ring3"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-                                                        
-    template.add_item_with_id("ring2", BossAccesorySurprise["ring2"])
-    template.add_item_with_id("ring3", MeisterSet["ring3"])
-    template.add_item_with_id("pendant1", BossAccesorySurprise["pendant1"])
-    template.add_item_with_id("pendant2", BossAccesorySurprise["pendant2"])
+    MeisterSet["ear"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    MeisterSet["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
     
-    template.add_items_with_id(Darkness.Factory.getAccesoryDict(star = accStar,
-                                                        bonus = accBonus,
-                                                        potential = accPtnl,
-                                                        additional_potential = accAPtnl,
-                                                        enhancer = it.CharacterModifier(att = 6)
-                                                        ))
+    DarknessSet = Darkness.Factory.getAccesoryDict(star = accStar,
+                                                    bonus = accBonus,
+                                                    potential = accPtnl,
+                                                    additional_potential = accAPtnl,
+                                                    enhancer = it.CharacterModifier(att = 6)
+                                                    )
     
-    arcaneSet = Arcane.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
-    arcaneSet["glove"].set_potential(MDF(crit_damage = 16, stat_main = 9))
-    template.add_item_with_id("glove", arcaneSet["glove"])
-    template.add_item_with_id("cloak", arcaneSet["cloak"])
-    template.add_item_with_id("shoulder", arcaneSet["shoulder"])
-    template.add_item_with_id("shoes", arcaneSet["shoes"])
-    template.add_item_with_id("ring3", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("ring4", Default.getEventRing(potential = accPtnl))
-    template.add_item_with_id("subweapon", Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory))
-    template.add_item_with_id("emblem", Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl))
+    ArcaneSet = Arcane.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
+    ArcaneSet["glove"].set_potential(MDF(crit_damage = 16, stat_main = 9))
     
-    template.add_item_with_id("weapon", Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ))
-    #print(template.itemlist["weapon"].att)
-
+    WeeklySet = Else.get_weekly_set()
 
     template.add_summary("기타: 핑아, 공마10훈장, 하트 공160, 펫공 120")
     
-    template.add_items_with_id( Else.get_weekly_set() )
-    template.add_item_with_id("title", Else.PingkbinAndMe.copy())
-    template.add_item_with_id("heart", Else.get_heart(160, accPtnl, accAPtnl))
-    template.add_item_with_id("pet", Else.get_pet(120))
+    template.set_items({
+        "head": ArcaneSet["head"],
+        "glove": ArcaneSet["glove"],
+        "top": RootAbyssSet["top"],
+        "bottom": RootAbyssSet["bottom"],
+        "shoes": ArcaneSet["shoes"],
+        "cloak": ArcaneSet["cloak"],
+        "eye": DarknessSet["eye"],
+        "face": DarknessSet["face"],
+        "ear": MeisterSet["ear"],
+        "belt": DarknessSet["belt"],
+        "ring1": BossAccesorySurprise["ring1"],
+        "ring2": MeisterSet["ring2"],
+        "ring3": Default.getEventRing(potential = accPtnl),
+        "ring4": Default.getEventRing(potential = accPtnl),
+        "shoulder": ArcaneSet["shoulder"],
+        "pendant1": BossAccesorySurprise["pendant1"],
+        "pendant2": BossAccesorySurprise["pendant2"],
+        "pocket": DarknessSet["pocket"],
+        "badge": WeeklySet["badge"],
+        "weapon": Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
+        "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory),
+        "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
+        "medal": WeeklySet["medal"],
+        "heart": Else.get_heart(160, accPtnl, accAPtnl),
+        "title": Else.PingkbinAndMe.copy(),
+        "pet": Else.get_pet(120),
+    })
     
     template.apply_modifiers([Arcane.Factory.getSetOption(6), 
                                 RootAbyss.Factory.getSetOption(2),

--- a/dpmModule/character/characterTemplateHigh.py
+++ b/dpmModule/character/characterTemplateHigh.py
@@ -69,33 +69,33 @@ def getU4000CharacterTemplate(_type):
 
     template.add_summary("장신구: 보장9셋")
     template.add_summary("방어구: 여제5셋, 카루타 4셋")
-    BossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar)
-    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
+    bossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar)
+    rootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
     
-    EmpressSet = Empress.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
+    empressSet = Empress.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar)
     
     template.add_summary("기타: 킹오루, 우르스 격파왕, 하트X, 펫공 X")
 
     template.set_items({
-        "head": EmpressSet["head"],
-        "glove": EmpressSet["glove"],
-        "top": RootAbyssSet["top"],
-        "bottom": RootAbyssSet["bottom"],
-        "shoes": EmpressSet["shoes"],
-        "cloak": EmpressSet["cloak"],
-        "eye": BossAccesorySet["eye"],
-        "face": BossAccesorySet["face"],
-        "ear": BossAccesorySet["ear"],
-        "belt": BossAccesorySet["belt"],
-        "ring1": BossAccesorySet["ring1"],
-        "ring2": BossAccesorySet["ring2"],
+        "head": empressSet["head"],
+        "glove": empressSet["glove"],
+        "top": rootAbyssSet["top"],
+        "bottom": rootAbyssSet["bottom"],
+        "shoes": empressSet["shoes"],
+        "cloak": empressSet["cloak"],
+        "eye": bossAccesorySet["eye"],
+        "face": bossAccesorySet["face"],
+        "ear": bossAccesorySet["ear"],
+        "belt": bossAccesorySet["belt"],
+        "ring1": bossAccesorySet["ring1"],
+        "ring2": bossAccesorySet["ring2"],
         "ring3": Default.getEventRing(potential = accPtnl),
         "ring4": Default.getEventRing(potential = accPtnl),
-        "shoulder": EmpressSet["shoulder"],
-        "pendant1": BossAccesorySet["pendant1"],
-        "pendant2": BossAccesorySet["pendant2"],
-        "pocket": BossAccesorySet["pocket"],
-        "badge": BossAccesorySet["badge"],
+        "shoulder": empressSet["shoulder"],
+        "pendant1": bossAccesorySet["pendant1"],
+        "pendant2": bossAccesorySet["pendant2"],
+        "pocket": bossAccesorySet["pocket"],
+        "badge": bossAccesorySet["badge"],
         "weapon": RootAbyss.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
         "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=RootAbyss.Factory),
         "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
@@ -137,33 +137,33 @@ def getU5000CharacterTemplate(_type):
     bonusAttIndex = 2
     template.add_summary("장신구: 보장9셋")
     template.add_summary("방어구: 앱솔5셋, 카루타 3셋")
-    BossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, enhance = 30, additional_potential = accAPtnl)
-    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30, additional_potential = armorAPtnl)
+    bossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, enhance = 30, additional_potential = accAPtnl)
+    rootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30, additional_potential = armorAPtnl)
     
-    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30, additional_potential = armorAPtnl)
+    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, enhance = 30, additional_potential = armorAPtnl)
 
     template.add_summary("기타: 킹오루, 우르스 격파왕, 하트 공30, 펫공 30")
 
     template.set_items({
-        "head": AbsolabSet["head"],
-        "glove": AbsolabSet["glove"],
-        "top": RootAbyssSet["top"],
-        "bottom": RootAbyssSet["bottom"],
-        "shoes": AbsolabSet["shoes"],
-        "cloak": AbsolabSet["cloak"],
-        "eye": BossAccesorySet["eye"],
-        "face": BossAccesorySet["face"],
-        "ear": BossAccesorySet["ear"],
-        "belt": BossAccesorySet["belt"],
-        "ring1": BossAccesorySet["ring1"],
-        "ring2": BossAccesorySet["ring2"],
+        "head": rootAbyssSet["head"],
+        "glove": absolabSet["glove"],
+        "top": rootAbyssSet["top"],
+        "bottom": rootAbyssSet["bottom"],
+        "shoes": absolabSet["shoes"],
+        "cloak": absolabSet["cloak"],
+        "eye": bossAccesorySet["eye"],
+        "face": bossAccesorySet["face"],
+        "ear": bossAccesorySet["ear"],
+        "belt": bossAccesorySet["belt"],
+        "ring1": bossAccesorySet["ring1"],
+        "ring2": bossAccesorySet["ring2"],
         "ring3": Default.getEventRing(potential = accPtnl),
         "ring4": Default.getEventRing(potential = accPtnl),
-        "shoulder": AbsolabSet["shoulder"],
-        "pendant1": BossAccesorySet["pendant1"],
-        "pendant2": BossAccesorySet["pendant2"],
-        "pocket": BossAccesorySet["pocket"],
-        "badge": BossAccesorySet["badge"],
+        "shoulder": absolabSet["shoulder"],
+        "pendant1": bossAccesorySet["pendant1"],
+        "pendant2": bossAccesorySet["pendant2"],
+        "pocket": bossAccesorySet["pocket"],
+        "badge": bossAccesorySet["badge"],
         "weapon": Absolab.Factory.getWeapon(_type, elist = [0,0,0,9], bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
         "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory),
         "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
@@ -211,34 +211,34 @@ def getU6000CharacterTemplate(_type):
 
     template.add_summary("장신구: 보장9셋")
     template.add_summary("방어구: 앱솔5셋, 카루타 3셋")
-    BossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, enhance = 30, star = accStar, additional_potential = accAPtnl)
-    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, enhance = 30, star = armorStar, additional_potential = armorAPtnl)
+    bossAccesorySet = BossAccesory.Factory.get11SetDict(potential = accPtnl, bonus = accBonus, enhance = 30, star = accStar, additional_potential = accAPtnl)
+    rootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, enhance = 30, star = armorStar, additional_potential = armorAPtnl)
     
-    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, enhance = 30, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
-    AbsolabSet["glove"].set_potential(MDF(crit_damage = 8))
+    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, enhance = 30, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
+    absolabSet["glove"].set_potential(MDF(crit_damage = 8))
 
     template.add_summary("기타: 핑아, 우르스 격파왕, 하트 공50, 펫공 40")
 
     template.set_items({
-        "head": AbsolabSet["head"],
-        "glove": AbsolabSet["glove"],
-        "top": RootAbyssSet["top"],
-        "bottom": RootAbyssSet["bottom"],
-        "shoes": AbsolabSet["shoes"],
-        "cloak": AbsolabSet["cloak"],
-        "eye": BossAccesorySet["eye"],
-        "face": BossAccesorySet["face"],
-        "ear": BossAccesorySet["ear"],
-        "belt": BossAccesorySet["belt"],
-        "ring1": BossAccesorySet["ring1"],
-        "ring2": BossAccesorySet["ring2"],
+        "head": rootAbyssSet["head"],
+        "glove": absolabSet["glove"],
+        "top": rootAbyssSet["top"],
+        "bottom": rootAbyssSet["bottom"],
+        "shoes": absolabSet["shoes"],
+        "cloak": absolabSet["cloak"],
+        "eye": bossAccesorySet["eye"],
+        "face": bossAccesorySet["face"],
+        "ear": bossAccesorySet["ear"],
+        "belt": bossAccesorySet["belt"],
+        "ring1": bossAccesorySet["ring1"],
+        "ring2": bossAccesorySet["ring2"],
         "ring3": Default.getEventRing(potential = accPtnl),
         "ring4": Default.getEventRing(potential = accPtnl),
-        "shoulder": AbsolabSet["shoulder"],
-        "pendant1": BossAccesorySet["pendant1"],
-        "pendant2": BossAccesorySet["pendant2"],
-        "pocket": BossAccesorySet["pocket"],
-        "badge": BossAccesorySet["badge"],
+        "shoulder": absolabSet["shoulder"],
+        "pendant1": bossAccesorySet["pendant1"],
+        "pendant2": bossAccesorySet["pendant2"],
+        "pocket": bossAccesorySet["pocket"],
+        "badge": bossAccesorySet["badge"],
         "weapon": Absolab.Factory.getWeapon(_type, elist = [0,0,0,9], bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
         "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Absolab.Factory),
         "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
@@ -285,55 +285,55 @@ def getU7000CharacterTemplate(_type):
 
     template.add_summary("장신구: 보장7셋, 마이, 칠요")
     template.add_summary("방어구: 앱솔5셋, 카루타 2셋, 1아케인(무기)")
-    BossAccesorySet = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl)
-    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
+    bossAccesorySet = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl)
+    rootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
     
-    BossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
+    bossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
                                                                 bonus = accBonus, 
                                                                 star = 0, 
                                                                 additional_potential = accAPtnl)
     
-    BossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
-    BossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    bossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
+    bossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
     
-    MeisterSet = Meister.Factory.getAccesoryDict(3, potential = accPtnl,  
+    meisterSet = Meister.Factory.getAccesoryDict(3, potential = accPtnl,  
                                                         bonus = accBonus,
                                                         additional_potential = accAPtnl,
                                                         star = 0)
-    MeisterSet["ring3"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    meisterSet["ring3"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
 
-    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = armorAPtnl, 
+    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, additional_potential = armorAPtnl, 
                                                         bonus = armorBonus, star = armorStar)
-    AbsolabSet["glove"].set_potential(MDF(crit_damage = 8))
+    absolabSet["glove"].set_potential(MDF(crit_damage = 8))
     
-    WeeklySet = Else.get_weekly_set()
+    weeklySet = Else.get_weekly_set()
     
     template.add_summary("기타: 핑아, 하트 공95, 펫공 80")
 
     template.set_items({
-        "head": AbsolabSet["head"],
-        "glove": AbsolabSet["glove"],
-        "top": RootAbyssSet["top"],
-        "bottom": RootAbyssSet["bottom"],
-        "shoes": AbsolabSet["shoes"],
-        "cloak": AbsolabSet["cloak"],
-        "eye": BossAccesorySet["eye"],
-        "face": BossAccesorySet["face"],
-        "ear": BossAccesorySet["ear"],
-        "belt": BossAccesorySet["belt"],
-        "ring1": BossAccesorySet["ring1"],
-        "ring2": BossAccesorySet["ring2"],
-        "ring3": MeisterSet["ring3"],
+        "head": absolabSet["head"],
+        "glove": absolabSet["glove"],
+        "top": rootAbyssSet["top"],
+        "bottom": rootAbyssSet["bottom"],
+        "shoes": absolabSet["shoes"],
+        "cloak": absolabSet["cloak"],
+        "eye": bossAccesorySet["eye"],
+        "face": bossAccesorySet["face"],
+        "ear": bossAccesorySet["ear"],
+        "belt": bossAccesorySet["belt"],
+        "ring1": bossAccesorySet["ring1"],
+        "ring2": bossAccesorySet["ring2"],
+        "ring3": meisterSet["ring3"],
         "ring4": Default.getEventRing(potential = accPtnl),
-        "shoulder": AbsolabSet["shoulder"],
-        "pendant1": BossAccesorySurprise["pendant1"],
-        "pendant2": BossAccesorySurprise["pendant2"],
-        "pocket": BossAccesorySet["pocket"],
-        "badge": WeeklySet["badge"],
+        "shoulder": absolabSet["shoulder"],
+        "pendant1": bossAccesorySurprise["pendant1"],
+        "pendant2": bossAccesorySurprise["pendant2"],
+        "pocket": bossAccesorySet["pocket"],
+        "badge": weeklySet["badge"],
         "weapon": Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
         "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory),
         "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
-        "medal": WeeklySet["medal"],
+        "medal": weeklySet["medal"],
         "heart": Else.get_heart(95, accPtnl, accAPtnl),
         "title": Else.PingkbinAndMe.copy(),
         "pet": Else.get_pet(80),
@@ -377,59 +377,59 @@ def getU8000CharacterTemplate(_type):
 
     template.add_summary("장신구: 보장5셋, 마이, 칠요")
     template.add_summary("방어구: 앱솔5셋, 카루타 2셋, 아케인셰이드")
-    BossAccesorySet = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl)
-    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
+    bossAccesorySet = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, bonus = accBonus, star = accStar, additional_potential = accAPtnl)
+    rootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
     
     ## 놀장 적용
-    BossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
+    bossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
                                                                 bonus = accBonus, 
                                                                 star = 0, 
                                                                 additional_potential = accAPtnl)
     
-    BossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
-    BossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-    BossAccesorySurprise["ring1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(110, 10))
+    bossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
+    bossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    bossAccesorySurprise["ring1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(110, 10))
     
     
-    MeisterSet = Meister.Factory.getAccesoryDict(2, potential = accPtnl,  
+    meisterSet = Meister.Factory.getAccesoryDict(2, potential = accPtnl,  
                                                         bonus = accBonus,
                                                         additional_potential = accAPtnl,
                                                         star = 0)
-    MeisterSet["ear"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-    MeisterSet["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    meisterSet["ear"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    meisterSet["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
     
-    AbsolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
-    AbsolabSet["glove"].set_potential(MDF(crit_damage = 16))
+    absolabSet = Absolab.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
+    absolabSet["glove"].set_potential(MDF(crit_damage = 16))
 
-    WeeklySet = Else.get_weekly_set()
+    weeklySet = Else.get_weekly_set()
 
     template.add_summary("기타: 핑아, 하트 공120, 펫공 120")
     
 
     template.set_items({
-        "head": AbsolabSet["head"],
-        "glove": AbsolabSet["glove"],
-        "top": RootAbyssSet["top"],
-        "bottom": RootAbyssSet["bottom"],
-        "shoes": AbsolabSet["shoes"],
-        "cloak": AbsolabSet["cloak"],
-        "eye": BossAccesorySet["eye"],
-        "face": BossAccesorySet["face"],
-        "ear": MeisterSet["ear"],
-        "belt": BossAccesorySet["belt"],
-        "ring1": BossAccesorySurprise["ring1"],
-        "ring2": MeisterSet["ring2"],
+        "head": absolabSet["head"],
+        "glove": absolabSet["glove"],
+        "top": rootAbyssSet["top"],
+        "bottom": rootAbyssSet["bottom"],
+        "shoes": absolabSet["shoes"],
+        "cloak": absolabSet["cloak"],
+        "eye": bossAccesorySet["eye"],
+        "face": bossAccesorySet["face"],
+        "ear": meisterSet["ear"],
+        "belt": bossAccesorySet["belt"],
+        "ring1": bossAccesorySurprise["ring1"],
+        "ring2": meisterSet["ring2"],
         "ring3": Default.getEventRing(potential = accPtnl),
         "ring4": Default.getEventRing(potential = accPtnl),
-        "shoulder": AbsolabSet["shoulder"],
-        "pendant1": BossAccesorySurprise["pendant1"],
-        "pendant2": BossAccesorySurprise["pendant2"],
-        "pocket": BossAccesorySet["pocket"],
-        "badge": WeeklySet["badge"],
+        "shoulder": absolabSet["shoulder"],
+        "pendant1": bossAccesorySurprise["pendant1"],
+        "pendant2": bossAccesorySurprise["pendant2"],
+        "pocket": bossAccesorySet["pocket"],
+        "badge": weeklySet["badge"],
         "weapon": Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
         "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory),
         "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
-        "medal": WeeklySet["medal"],
+        "medal": weeklySet["medal"],
         "heart": Else.get_heart(120, accPtnl, accAPtnl),
         "title": Else.PingkbinAndMe.copy(),
         "pet": Else.get_pet(120),
@@ -474,63 +474,63 @@ def getU8500CharacterTemplate(_type):
     template.add_summary("장신구: 칠흑셋, 칠요")
     template.add_summary("방어구 : 아케인6셋, 카루타 2셋")
 
-    RootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
+    rootAbyssSet = RootAbyss.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
 
     ## 놀장 적용
-    BossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
+    bossAccesorySurprise = BossAccesory.Factory.getBetter11SetDict(potential = accPtnl, 
                                                                 bonus = accBonus, 
                                                                 star = 0, 
                                                                 additional_potential = accAPtnl)
     
-    BossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
-    BossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-    BossAccesorySurprise["ring1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(110, 10))
+    bossAccesorySurprise["pendant1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(130, 12))
+    bossAccesorySurprise["pendant2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    bossAccesorySurprise["ring1"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(110, 10))
     
-    MeisterSet = Meister.Factory.getAccesoryDict(2, potential = accPtnl,  
+    meisterSet = Meister.Factory.getAccesoryDict(2, potential = accPtnl,  
                                                         bonus = accBonus,
                                                         additional_potential = accAPtnl,
                                                         star = 0)
-    MeisterSet["ear"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
-    MeisterSet["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    meisterSet["ear"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
+    meisterSet["ring2"].add_main_option(it.EnhancerFactory.get_surprise_enhancement(140, 12))
     
-    DarknessSet = Darkness.Factory.getAccesoryDict(star = accStar,
+    darknessSet = Darkness.Factory.getAccesoryDict(star = accStar,
                                                     bonus = accBonus,
                                                     potential = accPtnl,
                                                     additional_potential = accAPtnl,
                                                     enhancer = it.CharacterModifier(att = 6)
                                                     )
     
-    ArcaneSet = Arcane.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
-    ArcaneSet["glove"].set_potential(MDF(crit_damage = 16, stat_main = 9))
+    arcaneSet = Arcane.Factory.getArmorSetDict(potential = armorPtnl, bonus = armorBonus, star = armorStar, additional_potential = armorAPtnl)
+    arcaneSet["glove"].set_potential(MDF(crit_damage = 16, stat_main = 9))
     
-    WeeklySet = Else.get_weekly_set()
+    weeklySet = Else.get_weekly_set()
 
     template.add_summary("기타: 핑아, 하트 공160, 펫공 120")
     
     template.set_items({
-        "head": ArcaneSet["head"],
-        "glove": ArcaneSet["glove"],
-        "top": RootAbyssSet["top"],
-        "bottom": RootAbyssSet["bottom"],
-        "shoes": ArcaneSet["shoes"],
-        "cloak": ArcaneSet["cloak"],
-        "eye": DarknessSet["eye"],
-        "face": DarknessSet["face"],
-        "ear": MeisterSet["ear"],
-        "belt": DarknessSet["belt"],
-        "ring1": BossAccesorySurprise["ring1"],
-        "ring2": MeisterSet["ring2"],
+        "head": arcaneSet["head"],
+        "glove": arcaneSet["glove"],
+        "top": rootAbyssSet["top"],
+        "bottom": rootAbyssSet["bottom"],
+        "shoes": arcaneSet["shoes"],
+        "cloak": arcaneSet["cloak"],
+        "eye": darknessSet["eye"],
+        "face": darknessSet["face"],
+        "ear": meisterSet["ear"],
+        "belt": darknessSet["belt"],
+        "ring1": bossAccesorySurprise["ring1"],
+        "ring2": meisterSet["ring2"],
         "ring3": Default.getEventRing(potential = accPtnl),
         "ring4": Default.getEventRing(potential = accPtnl),
-        "shoulder": ArcaneSet["shoulder"],
-        "pendant1": BossAccesorySurprise["pendant1"],
-        "pendant2": BossAccesorySurprise["pendant2"],
-        "pocket": DarknessSet["pocket"],
-        "badge": WeeklySet["badge"],
+        "shoulder": arcaneSet["shoulder"],
+        "pendant1": bossAccesorySurprise["pendant1"],
+        "pendant2": bossAccesorySurprise["pendant2"],
+        "pocket": darknessSet["pocket"],
+        "badge": weeklySet["badge"],
         "weapon": Arcane.Factory.getWeapon(_type, bonusAttIndex = bonusAttIndex, star = weaponStar, potential = MDF(), additional_potential = weaponAPtnl ),
         "subweapon": Default.get_subweapon_covering_exception(_type, potential = MDF(), additional_potential = subAPtnl, factory_hook=Arcane.Factory),
         "emblem": Default.getEmblem(potential = MDF(), additional_potential = emblemAPtnl),
-        "medal": WeeklySet["medal"],
+        "medal": weeklySet["medal"],
         "heart": Else.get_heart(160, accPtnl, accAPtnl),
         "title": Else.PingkbinAndMe.copy(),
         "pet": Else.get_pet(120),

--- a/dpmModule/item/Absolab.py
+++ b/dpmModule/item/Absolab.py
@@ -49,7 +49,8 @@ class Factory():
             item = package[itemkey]
             item.set_potential(potential)
             item.set_additional_potential(additional_potential)
-            item.add_main_option(bonus)
+            if itemkey != "shoulder":
+                item.add_main_option(bonus)
             item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(160, star))
             if itemkey == "glove":
                 item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(160, elist = scrolls[idx]))

--- a/dpmModule/item/Absolab.py
+++ b/dpmModule/item/Absolab.py
@@ -52,11 +52,11 @@ class Factory():
             if itemkey != "shoulder":
                 item.add_main_option(bonus)
             item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(160, star))
-            if itemkey == "glove":
-                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(160, elist = scrolls[idx]))
-            else: #For glove
+            if itemkey == "glove": #For glove
                 item.add_main_option(it.EnhancerFactory.get_glove_scroll_enhancement(160, elist = scrolls[idx]))
                 item.add_main_option(it.EnhancerFactory.get_glove_bonus_starforce_enhancement(star))
+            else:
+                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(160, elist = scrolls[idx]))
             
         return package
     

--- a/dpmModule/item/Absolab.py
+++ b/dpmModule/item/Absolab.py
@@ -1,10 +1,10 @@
 from . import ItemKernel as it
 
-Head = it.Item(stat_main = 45, stat_sub = 45, att = 3, armor_ignore = 10)
-Glove = it.Item(stat_main = 20, stat_sub = 20, att = 5)
-Shoes = it.Item(stat_main = 20, stat_sub = 20, att = 5)
-Cloak = it.Item(stat_main = 15, stat_sub = 15, att = 2)
-Shoulder = it.Item(stat_main = 14, stat_sub = 14, att = 10)
+Head = it.Item(name="앱솔랩스 모자", stat_main = 45, stat_sub = 45, att = 3, armor_ignore = 10, level = 160)
+Glove = it.Item(name="앱솔랩스 장갑", stat_main = 20, stat_sub = 20, att = 5, level = 160)
+Shoes = it.Item(name="앱솔랩스 신발", stat_main = 20, stat_sub = 20, att = 5, level = 160)
+Cloak = it.Item(name="앱솔랩스 망토", stat_main = 15, stat_sub = 15, att = 2, level = 160)
+Shoulder = it.Item(name="앱솔랩스 견장", stat_main = 14, stat_sub = 14, att = 10, level = 160)
 
 # 업횟 11+1
 # 일반적인 템셋에서 카벨 모자를 사용할 직업은 제로뿐이므로 앱솔/아케인 무기 착용으로 가정
@@ -27,36 +27,6 @@ WeaponFactory = it.WeaponFactoryClass(160, _valueMap, modifier = it.CharacterMod
 
 
 class Factory():
-    @staticmethod
-    def getArmorSet(star = 0, enhance = 30, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
-        assert(enhance in [100, 70, 30])
-        #TODO : Simplyfy this dirty codes.
-        if not hammer: 
-            upgrades = [11,7,7,7,1]
-        else:
-            upgrades = [12,8,8,8,2]
-         
-        if enhance == 100:
-            scrolls = [[upgrades[i],0,0] for i in range(5)]
-        elif enhance == 70:
-            scrolls = [[0,upgrades[i],0] for i in range(5)]
-        else:
-            scrolls = [[0,0,upgrades[i]] for i in range(5)]
-            
-        retli = [ Head.copy(), Glove.copy(), Shoes.copy(), Cloak.copy(), Shoulder.copy()]
-        for idx, item in zip([0,1,2,3,4],retli):
-            item.set_potential(potential)
-            item.set_additional_potential(additional_potential)
-            item.add_main_option(bonus)
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(160, star))
-            if idx != 1:
-                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(160, elist = scrolls[idx]))
-            else: #For glove
-                item.add_main_option(it.EnhancerFactory.get_glove_scroll_enhancement(160, elist = scrolls[idx]))
-                item.add_main_option(it.EnhancerFactory.getGloveStarforceEnhancement(star))
-            
-        return retli
-
     @staticmethod
     def getArmorSetDict(star = 0, enhance = 30, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
         assert(enhance in [100, 70, 30])

--- a/dpmModule/item/Arcane.py
+++ b/dpmModule/item/Arcane.py
@@ -45,7 +45,8 @@ class Factory():
             item = package[itemkey]
             item.set_potential(potential)
             item.set_additional_potential(additional_potential)
-            item.add_main_option(bonus)
+            if itemkey != "shoulder":
+                item.add_main_option(bonus)
             item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(200, star))
             if itemkey == "glove":
                 item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(200, elist = scrolls[idx]))

--- a/dpmModule/item/Arcane.py
+++ b/dpmModule/item/Arcane.py
@@ -1,10 +1,10 @@
 from . import ItemKernel as it
 
-Head = it.Item(stat_main = 65, stat_sub = 65, att = 7, armor_ignore = 15)
-Glove = it.Item(stat_main = 40, stat_sub = 40, att = 9)
-Shoes = it.Item(stat_main = 40, stat_sub = 40, att = 9)
-Cloak = it.Item(stat_main = 35, stat_sub = 35, att = 6)
-Shoulder = it.Item(stat_main = 35, stat_sub = 35, att = 20)
+Head = it.Item(name="아케인셰이드 모자", stat_main = 65, stat_sub = 65, att = 7, armor_ignore = 15, level = 200)
+Glove = it.Item(name="아케인셰이드 장갑", stat_main = 40, stat_sub = 40, att = 9, level = 200)
+Shoes = it.Item(name="아케인셰이드 신발", stat_main = 40, stat_sub = 40, att = 9, level = 200)
+Cloak = it.Item(name="아케인셰이드 망토", stat_main = 35, stat_sub = 35, att = 6, level = 200)
+Shoulder = it.Item(name="아케인셰이드 견장", stat_main = 35, stat_sub = 35, att = 20, level = 200)
 
 _valueMap = [[149, [0,27,40,55,72,92]],
                 [216,[0,39,58,79,104,133]],
@@ -23,36 +23,6 @@ WeaponFactory = it.WeaponFactoryClass(200, _valueMap, modifier = it.CharacterMod
 
 
 class Factory():
-    @staticmethod
-    def getArmorSet(star = 0, enhance = 30, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
-        assert(enhance in [100, 70, 30])
-        #TODO : Simplyfy this dirty codes.
-        if not hammer: 
-            upgrades = [11,7,7,7,1]
-        else:
-            upgrades = [12,8,8,8,2]
-         
-        if enhance == 100:
-            scrolls = [[upgrades[i],0,0] for i in range(5)]
-        elif enhance == 70:
-            scrolls = [[0,upgrades[i],0] for i in range(5)]
-        else:
-            scrolls = [[0,0,upgrades[i]] for i in range(5)]
-            
-        retli = [ Head.copy(), Glove.copy(), Shoes.copy(), Cloak.copy(), Shoulder.copy()]
-        for idx, item in zip([0,1,2,3,4],retli):
-            item.get_potential(potential)
-            item.set_additional_potential(additional_potential)
-            item.add_main_option(bonus)
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(200, star))
-            if idx != 1:
-                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(200, elist = scrolls[idx]))
-            else: #For glove
-                item.add_main_option(it.EnhancerFactory.get_glove_scroll_enhancement(200, elist = scrolls[idx]))
-                item.add_main_option(it.EnhancerFactory.get_glove_bonus_starforce_enhancement(star))
-            
-        return retli
-
     @staticmethod
     def getArmorSetDict(star = 0, enhance = 30, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
         assert(enhance in [100, 70, 30])

--- a/dpmModule/item/Arcane.py
+++ b/dpmModule/item/Arcane.py
@@ -48,11 +48,11 @@ class Factory():
             if itemkey != "shoulder":
                 item.add_main_option(bonus)
             item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(200, star))
-            if itemkey == "glove":
-                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(200, elist = scrolls[idx]))
-            else: #For glove
+            if itemkey == "glove": #For glove
                 item.add_main_option(it.EnhancerFactory.get_glove_scroll_enhancement(200, elist = scrolls[idx]))
                 item.add_main_option(it.EnhancerFactory.get_glove_bonus_starforce_enhancement(star))
+            else:
+                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(200, elist = scrolls[idx]))
             
         return package
     

--- a/dpmModule/item/BossAccesory.py
+++ b/dpmModule/item/BossAccesory.py
@@ -29,8 +29,7 @@ Ring110 =  it.Item(name="실버블라썸 링", stat_main = 5, stat_sub = 5, att 
 #혼테일 목걸이..(0) -> 알발린상태로 계산 필요
 
 #아카이럼 매커...(2)
-# TODO: 120으로 변경
-Pendant130 =  it.Item(name="매커네이터 펜던트", stat_main = 10, stat_sub = 10, att = 1, level = 130)
+Pendant120 =  it.Item(name="매커네이터 펜던트", stat_main = 10, stat_sub = 10, att = 1, level = 120)
 
 #아카이럼 도미...(6 or 0) 파편작 가정
 Pendant140 =  it.Item(name="도미네이터 펜던트", stat_main = 5, stat_sub = 5, att = 5, level = 140)
@@ -49,11 +48,11 @@ class Factory():
     @staticmethod
     def get11SetDict(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
         package = [Eye100.copy(), Face110.copy(), Ear130.copy(), Ring110.copy(), Ring120.copy(), \
-                    Pendant130.copy(), Pendant140.copy(), Belt140.copy(), Pocket140.copy(), \
+                    Pendant120.copy(), Pendant140.copy(), Belt140.copy(), Pocket140.copy(), \
                     Badge130.copy(), Shoulder120.copy()]
 
         package = {"eye" : Eye100.copy(), "face" : Face110.copy(), "ear" : Ear130.copy(), "ring1" : Ring110.copy(), \
-                    "ring2" : Ring120.copy(), "pendant1" : Pendant130.copy(), "pendant2" : Pendant140.copy(), \
+                    "ring2" : Ring120.copy(), "pendant1" : Pendant120.copy(), "pendant2" : Pendant140.copy(), \
                     "belt" : Belt140.copy(), "pocket" : Pocket140.copy(), \
                     "badge" : Badge130.copy(), "shoulder" : Shoulder120.copy()}
         keylist = ["eye", "face", "ear", "ring1", "ring2", "pendant1", "pendant2", "belt", "pocket", "badge", "shoulder"]
@@ -88,7 +87,7 @@ class Factory():
     @staticmethod    
     def getBetter11SetDict(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
         package = {"eye" : Eye145.copy(), "face" : Face110.copy(), "ear" : Ear130.copy(), "ring1" : Ring110.copy(), \
-                    "ring2" : Ring120.copy(), "pendant1" : Pendant130.copy(), "pendant2" : Pendant140Fragment.copy(), \
+                    "ring2" : Ring120.copy(), "pendant1" : Pendant120.copy(), "pendant2" : Pendant140Fragment.copy(), \
                     "belt" : Belt140.copy(), "pocket" : Pocket140.copy(), \
                     "badge" : Badge130.copy(), "shoulder" : Shoulder120.copy()}
         keylist = ["eye", "face", "ear", "ring1", "ring2", "pendant1", "pendant2", "belt", "pocket", "badge", "shoulder"]

--- a/dpmModule/item/BossAccesory.py
+++ b/dpmModule/item/BossAccesory.py
@@ -74,12 +74,14 @@ class Factory():
                     
         for idx, itemkey in zip([i for i in range(11)], keylist):
             item = package[itemkey]
-            item.set_potential(potential)
-            item.set_additional_potential(additional_potential)
-            if itemkey not in ["ring1", "ring2","shoulder","badge"]:
+            item = package[itemkey]
+            if itemkey not in ["ring1", "ring2", "shoulder", "badge"]:
                 item.add_main_option(bonus)
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(item.level, star))
-            item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(item.level, elist = scrolls[idx]))
+            if itemkey not in ["pocket", "badge"]:
+                item.set_potential(potential)
+                item.set_additional_potential(additional_potential)
+                item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(item.level, star))
+                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(item.level, elist = scrolls[idx]))
             
         return package
     
@@ -107,12 +109,13 @@ class Factory():
                     
         for idx, itemkey in zip([i for i in range(11)], keylist):
             item = package[itemkey]
-            item.set_potential(potential)
-            item.set_additional_potential(additional_potential)
-            if itemkey not in ["ring1", "ring2","shoulder","badge"]:
-                item.add_main_option(bonus)            
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(item.level, star))
-            item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(item.level, elist = scrolls[idx]))
+            if itemkey not in ["ring1", "ring2", "shoulder", "badge"]:
+                item.add_main_option(bonus)
+            if itemkey not in ["pocket", "badge"]:
+                item.set_potential(potential)
+                item.set_additional_potential(additional_potential)
+                item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(item.level, star))
+                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(item.level, elist = scrolls[idx]))
             
         return package
         

--- a/dpmModule/item/BossAccesory.py
+++ b/dpmModule/item/BossAccesory.py
@@ -3,94 +3,49 @@ from . import ItemKernel as it
 #No upgrade
 
 #자쿰 얼장(응축된 힘의 결정석)...(5)
-Face110 = it.Item(stat_main = 5, stat_sub = 5, att = 5, level = 110)
+Face110 = it.Item(name="응축된 힘의 결정석", stat_main = 5, stat_sub = 5, att = 5, level = 110)
 #자쿰 눈장....(3)
-Eye100 = it.Item(stat_main = 6, stat_sub = 6, att = 1, level = 100)
+Eye100 = it.Item(name="아쿠아틱 레터 눈장식", stat_main = 6, stat_sub = 6, att = 1, level = 100)
 #자쿰 벨트....(3)
-Belt150 =  it.Item(stat_main = 18, stat_sub = 18, att = 1, level = 150)
+Belt150 =  it.Item(name="분노한 자쿰의 벨트", stat_main = 18, stat_sub = 18, att = 1, level = 150)
 
 #매그너스 숄더..(1)
-Shoulder120 =  it.Item(stat_main = 10, stat_sub = 10, att = 6, level = 120)
+Shoulder120 =  it.Item(name="로얄 블랙메탈 숄더", stat_main = 10, stat_sub = 10, att = 6, level = 120)
 #매그너스 뱃지..(0)
-Badge130 =  it.Item(stat_main = 10, stat_sub = 10, att = 5, level = 130)
+Badge130 =  it.Item(name="크리스탈 웬투스 뱃지", stat_main = 10, stat_sub = 10, att = 5, level = 130)
 
 #힐라 -> 미사용, 무시
 
 #파풀 눈장..(5)
-Eye150 =  it.Item(stat_main = 8, stat_sub = 8, att = 1, level = 150)
+Eye145 =  it.Item(name="파풀라투스 마크", stat_main = 8, stat_sub = 8, att = 1, level = 140) # 145제는 140제와 같은 강화 테이블 사용
 
 #반레온보장..(2)
-Ring120 =  it.Item(stat_main = 5, stat_sub = 5, att = 2, level = 120)
+Ring120 =  it.Item(name="고귀한 이피아의 반지", stat_main = 5, stat_sub = 5, att = 2, level = 120)
 
 #혼테일 귀고리...(6)
-Ear130 =  it.Item(stat_main = 5, stat_sub = 5, att = 2, level = 130)
+Ear130 =  it.Item(name="데아 시두스 이어림", stat_main = 5, stat_sub = 5, att = 2, level = 130)
 #혼테일 링...(2)
-Ring110 =  it.Item(stat_main = 5, stat_sub = 5, att = 2, level = 110)
+Ring110 =  it.Item(name="실버블라썸 링", stat_main = 5, stat_sub = 5, att = 2, level = 110)
 #혼테일 목걸이..(0) -> 알발린상태로 계산 필요
 
 #아카이럼 매커...(2)
 # TODO: 120으로 변경
-Pendant130 =  it.Item(stat_main = 10, stat_sub = 10, att = 1, level = 130)
+Pendant130 =  it.Item(name="매커네이터 펜던트", stat_main = 10, stat_sub = 10, att = 1, level = 130)
 
 #아카이럼 도미...(6 or 0) 파편작 가정
-Pendant140 =  it.Item(stat_main = 5, stat_sub = 5, att = 5, level = 140)
-Pendant140Fragment = it.Item(stat_main = 23, stat_sub = 23, att = 23, level = 140)
+Pendant140 =  it.Item(name="도미네이터 펜던트", stat_main = 5, stat_sub = 5, att = 5, level = 140)
+Pendant140Fragment = it.Item(name="도미네이터 펜던트", stat_main = 23, stat_sub = 23, att = 23, level = 140)
 
 #핑크빈 포켓 ... 0
-Pocket140 = it.Item(stat_main = 5, stat_sub = 5, att = 5, level = 140)
+Pocket140 = it.Item(name="핑크빛 성배", stat_main = 5, stat_sub = 5, att = 5, level = 140)
 #핑크빈 벨트 ... 3
-Belt140 =  it.Item(stat_main = 15, stat_sub = 15, att = 1, level = 140)
+Belt140 =  it.Item(name="골든 클로버 벨트", stat_main = 15, stat_sub = 15, att = 1, level = 140)
 #핑크빈 얼장 ... 5
-Eye135 = it.Item(stat_main = 7, stat_sub = 7, att = 1, level = 135)
+Eye135 = it.Item(name="블랙빈 마크", stat_main = 7, stat_sub = 7, att = 1, level = 130) # 135제는 130제와 같은 강화 테이블 사용
 
 
 
 class Factory():
-    @staticmethod
-    def get11Set(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
-        '''get11Set : Package of Item set With Followings
-        Eye : Eye100(Zakum)
-        Face : Face110(Zakum)
-        Ear : Ear130(Horntail)
-        Ring1 : Ring110(Horntail)
-        Ring2 : Ring120(Van Leon)
-        ! NO Ring3 / Ring4
-        Pendant1: Pendant130(Acairum)
-        Pendant1: Pendant140(Acairum)
-        Belt : Belt140(PinkBin)
-        Pocket : Pocket140(PinkBin)
-        
-        Badge : Badge130(Magnus)
-        Shoulder : Shoulder120(Magnus)
-        '''
-        package = [Eye100.copy(), Face110.copy(), Ear130.copy(), Ring110.copy(), Ring120.copy(), \
-                    Pendant130.copy(), Pendant140.copy(), Belt140.copy(), Pocket140.copy(), \
-                    Badge130.copy(), Shoulder120.copy()]
-
-        upgrades = [3, 5, 6, 2, 2, 2, 6, 3, 0, 0, 2]
-        if hammer:            
-            upgrades = [i+1 for i in upgrades]
-            
-        #TODO : Simplyfy this dirty codes.
-        if enhance == 100:
-            scrolls = [[upgrades[i],0,0] for i in range(11)]
-        elif enhance == 70:
-            scrolls = [[0,upgrades[i],0] for i in range(11)]
-        elif enhance == 30:
-            scrolls = [[0,0,upgrades[i]] for i in range(11)]
-        else:
-            raise TypeError("enhance must be 100, 70, or 30.")
-                    
-        for idx, item in zip([i for i in range(11)], package):
-            item.set_potential(potential)
-            item.set_additional_potential(additional_potential)
-            if idx not in [3,4,9,10]:
-                item.add_main_option(bonus)
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(item.level, star))
-            item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(item.level, elist = scrolls[idx]))
-            
-        return package
-    
     @staticmethod
     def get11SetDict(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
         package = [Eye100.copy(), Face110.copy(), Ear130.copy(), Ring110.copy(), Ring120.copy(), \
@@ -129,52 +84,8 @@ class Factory():
         return package
     
     @staticmethod    
-    def getBetter11Set(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
-        '''getBetter11Set : Package of Item set With Followings
-        Eye : Eye100(Zakum) -> Eye135(PinkBin)
-        Face : Face110(Zakum) -> Face150(Papul)
-        Ear : Ear130(Horntail)
-        Ring1 : Ring110(Horntail)
-        Ring2 : Ring120(Horntail)
-        ! NO Ring3 / Ring4
-        Pendant1: Pendant130(Acairum)
-        Pendant2: Pendant140(Acairum) -> Pendant140Fragment(Acairum)
-        Belt : Belt140(PinkBin)
-        Pocket : Pocket140(PinkBin)
-        
-        Badge : Badge130(Magnus)
-        Shoulder : Shoulder120(Magnus)
-        '''
-        package = [Eye150.copy(), Face110.copy(), Ear130.copy(), Ring110.copy(), Ring120.copy(), \
-                    Pendant130.copy(), Pendant140Fragment.copy(), Belt140.copy(), Pocket140.copy(), \
-                    Badge130.copy(), Shoulder120.copy()]
-        upgrades = [5, 5, 6, 2, 2, 2, 0, 3, 0, 0, 2]
-        if hammer:            
-            upgrades = [i+1 for i in upgrades]
-            
-        #TODO : Simplyfy this dirty codes.
-        if enhance == 100:
-            scrolls = [[upgrades[i],0,0] for i in range(11)]
-        elif enhance == 70:
-            scrolls = [[0,upgrades[i],0] for i in range(11)]
-        elif enhance == 30:
-            scrolls = [[0,0,upgrades[i]] for i in range(11)]
-        else:
-            raise TypeError("enhance must be 100, 70, or 30.")                    
-                    
-        for idx, item in zip([0,1,2], package):
-            item.set_potential(potential)
-            item.set_additional_potential(additional_potential)
-            if idx not in [3,4,9,10]:
-                item.add_main_option(bonus)
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(item.level, star))
-            item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(item.level, elist = scrolls[idx]))
-            
-        return package
-        
-    @staticmethod    
     def getBetter11SetDict(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
-        package = {"eye" : Eye150.copy(), "face" : Face110.copy(), "ear" : Ear130.copy(), "ring1" : Ring110.copy(), \
+        package = {"eye" : Eye145.copy(), "face" : Face110.copy(), "ear" : Ear130.copy(), "ring1" : Ring110.copy(), \
                     "ring2" : Ring120.copy(), "pendant1" : Pendant130.copy(), "pendant2" : Pendant140Fragment.copy(), \
                     "belt" : Belt140.copy(), "pocket" : Pocket140.copy(), \
                     "badge" : Badge130.copy(), "shoulder" : Shoulder120.copy()}

--- a/dpmModule/item/Darkness.py
+++ b/dpmModule/item/Darkness.py
@@ -46,12 +46,12 @@ class Factory():
                 item.set_potential(potential)
                 item.set_additional_potential(additional_potential)
             
-            scroll_enhance = it.CharacterModifier()
-            for i in range(enhance):
-                scroll_enhance += enhancer
+                scroll_enhance = it.CharacterModifier()
+                for i in range(enhance):
+                    scroll_enhance += enhancer
                 
-            item.add_main_option(scroll_enhance)
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(level, star))
+                item.add_main_option(scroll_enhance)
+                item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(level, star))
         
         return {"eye" : black_eye ,
                 "face" : black_face,

--- a/dpmModule/item/Darkness.py
+++ b/dpmModule/item/Darkness.py
@@ -1,10 +1,10 @@
 from . import ItemKernel as it
 
-Face = it.Item(stat_main = 10, stat_sub = 10, att = 10)#160 // 5
-Eye = it.Item(stat_main = 15, stat_sub = 15, att = 3)#160 // 3
-Belt = it.Item(stat_main = 50, stat_sub = 50, att = 6)#200 // 3
-Pendant = it.Item(stat_main = 10, stat_sub = 10, att = 5)#160 // 5
-Pocket = it.Item(stat_main = 20, stat_sub = 10, att = 10)#160
+Face = it.Item(name="루즈 컨트롤 머신 마크", stat_main = 10, stat_sub = 10, att = 10, level = 160)#160 // 5
+Eye = it.Item(name="마력이 깃든 안대", stat_main = 15, stat_sub = 15, att = 3, level = 160)#160 // 3
+Belt = it.Item(name="몽환의 벨트", stat_main = 50, stat_sub = 50, att = 6, level = 200)#200 // 3
+Pendant = it.Item(name="고통의 근원", stat_main = 10, stat_sub = 10, att = 5, level = 160)#160 // 5
+Pocket = it.Item(name="저주받은 #의 마도서", stat_main = 20, stat_sub = 10, att = 10, level = 160)#160
 #Heart = it.Item(stat_main = 50, stat_sub = 50, att = 77, boss_pdamage = 30, armor_ignore = 30)
 #Badge = it.Item(stat_main = 15, stat_sub = 15, att = 10)
 #Ring = it.Item(stat_main = 5, stat_sub = 5, att = 4)

--- a/dpmModule/item/Default.py
+++ b/dpmModule/item/Default.py
@@ -2,23 +2,23 @@ from . import ItemKernel as it
 
 #TODO : 이런 프로세스들을 좀 더 factorization 할 수는 없을까..
 
-EventRing = it.Item(stat_main = 30, stat_sub = 30, att = 20)
+EventRing = it.Item(name="이벤트 링", stat_main = 30, stat_sub = 30, att = 20, level = 120)
 def getEventRing(potential = it.CharacterModifier(), additional_potential = it.CharacterModifier()):
     item = EventRing.copy()
     item.set_potential(potential)
     item.set_additional_potential(additional_potential)
     return item
 
-Subweapon = it.Item(stat_main = 10, stat_sub = 10, att = 3)
+Subweapon = it.Item(name="보조무기", stat_main = 10, stat_sub = 10, att = 3, level = 100)
 def getSubweapon(potential = it.CharacterModifier(), additional_potential = it.CharacterModifier()):
     item = Subweapon.copy()
     item.set_potential(potential)
     item.set_additional_potential(additional_potential)
     return item
     
-Emblem = it.Item(stat_main = 10, stat_sub = 10, att = 2)
+Emblem = it.Item(name="엠블럼", stat_main = 10, stat_sub = 10, att = 2, level = 100)
 def getEmblem(potential = it.CharacterModifier(), additional_potential = it.CharacterModifier()):
-    item = Subweapon.copy()
+    item = Emblem.copy()
     item.set_potential(potential)
     item.set_additional_potential(additional_potential)
     return item

--- a/dpmModule/item/Else.py
+++ b/dpmModule/item/Else.py
@@ -5,34 +5,34 @@ from . import ItemKernel as it
 #칭호들
 
 
-KingOfRootAbyss = it.Item(att=3, stat_main = 8, stat_sub=8, potential = it.CharacterModifier(armor_ignore = 5, boss_pdamage = 5))
-PingkbinAndMe = it.Item(att = 5, stat_main = 10, stat_sub=10, potential = it.CharacterModifier( boss_pdamage = 10))
-MaplewellKnown = it.Item(att = 5, stat_main = 10, stat_sub=10, potential = it.CharacterModifier( armor_ignore = 10))
+KingOfRootAbyss = it.Item(name="킹 오브 루타비스", att=3, stat_main = 8, stat_sub=8, potential = it.CharacterModifier(armor_ignore = 5, boss_pdamage = 5))
+PingkbinAndMe = it.Item(name="핑아일체", att = 5, stat_main = 10, stat_sub=10, potential = it.CharacterModifier( boss_pdamage = 10))
+MaplewellKnown = it.Item(name="메이플을 잘 아는", att = 5, stat_main = 10, stat_sub=10, potential = it.CharacterModifier( armor_ignore = 10))
 
 
 # 칠요셋
-WeeklyParkBadge = it.Item(stat_main = 7, stat_sub = 7, att = 7, armor_ignore = 19)  #뱃지가 따기 더 힘드므로 세트 옵션을 아예 임베딩
+WeeklyParkBadge = it.Item(name="칠요의 뱃지", stat_main = 7, stat_sub = 7, att = 7, armor_ignore = 19)  #뱃지가 따기 더 힘드므로 세트 옵션을 아예 임베딩
 # 뱃지 방무와 세트 효과 방무는 별개이므로 방무 10퍼씩 2번 적용. (19퍼랑 동일)
-WeeklyParkTitle = it.Item(stat_main = 7, stat_sub = 7, armor_ignore = 10)
+WeeklyParkMedal = it.Item(name="칠요의 몬스터파커", stat_main = 7, stat_sub = 7, armor_ignore = 10)
 
 def get_weekly_set():
     return {"badge" : WeeklyParkBadge.copy(),
-                "title" : WeeklyParkTitle.copy() }
+                "medal" : WeeklyParkMedal.copy() }
 
 def get_medal(value):
-    return it.Item(att = value, stat_main = value, stat_sub = value)
+    return it.Item(name="훈장", att = value, stat_main = value, stat_sub = value)
 
 def get_pet(att):   
-    return it.Item(att = att)
+    return it.Item(name="펫장비", att = att)
 
 def get_heart(att, ptnl = it.CharacterModifier(), aptnl = it.CharacterModifier()):
-    return it.Item(att, potential = ptnl, additional_potential = aptnl)
+    return it.Item(name="하트", att = att, potential = ptnl, additional_potential = aptnl)
 
 def ocean_glow(star, each_enhance = it.CharacterModifier(), potential = it.CharacterModifier(),
                         additional_potential = it.CharacterModifier(),
                         bonus = it.CharacterModifier()):
     
-    OceanGlowEaring = it.Item(stat_main = 7, stat_sub = 5, att = 5)
+    OceanGlowEaring = it.Item(name="오션 글로우 이어링", stat_main = 7, stat_sub = 5, att = 5)
     OceanGlowEaring.add_main_option(bonus)
     OceanGlowEaring.set_potential(potential)
     OceanGlowEaring.set_additional_potential(additional_potential)

--- a/dpmModule/item/Empress.py
+++ b/dpmModule/item/Empress.py
@@ -44,13 +44,14 @@ class Factory():
             item = package[itemkey]
             item.set_potential(potential)
             item.set_additional_potential(additional_potential)
-            item.add_main_option(bonus)
+            if itemkey != "shoulder":
+                item.add_main_option(bonus)
             item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(140, star))
-            if itemkey == "glove":
-                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(140, elist = scrolls[idx]))
-            else: #For glove
-                item.add_main_option(it.EnhancerFactory.get_glove_scroll_enhancement(140, elist = scrolls[idx]))
+            if itemkey == "glove": #For glove
                 item.add_main_option(it.EnhancerFactory.get_glove_bonus_starforce_enhancement(star))
+                item.add_main_option(it.EnhancerFactory.get_glove_scroll_enhancement(140, elist = scrolls[idx]))
+            else:
+                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(140, elist = scrolls[idx]))
             
         return package
         

--- a/dpmModule/item/Empress.py
+++ b/dpmModule/item/Empress.py
@@ -1,10 +1,10 @@
 from . import ItemKernel as it
 
-Head = it.Item(stat_main = 25, stat_sub = 25, att = 1, armor_ignore = 10)
-Glove = it.Item(stat_main = 16, stat_sub = 16, att = 5)
-Shoes = it.Item(stat_main = 15, stat_sub = 15, att = 1)
-Cloak = it.Item(stat_main = 7, stat_sub = 7, att = 1)
-Shoulder = it.Item(stat_main = 11, stat_sub = 11, att = 7)
+Head = it.Item(name="여제 모자", stat_main = 25, stat_sub = 25, att = 1, armor_ignore = 10, level = 140)
+Glove = it.Item(name="여제 장갑", stat_main = 16, stat_sub = 16, att = 5, level = 140)
+Shoes = it.Item(name="여제 신발", stat_main = 15, stat_sub = 15, att = 1, level = 140)
+Cloak = it.Item(name="여제 망토", stat_main = 7, stat_sub = 7, att = 1, level = 140)
+Shoulder = it.Item(name="여제 견장", stat_main = 11, stat_sub = 11, att = 7, level = 140)
 
 _valueMap = [[69, [0,9,13,17,23,29]],
                 [100,[0,12,18,25,32,41]],
@@ -22,36 +22,6 @@ _valueMap = [[69, [0,9,13,17,23,29]],
 WeaponFactory = it.WeaponFactoryClass(140, _valueMap, modifier = it.CharacterModifier(stat_main = 35, stat_sub = 20))
 
 class Factory():
-    @staticmethod
-    def getArmorSet(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
-        assert(enhance in [100, 70, 30])
-        #TODO : Simplyfy this dirty codes.
-        if not hammer: 
-            upgrades = [10,7,7,7,1]
-        else:
-            upgrades = [11,8,8,8,2]
-         
-        if enhance == 100:
-            scrolls = [[upgrades[i],0,0] for i in range(5)]
-        elif enhance == 70:
-            scrolls = [[0,upgrades[i],0] for i in range(5)]
-        else:
-            scrolls = [[0,0,upgrades[i]] for i in range(5)]
-            
-        retli = [ Head.copy(), Glove.copy(), Shoes.copy(), Cloak.copy(), Shoulder.copy()]
-        for idx, item in zip([0,1,2,3,4],retli):
-            item.set_potential(potential)
-            item.set_additional_potential(additional_potential)
-            item.add_main_option(bonus)
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(140, star))
-            if idx != 1:
-                item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(140, elist = scrolls[idx]))
-            else: #For glove
-                item.add_main_option(it.EnhancerFactory.get_glove_scroll_enhancement(140, elist = scrolls[idx]))
-                item.add_main_option(it.EnhancerFactory.get_glove_bonus_starforce_enhancement(star))
-            
-        return retli
-
     @staticmethod
     def getArmorSetDict(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
         assert(enhance in [100, 70, 30])

--- a/dpmModule/item/ItemKernel.py
+++ b/dpmModule/item/ItemKernel.py
@@ -238,7 +238,7 @@ class EnhancerFactory():
         elif level == 200:
             stli, atli = EnhancerFactory.starforce_200_stat, EnhancerFactory.starforce_200_armor_att            
         else:
-            raise TypeError("Level Must be 90, 110, 120, 130, 140, 150, 160, 200")
+            raise TypeError("Level Must be 90, 100, 110, 120, 130, 140, 150, 160, 200")
         return CharacterModifier(stat_main = stli[min(star, len(stli) - 1)], stat_sub = stli[min(star, len(stli) - 1)], att = atli[min(star, len(atli) - 1)])  
     
     @classmethod    

--- a/dpmModule/item/ItemKernel.py
+++ b/dpmModule/item/ItemKernel.py
@@ -73,7 +73,7 @@ class Item():
         self.additional_potential = mdf.copy()
         
     def copy(self):
-        return Item(stat_main = self.stat_main, \
+        return Item(name = self.name, level = self.level, stat_main = self.stat_main, \
         stat_sub = self.stat_sub, att = self.att, patt = self.patt, pdamage = self.pdamage,\
         armor_ignore = self.armor_ignore, pstat_main = self.pstat_main, pstat_sub = self.pstat_sub, \
         potential = self.potential, \
@@ -84,45 +84,32 @@ class Item():
                 "potential" : self.potential.as_dict(),
                 "additional_potential" : self.additional_potential.as_dict()}
         
-class Potential():
-    def __init__(self):
-        self.stat_main = 0
-        self.stat_sub = 0
-        self.pstat_main = 0
-        self.pstat_sub = 0
-        
-        self.att = 0
-        self.patt = 0
-        self.pdamage = 0
-        self.boss_pdamage = 0
-        self.armor_ignore = 0
-        
-        self.crit = 0
-        self.crit_damage = 0
-    
-    def dump(self):
-        dump = str(self.stat_main) + "," + str(self.stat_sub) + "," + str(self.pstat_main) + "," + str(self.pstat_sub) + "," + str(self.att) + "," + str(self.patt) + "," + self.pdamage + "," + self.boss_pdamage + "," + self.armor_ignore + "," + self.crit
-        return dump
-        
-    def load(self, dump_string):
-        vals = dump_string.split(",")
-        self.stat_main = int(vals[0])
-        self.stat_sub = int(vals[1])
-        self.pstat_main = int(vals[2])
-        self.pstat_sub = int(vals[3])
-        
-        self.att = int(vals[4])
-        self.patt = int(vals[5])
-        self.pdamage = int(vals[6])
-        self.boss_pdamage = int(vals[7])
-        self.armor_ignore = int(vals[8])
-        
-        self.crit = int(vals[9])
-        
-    def get_modifier(self):
-        return CharacterModifier(stat_main = self.stat_main, stat_sub = self.stat_sub, pstat_main = self.pstat_main, pstat_sub = self.pstat_sub, att = self.att, patt = self.patt, pdamage = self.pdamage, boss_pdamage = self.boss_pdamage, armor_ignore = self.armor_ignore, crit = self.crit, crit_damage = self.crit_damage)
+    def log(self):
+        txt = "name : %s, level : %d\n"%(self.name, self.level)
+        txt += "stat_main : %.1f, stat_sub %.1f\n"%(self.stat_main, self.stat_sub)
+        txt += "pstat_main : %.1f, pstat_sub %.1f\n"%(self.pstat_main, self.pstat_sub)
+        txt += "att : %.1f, patt %.1f\n"%(self.att, self.patt)
+        txt += "pdamage : %.1f, armor_ignore %.1f\n"%(self.pdamage, self.armor_ignore)
+        txt += "==potential==\n"
+        txt += "pstat_main : %.1f, pstat_sub %.1f\n"%(self.potential.pstat_main, self.potential.pstat_sub)
+        txt += "att : %.1f, patt %.1f\n"%(self.potential.att, self.potential.patt)
+        txt += "pdamage : %.1f, armor_ignore %.1f\n"%(self.potential.pdamage, self.potential.armor_ignore)
+        txt += "==additional_potential==\n"
+        txt += "pstat_main : %.1f, pstat_sub %.1f\n"%(self.additional_potential.pstat_main, self.additional_potential.pstat_sub)
+        txt += "att : %.1f, patt %.1f\n"%(self.additional_potential.att, self.additional_potential.patt)
+        txt += "pdamage : %.1f, armor_ignore %.1f\n"%(self.additional_potential.pdamage, self.additional_potential.armor_ignore)
+        return txt
 
 class EnhancerFactory():
+    starforce_90_stat = [0, 2, 4, 6, 8, 10]
+    starforce_90_armor_att = [0, 0, 0, 0, 0]
+    
+    starforce_100_stat = [0, 2, 4, 6, 8, 10, 13, 16, 19]
+    starforce_100_armor_att = [0, 0, 0, 0, 0, 0, 0, 0, 0]
+    
+    starforce_110_stat = [0, 2, 4, 6, 8, 10, 13, 16, 19, 22, 25]
+    starforce_110_armor_att = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
     starforce_120_stat = [0, 2, 4, 6, 8, 10, 13, 16, 19, 22, 25, 28, 31, 34, 37, 40]
     starforce_120_armor_att = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]    
     
@@ -230,7 +217,13 @@ class EnhancerFactory():
     
     @classmethod
     def get_armor_starforce_enhancement(self, level, star):
-        if level == 120:
+        if level == 90:
+            stli, atli = EnhancerFactory.starforce_90_stat, EnhancerFactory.starforce_90_armor_att
+        elif level == 100:
+            stli, atli = EnhancerFactory.starforce_100_stat, EnhancerFactory.starforce_100_armor_att
+        elif level == 110:
+            stli, atli = EnhancerFactory.starforce_110_stat, EnhancerFactory.starforce_110_armor_att
+        elif level == 120:
             stli, atli = EnhancerFactory.starforce_120_stat, EnhancerFactory.starforce_120_armor_att
         elif level == 130:
             stli, atli = EnhancerFactory.starforce_130_stat, EnhancerFactory.starforce_130_armor_att
@@ -243,8 +236,8 @@ class EnhancerFactory():
         elif level == 200:
             stli, atli = EnhancerFactory.starforce_200_stat, EnhancerFactory.starforce_200_armor_att            
         else:
-            raise TypeError("Level Must be 120, 130, 140, 150, 160, 200")
-        return CharacterModifier(stat_main = stli[star], stat_sub = stli[star], att = atli[star])  
+            raise TypeError("Level Must be 90, 110, 120, 130, 140, 150, 160, 200")
+        return CharacterModifier(stat_main = stli[min(star, len(stli) - 1)], stat_sub = stli[min(star, len(stli) - 1)], att = atli[min(star, len(atli) - 1)])  
     
     @classmethod    
     def get_glove_scroll_enhancement(self, level, elist = [0, 0, 0]):
@@ -356,7 +349,7 @@ class WeaponFactoryClass():
         if _type == '블레이드':
             _type = '단검'
         _att, _bonus = self.getMap(_type)
-        item = Item(att = _att)
+        item = Item(name = _type, att = _att, level = self.level)
         item.add_main_option(self.modifier)
         item.add_main_option(EnhancerFactory.get_weapon_scroll_enhancement(self.level, elist))
         item.add_main_option(CharacterModifier(att = _bonus[-1*bonusAttIndex]))
@@ -378,7 +371,7 @@ class WeaponFactoryClass():
             raise TypeError("Invalid blade, (Arcane, Absolab, RootAbyss) is allowed.")
 
         _att, _bonus = self.getMap(_type)
-        item = Item(att = _att)
+        item = Item(name = "블레이드", att = _att, level = self.level)
         item.add_main_option(get_blade_modifier())
         item.add_main_option(EnhancerFactory.get_weapon_scroll_enhancement(self.level, elist))
         item.add_main_option(EnhancerFactory.get_weapon_starforce_enhancement(item, self.level, star))

--- a/dpmModule/item/ItemKernel.py
+++ b/dpmModule/item/ItemKernel.py
@@ -94,10 +94,12 @@ class Item():
         txt += "pstat_main : %.1f, pstat_sub %.1f\n"%(self.potential.pstat_main, self.potential.pstat_sub)
         txt += "att : %.1f, patt %.1f\n"%(self.potential.att, self.potential.patt)
         txt += "pdamage : %.1f, armor_ignore %.1f\n"%(self.potential.pdamage, self.potential.armor_ignore)
+        txt += "crit : %.1f, crit_damage %.1f\n"%(self.potential.crit, self.potential.crit_damage)
         txt += "==additional_potential==\n"
         txt += "pstat_main : %.1f, pstat_sub %.1f\n"%(self.additional_potential.pstat_main, self.additional_potential.pstat_sub)
         txt += "att : %.1f, patt %.1f\n"%(self.additional_potential.att, self.additional_potential.patt)
         txt += "pdamage : %.1f, armor_ignore %.1f\n"%(self.additional_potential.pdamage, self.additional_potential.armor_ignore)
+        txt += "crit : %.1f, crit_damage %.1f\n"%(self.potential.crit, self.potential.crit_damage)
         return txt
 
 class EnhancerFactory():

--- a/dpmModule/item/Meister.py
+++ b/dpmModule/item/Meister.py
@@ -1,8 +1,8 @@
 from . import ItemKernel as it
 
-Ring = it.Item(stat_main = 5, stat_sub = 5, att = 1)
-Ear = it.Item(stat_main = 5, stat_sub = 5, att = 4)
-Soulder = it.Item(stat_main = 13, stat_sub = 13, att = 9)
+Ring = it.Item(name="마이스터링", stat_main = 5, stat_sub = 5, att = 1, level = 140)
+Ear = it.Item(name="마이스터 이어링", stat_main = 5, stat_sub = 5, att = 4, level = 140)
+Soulder = it.Item(name="마이스터 숄더", stat_main = 13, stat_sub = 13, att = 9, level = 140)
 
 
 class Factory():

--- a/dpmModule/item/Meister.py
+++ b/dpmModule/item/Meister.py
@@ -14,8 +14,6 @@ class Factory():
             upgrades = [6,1,1]
         else:
             upgrades = [7,2,2]
-            
-        item_level = 140
         
         miester_ring = Ring.copy()
         miester_ear = Ear.copy()

--- a/dpmModule/item/RootAbyss.py
+++ b/dpmModule/item/RootAbyss.py
@@ -2,9 +2,9 @@ from . import ItemKernel as it
 
 ## Armors ##
 #No upgrade
-Top = it.Item(stat_main = 30, stat_sub = 30, att = 2, armor_ignore = 5)
-Bottom = it.Item(stat_main = 30, stat_sub = 30, att = 2, armor_ignore = 5)
-Head = it.Item(stat_main = 40, stat_sub = 40, att = 2, armor_ignore = 10)
+Top = it.Item(name="이글아이 아머", stat_main = 30, stat_sub = 30, att = 2, armor_ignore = 5, level = 150)
+Bottom = it.Item(name="트릭스터 팬츠", stat_main = 30, stat_sub = 30, att = 2, armor_ignore = 5, level = 150)
+Head = it.Item(name="하이네스 햇", stat_main = 40, stat_sub = 40, att = 2, armor_ignore = 10, level = 150)
 
 _valueMap = [[86, [0,11,16,21,28,36]],
                 [125,[0,15,22,31,40,52]],
@@ -23,32 +23,6 @@ WeaponFactory = it.WeaponFactoryClass(150, _valueMap, modifier = it.CharacterMod
 
 
 class Factory():
-    @staticmethod
-    def getArmorSet(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
-        if not hammer: 
-            upgrades = [11,7,7]
-        else:
-            upgrades = [12,8,8]
-        #TODO : Simplyfy this dirty codes.
-        if enhance == 100:
-            scrolls = [[upgrades[i],0,0] for i in range(3)]
-        elif enhance == 70:
-            scrolls = [[0,upgrades[i],0] for i in range(3)]
-        elif enhance == 30:
-            scrolls = [[0,0,upgrades[i]] for i in range(3)]
-        else:
-            raise TypeError("enhance must be 100, 70, or 30.")
-            
-        retli = [ Head.copy(), Top.copy(), Bottom.copy()]
-        for idx, item in zip([0,1,2],retli):
-            item.set_potential(potential)
-            item.set_additional_potential(additional_potential)
-            item.add_main_option(bonus)
-            item.add_main_option(it.EnhancerFactory.get_armor_starforce_enhancement(150, star))
-            item.add_main_option(it.EnhancerFactory.get_armor_scroll_enhancement(150, elist = scrolls[idx]))
-            
-        return retli
-        
     @staticmethod
     def getArmorSetDict(star = 0, enhance = 70, potential = it.CharacterModifier(), additional_potential = it.CharacterModifier(), bonus = it.CharacterModifier(), hammer = True):
         if not hammer: 

--- a/dpmModule/item/Tyrant.py
+++ b/dpmModule/item/Tyrant.py
@@ -3,10 +3,10 @@ from . import ItemKernel as it
 # 장갑은 아무도 안씀
 #Glove = it.Item(stat_main = 12, stat_sub = 12, att = 15)
 # 신발 업횟 2
-Shoes = it.Item(stat_main = 50, stat_sub = 50, att = 30)
+Shoes = it.Item(name="타일런트 슈즈", stat_main = 50, stat_sub = 50, att = 30, level = 150)
 # 망토 업횟 2
-Cloak = it.Item(stat_main = 50, stat_sub = 50, att = 30)
+Cloak = it.Item(name="타일런트 클록", stat_main = 50, stat_sub = 50, att = 30, level = 150)
 # 벨트 업횟 1
-Belt = it.Item(stat_main = 50, stat_sub = 50, att = 25)
+Belt = it.Item(name="타일런트 벨트", stat_main = 50, stat_sub = 50, att = 25, level = 150)
 
 # get_surprise_enhance_list_direct 사용 (150제)

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1693,7 +1693,7 @@ class Analytics():
         
         #For speed acceleration
         if self.print_calculation_progress:
-            self.log('At Time %.1f, Skill [%s] ... Damage [%.1f] ... Delay [%.1f]' % (result.time, result.sname, deal, result.delay))
+            self.log('At Time %.1f, Skill [%s] ... Damage [%.1f] ... Loss [%.1f] ... Delay [%.1f]' % (result.time, result.sname, deal, free_deal - deal, result.delay))
             self.log(f'{result.mdf}')
         if deal > 0:
             self.logList.append({"result":result, "time" : (result.time), "deal" : deal, "loss" : free_deal - deal})


### PR DESCRIPTION
fix #198
fix #205
* 레벨 누락된 아이템들 전부 추가
* 아이템들에 이름 추가
* template의 아이템들 출력하는 메소드 추가
* 안쓰는 getArmorSet 메소드 제거
* 안쓰는 Potential 클래스 제거
* 90~110렙 스타포스 테이블 추가
* 칠요의 몬스터파커 훈장이 칭호로 적용되던것 수정
* 엠블럼 자리에 보조무기가 들어가던것 수정
* 파풀마 렙제, 블빈마 렙제 강화 범위에 맞게 수정
* 템플릿 코드 리팩토링
* add_item 관련 제거, set_items로 일괄 정리
* 견장에 추옵 붙던것 수정
* 포켓, 뱃지에 스타포스 되던것 수정
* 8000이상 22성 마이스터 이어링 사용
* 놀장고피아 못씀, 놀장실블로 변경
* 8000이상 놀장실블/마이링/이벤링/이벤링
* 여제셋 사용하는 스펙에 장갑 누락 수정
* log에 맥뎀누수 표기
* 매커네이터 120제로 수정
* 일부 앱솔셋에 빠진 에디 공10 적용
* 6000 잠재 15%로 써두고 12%로 적용한것 수정
* Item.log()에 크확 크뎀 추가
* 8500급 템플릿 설명 동기화
* 에디셔널 누락된 아이템 추가
* 장갑과 다른 방어구 작,강화 로직 뒤바뀐것 수정