### PR TITLE
feat: 도트 스킬에 뎀퍼, 최종뎀 적용 안되게 함

### DIFF
--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -151,28 +151,29 @@ class CharacterModifier(object):
 
                 else:
                     return M
-        
-        if spec == "dot":
-            pdamage = 0
-            pdamage_indep = 0
-        else:
-            pdamage = self.pdamage
-            pdamage_indep = self.pdamage_indep
 
         #Optimized
         real_crit = min(100, self.crit)
         stat = (4 * self.stat_main * (1 + 0.01 * self.pstat_main) + self.stat_sub * (1 + 0.01 * self.pstat_sub)) + (4 * self.stat_main_fixed + self.stat_sub_fixed )
         adap = self.att * (1 + 0.01 * self.patt)
-        factor_crit_removed = (1 + 0.01 * (max(pdamage + self.boss_pdamage, 0))) * (1 + 0.01 * pdamage_indep)
-        ignorance = max((100 - armor * (1 - 0.01* self.armor_ignore)) * 0.01, 0)        
+        factor_crit_removed = (1 + 0.01 * (max(self.pdamage + self.boss_pdamage, 0))) * (1 + 0.01 * self.pdamage_indep)
+        ignorance = max((100 - armor * (1 - 0.01* self.armor_ignore)) * 0.01, 0)
+        expert_max = 100 / 95
+        expert_min = 90 / 95
+
+        if spec == "dot":
+            real_crit = 0
+            factor_crit_removed = 1
+            ignorance = 1
+            expert_min = expert_max
         
         factor_aggregated = stat * adap * factor_crit_removed * ignorance * damage * 0.0001
         
         max_crit_factor = (1 + 0.0001 * max(0, real_crit) * (self.crit_damage + 50))
         min_crit_factor = (1 + 0.0001 * max(0, real_crit) * (self.crit_damage + 20))
         
-        max_damage_factor = factor_aggregated * (100/95)
-        min_damage_factor = factor_aggregated * (90/95)
+        max_damage_factor = factor_aggregated * expert_max
+        min_damage_factor = factor_aggregated * expert_min
 
         real_damage = hit * (max_crit_factor + min_crit_factor) / 2 * (max_damage_factor + min_damage_factor) / 2 # W/O restriction
         res_damage = hit * restricted_damage(min_damage_factor, max_damage_factor, min_crit_factor, max_crit_factor, MAX_DAMAGE_RESTRICTION)  # W/ restriction
@@ -1137,7 +1138,7 @@ class BuffSkillWrapper(AbstractSkillWrapper):
             self.available = False
         delay = self.skill.delay
         #mdf = self.get_modifier()
-        return ResultObject(delay, CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'buff', kwargs = {"remain" : self.skill.remain * (1+0.01*rem*self.skill.rem)})
+        return ResultObject(delay, CharacterModifier(), 0, 0, sname = self.skill.name, spec = self.skill.spec, kwargs = {"remain" : self.skill.remain * (1+0.01*rem*self.skill.rem)})
 
     def get_modifier(self) -> CharacterModifier:
         if self.onoff:
@@ -1242,7 +1243,7 @@ class DamageSkillWrapper(AbstractSkillWrapper):
         self.cooltimeLeft = self.skill.cooltime * (1-0.01*red*self.skill.red)
         if self.cooltimeLeft > 0:
             self.available = False
-        return ResultObject(self.skill.delay, self.get_modifier(), self.skill.damage, self.skill.hit, sname = self.skill.name, spec = 'deal')
+        return ResultObject(self.skill.delay, self.get_modifier(), self.skill.damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
         #return delay, mdf, dmg, self.cascade
         
     def get_modifier(self) -> CharacterModifier:


### PR DESCRIPTION
* calculate_damage에 AbstractSkill의 spec을 전달
* spec이 dot라면 최종뎀, 뎀퍼를 0으로 적용

fix https://github.com/oleneyl/maplestory_dpm_calc/issues/212

@oleneyl 이런 식으로 변경해도 되는건지 확인 부탁드립니다.