### PR TITLE
fix: 시그너스 직업 스킬

### DIFF
--- a/dpmModule/jobs/jobbranch/bowmen.py
+++ b/dpmModule/jobs/jobbranch/bowmen.py
@@ -13,7 +13,7 @@ from functools import partial
 # bonus = 직업별 보정 수치. self.char.get_modifier()가 패시브만 적용된 수치를 반환하므로, 버프 스킬로 오르는 크확을 따로 표시해줘야 한다.
 class CriticalReinforceWrapper(core.BuffSkillWrapper):
     def __init__(self, vEhc, character : ck.AbstractCharacter, num1, num2, bonus):
-        skill = core.BuffSkill("크리티컬 리인포스", 780, 30 * 1000, cooltime = 120 * 1000).isV(vEhc, num1, num2)
+        skill = core.BuffSkill("크리티컬 리인포스", 600, 30 * 1000, cooltime = 120 * 1000).isV(vEhc, num1, num2)
         super(CriticalReinforceWrapper, self).__init__(skill)
         self.char = character
         self.inhancer = (20 + vEhc.getV(num1, num2))*0.01

--- a/dpmModule/jobs/jobbranch/pirates.py
+++ b/dpmModule/jobs/jobbranch/pirates.py
@@ -7,7 +7,7 @@ from functools import partial
 # 오버드라이브 함수 버전
 # 직업 소스에서 chtr.itemlist["weapon"].att 으로 무기 공격력 접근이 가능하나 강화 후 공격력이 나옴
 def OverdriveWrapper(vEhc, num1, num2, WEAPON_ATT):
-    Overdrive = core.BuffSkill("오버 드라이브", 540, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
+    Overdrive = core.BuffSkill("오버 드라이브", 420, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     OverdrivePenalty = core.BuffSkill("오버 드라이브(페널티)", 0, (40 - 0.2*vEhc.getV(num1, num2))*1000, cooltime = -1, att = -0.15 * WEAPON_ATT).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
     OverdrivePenalty.set_disabled_and_time_left(-1)

--- a/dpmModule/jobs/jobbranch/thieves.py
+++ b/dpmModule/jobs/jobbranch/thieves.py
@@ -8,7 +8,7 @@ from functools import partial
 
 # 직업별 스크립트 완전히 파악되면 통합 필요
 def ReadyToDieWrapper(vEhc, num1, num2):
-    ReadyToDie = core.BuffSkill("레디 투 다이", 780, 15*1000, cooltime = (90-int(0.5*vEhc.getV(num1, num2)))*1000, pdamage_indep = 30+int(0.2*vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
+    ReadyToDie = core.BuffSkill("레디 투 다이", 600 * 2, 15*1000, cooltime = (90-int(0.5*vEhc.getV(num1, num2)))*1000, pdamage_indep = 30+int(0.2*vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     return ReadyToDie
 
 def ReadyToDiePassiveWrapper(vEhc, num1, num2):

--- a/dpmModule/jobs/jobbranch/warriors.py
+++ b/dpmModule/jobs/jobbranch/warriors.py
@@ -7,7 +7,7 @@ from functools import partial
 class AuraWeaponBuilder():
     def __init__(self, enhancer, skill_importance, enhance_importance, modifier=core.CharacterModifier(), hit=6):
         self.AuraWeaponBuff = core.BuffSkill(
-            "오라 웨폰(버프)", 0, (80 +2*enhancer.getV(skill_importance,enhance_importance)) * 1000, 
+            "오라 웨폰(버프)", 720, (80 +2*enhancer.getV(skill_importance,enhance_importance)) * 1000, 
             cooltime = 180 * 1000, armor_ignore = 15, pdamage_indep = (enhancer.getV(skill_importance, enhance_importance) // 5)
         ).isV(enhancer, skill_importance, enhance_importance).wrap(core.BuffSkillWrapper)  #두 스킬 syncronize 할 것!
         self.AuraWeaponCooltimeDummy = core.BuffSkill("오라웨폰(딜레이 더미)", 0, 5000, cooltime = -1).wrap(core.BuffSkillWrapper)   # 한 번 발동된 이후에는 4초간 발동되지 않도록 합니다.

--- a/dpmModule/jobs/jobclass/cygnus.py
+++ b/dpmModule/jobs/jobclass/cygnus.py
@@ -5,7 +5,7 @@ from ...character import characterKernel as ck
 from functools import partial
 
 def PhalanxChargeWrapper(vEhc, num1, num2):
-    PhalanxCharge = core.DamageSkill("시그너스 팔랑크스", 780, 450 + 18*vEhc.getV(num1, num2), 40 + vEhc.getV(num1, num2), cooltime = 30 * 1000).isV(vEhc, num1, num2).wrap(core.DamageSkillWrapper)
+    PhalanxCharge = core.DamageSkill("시그너스 팔랑크스", 600, 450 + 18*vEhc.getV(num1, num2), 40 + vEhc.getV(num1, num2), cooltime = 30 * 1000).isV(vEhc, num1, num2).wrap(core.DamageSkillWrapper)
     return PhalanxCharge
 
 class CygnusBlessWrapper(core.BuffSkillWrapper):

--- a/dpmModule/jobs/nightwalker.py
+++ b/dpmModule/jobs/nightwalker.py
@@ -65,14 +65,14 @@ class JobGenerator(ck.JobGenerator):
         JUMPRATE = 1
         BATRATE = 0.3333
 
-        ElementalDarkness = core.BuffSkill("엘리멘탈 : 다크니스", 1440, 180000, armor_ignore = (4+1+1+1) * (2+1+1+1)).wrap(core.BuffSkillWrapper)
+        ElementalDarkness = core.BuffSkill("엘리멘탈 : 다크니스", 900, 180000, armor_ignore = (4+1+1+1) * (2+1+1+1)).wrap(core.BuffSkillWrapper)
         ElementalDarknessDOT = core.DotSkill("엘리멘탈 : 다크니스(도트)", (80 + 40 + 50 + 50) * (2+1+1+1), 100000000).wrap(core.SummonSkillWrapper)
         Heist = core.BuffSkill("헤이스트", 0, 180000, rem  = True).wrap(core.BuffSkillWrapper)
-        Booster = core.BuffSkill("부스터", 0, 180000, rem  = True).wrap(core.BuffSkillWrapper)
-        ShadowServent = core.BuffSkill("쉐도우 서번트", 990, 180000).wrap(core.BuffSkillWrapper)
-        SpiritThrowing = core.BuffSkill("스피릿 스로잉", 0, 180000, rem  = True).wrap(core.BuffSkillWrapper)
+        Booster = core.BuffSkill("부스터", 0, 180000, rem  = True).wrap(core.BuffSkillWrapper) # 펫버프
+        ShadowServent = core.BuffSkill("쉐도우 서번트", 0, 180000).wrap(core.BuffSkillWrapper) # 펫버프
+        SpiritThrowing = core.BuffSkill("스피릿 스로잉", 0, 180000, rem  = True).wrap(core.BuffSkillWrapper) # 펫버프
         
-        ShadowBat = core.DamageSkill("쉐도우 배트", 0, 150 + 120 + 150 + 200 - 30, BATRATE).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)  #3회 공격당 1번 소환
+        ShadowBat = core.DamageSkill("쉐도우 배트", 0, 150 + 120 + 150 + 200, BATRATE).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)  #3회 공격당 1번 소환
         
         #점샷기준(400ms)
         QuintupleThrow = core.DamageSkill("퀸터플 스로우", (400 * JUMPRATE + 630 * (1-JUMPRATE)), 340, 4, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, crit = 10, pdamage_indep = (JUMPRATE*15))).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
@@ -88,8 +88,8 @@ class JobGenerator(ck.JobGenerator):
         QuintupleThrowFinal_V = core.DamageSkill("퀸터플 스로우(5차)(막타)", 0, 475 * 0.01 * (20+vEhc.getV(0,0)), 1, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, crit = 10, pdamage_indep = (JUMPRATE*15))).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
     
         #하이퍼스킬
-        ShadowElusion = core.BuffSkill("쉐도우 일루전", 990, 30000, cooltime = 180000).wrap(core.BuffSkillWrapper)
-        Dominion = core.BuffSkill("도미니언", 2680, 30000, crit = 100, pdamage_indep = 20, cooltime = 180000).wrap(core.BuffSkillWrapper)
+        ShadowElusion = core.BuffSkill("쉐도우 일루전", 690, 30000, cooltime = 180000).wrap(core.BuffSkillWrapper)
+        Dominion = core.BuffSkill("도미니언", 1890, 30000, crit = 100, pdamage_indep = 20, cooltime = 180000).wrap(core.BuffSkillWrapper)
         DominionAttack = core.DamageSkill("도미니언(공격)", 0, 1000, 10).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
 
         GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
@@ -98,14 +98,14 @@ class JobGenerator(ck.JobGenerator):
 
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 3, 3)
 
-        ShadowSpear = core.BuffSkill("쉐도우 스피어", 600, (50+vEhc.getV(0,0))*1000, red = True, cooltime = (181-vEhc.getV(0,0)//2)*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        ShadowSpear = core.BuffSkill("쉐도우 스피어", 600, (50+vEhc.getV(0,0))*1000, red = True, cooltime = int(181 - vEhc.getV(0,0) / 2)*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         ShadowSpearSmall = core.DamageSkill("쉐도우 스피어(창)", 0, 100+4*vEhc.getV(0,0), 4).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         ShadowSpearSmallBat = core.DamageSkill("쉐도우 스피어(창)(배트)", 0, 100+4*vEhc.getV(0,0), 4.0*BATRATE).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
-        ShadowSpearLarge = core.SummonSkill("쉐도우 스피어(거대 창)", 0, 3000, 400 + 32*vEhc.getV(0,0), 6, (50+vEhc.getV(0,0))*1000 - 1, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        ShadowSpearLarge = core.SummonSkill("쉐도우 스피어(거대 창)", 0, 3000, 400 + 16*vEhc.getV(0,0), 6, (50+vEhc.getV(0,0))*1000 - 1, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
 
         ShadowServentExtend = core.BuffSkill("쉐도우 서번트 익스텐드", 570, (30+vEhc.getV(1,1)//2)*1000, red = True, cooltime = 60000).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)
 
-        ShadowBite = core.DamageSkill("쉐도우 바이트", 810, 600+24*vEhc.getV(2,2), 14, red = True, cooltime = 20000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowBite = core.DamageSkill("쉐도우 바이트", 630, 600+24*vEhc.getV(2,2), 14, red = True, cooltime = 20000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         ShadowBiteBuff = core.BuffSkill("쉐도우 바이트(버프)", 0, (15+vEhc.getV(2,2)//10)*1000, pdamage_indep = (8+vEhc.getV(2,2)//4), cooltime = -1).isV(vEhc,2,2).wrap(core.BuffSkillWrapper)
         ######   Skill Wrapper   ######
 

--- a/dpmModule/jobs/soulmaster.py
+++ b/dpmModule/jobs/soulmaster.py
@@ -72,8 +72,8 @@ class JobGenerator(ck.JobGenerator):
         
         CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 4, 4)
         
-        SelestialDanceInit = core.BuffSkill("셀레스티얼 댄스", 700, (40+vEhc.getV(0,0))*1000, cooltime = 150 * 1000, red = True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
-        SelestialDanceSummon = core.SummonSkill("셀레스티얼 댄스(추가타)", 0, 5000, (1200 + 40 * vEhc.getV(0,0)), 3, (40 + vEhc.getV(0,0)) * 1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) #딜레이 모름
+        SelestialDanceInit = core.BuffSkill("셀레스티얼 댄스", 570, (40+vEhc.getV(0,0))*1000, cooltime = 150 * 1000, red = True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        SelestialDanceSummon = core.SummonSkill("셀레스티얼 댄스(추가타)", 0, 5000, (1200 + 40 * vEhc.getV(0,0)), 3, (40 + vEhc.getV(0,0)) * 1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         SelestialDanceAttack = core.DamageSkill("댄스오브 문/스피딩 선셋(셀레스티얼)", 0, 400*0.01*(30+vEhc.getV(0,0)), 4 * 2, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20) + FallingMoon).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)    #직접사용 X
         
         #엘리시온 38타 / 3타

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -64,7 +64,7 @@ class JobGenerator(ck.JobGenerator):
         
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
-        하이퍼 : 질풍-보너스어택 + 섬멸-리인포스/보스킬러  + 벽력-리인포스/보너스어택
+        하이퍼 : 질풍-보너스어택 + 섬멸-리인포스/이그노어 가드/보스킬러  + 벽력-보너스어택
         
         코강 : 10개
         섬멸, 벽력, 승천, (뇌성)
@@ -78,11 +78,8 @@ class JobGenerator(ck.JobGenerator):
         벽섬 : 1020ms
         태섬 : 900ms
         
-        팔랑크스의 타수를 2/3만 적용되도록 함
         모든 스킬은 쿨타임마다 사용
         '''
-
-        PALANKSRATE = 2 / 3
         CHOOKROI = 0.7
         #Buff skills
 
@@ -95,13 +92,10 @@ class JobGenerator(ck.JobGenerator):
 
         HuricaneConcat = core.DamageSkill("태풍(연계)", 420, 390, 5+1, modifier = core.CharacterModifier(pdamage_indep = 20)).setV(vEhc, 0, 2).wrap(core.DamageSkillWrapper)
         
-        Destroy = core.DamageSkill("섬멸", 480, 350, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        Thunder = core.DamageSkill("벽력", 540, 320, 5 + 1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        DestroyConcat = core.DamageSkill("섬멸(연계)", 480, 350, 2 + 5, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20, pdamage_indep = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        ThunderConcat = core.DamageSkill("벽력(연계)", 540, 320, 5 + 1, modifier = core.CharacterModifier(pdamage = 20, pdamage_indep = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #연계최종뎀 20%
-        
-        #BasicAttack = core.DamageSkill("섬멸(기본공격)", 420, 350, 2 + 5, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        #BasicAttack = core.DamageSkill("벽력(기본공격)", 660, 320, 5 + 1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)        
+        Destroy = core.DamageSkill("섬멸", 480, 350, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        Thunder = core.DamageSkill("벽력", 540, 320, 5 + 1).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        DestroyConcat = core.DamageSkill("섬멸(연계)", 480, 350, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20, pdamage_indep = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        ThunderConcat = core.DamageSkill("벽력(연계)", 540, 320, 5 + 1, modifier = core.CharacterModifier(pdamage_indep = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #연계최종뎀 20%
 
         # 하이퍼
         # 딜레이 추가 필요
@@ -109,7 +103,7 @@ class JobGenerator(ck.JobGenerator):
         
         GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
-        CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 780, 120, 450 + 18*vEhc.getV(4,4), 1, 120 * (40 + vEhc.getV(4,4)) * PALANKSRATE, cooltime = 30 * 1000).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
+        CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 600, 120, 450 + 18*vEhc.getV(4,4), 1, 120 * (40 + vEhc.getV(4,4)), cooltime = 30 * 1000).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
         LuckyDice = core.BuffSkill("로디드 다이스", 0, 180*1000, pdamage = 20).isV(vEhc,1,3).wrap(core.BuffSkillWrapper)
 
         #오버드라이브 (앱솔 가정)
@@ -117,7 +111,7 @@ class JobGenerator(ck.JobGenerator):
         WEAPON_ATT = jobutils.get_weapon_att("너클")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
 
-        ShinNoiHapL = core.BuffSkill("신뇌합일", 0, (30+vEhc.getV(3,2)//2) * 1000, red = True, cooltime = (121-vEhc.getV(3,2)//2)*1000, pdamage_indep=4+vEhc.getV(3,2)//5).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
+        ShinNoiHapL = core.BuffSkill("신뇌합일", 540, (30+vEhc.getV(3,2)//2) * 1000, red = True, cooltime = (121-vEhc.getV(3,2)//2)*1000, pdamage_indep=4+vEhc.getV(3,2)//5).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
         ShinNoiHapLAttack = core.SummonSkill("신뇌합일(공격)", 0, 3000, 16*vEhc.getV(3,2) + 400, 7, (30+vEhc.getV(3,2)//2) * 1000, cooltime = -1).isV(vEhc,3,2).wrap(core.SummonSkillWrapper)
         ShinNoiHapLAttack_ChookRoi = core.DamageSkill('신뇌합일(축뢰)', 0, (16*vEhc.getV(3,2) + 400) * CHOOKROI, 7 ).wrap(core.DamageSkillWrapper)
         GioaTan = core.DamageSkill("교아탄", 480, 1000+40*vEhc.getV(2,1), 7, cooltime = 8000, modifier = core.CharacterModifier(pdamage_indep = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper) #  교아탄-벽력 콤보 사용함

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -52,26 +52,26 @@ class JobGenerator(ck.JobGenerator):
         SharpEyes = core.BuffSkill("샤프 아이즈", 660, 300 * 1000, crit = 20 + combat*1, crit_damage = 15 + combat*1, rem = True).wrap(core.BuffSkillWrapper)
         GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
-        StormBringerDummy = core.BuffSkill("스톰 브링어(버프)", 660, 200 * 1000).wrap(core.BuffSkillWrapper)  #딜레이 계산 필요
+        StormBringerDummy = core.BuffSkill("스톰 브링어(버프)", 0, 200 * 1000).wrap(core.BuffSkillWrapper)  #딜레이 계산 필요
         # 하이퍼: 데미지 증가, 확률 10% 증가, 타수 증가
         TriflingWhim = core.DamageSkill("트라이플링 윔", 0, (290+3*combat)*0.8+(390+3*combat)*0.2, 2*(0.5+0.1), modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         StormBringer = core.DamageSkill("스톰 브링어", 0, 500, 0.3).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
     
         # 핀포인트 피어스
-        PinPointPierce = core.DamageSkill("핀포인트 피어스", 900, 340, 2, cooltime=30 * 1000).wrap(core.DamageSkillWrapper)
+        PinPointPierce = core.DamageSkill("핀포인트 피어스", 690, 340, 2, cooltime=30 * 1000).wrap(core.DamageSkillWrapper)
         PinPointPierceDebuff = core.BuffSkill("핀포인트 피어스(버프)", 0, 30 * 1000, cooltime=-1, pdamage=15, armor_ignore=15).wrap(core.BuffSkillWrapper)
 
         #Damage Skills
         SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 +combat*3, 1, modifier = core.CharacterModifier(pdamage = 127.36, boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)# 코강렙 20이상 가정.
         
-        CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 780, 120 * 5, 450 + 18*vEhc.getV(0,0), 5, 120 * (40 + vEhc.getV(0,0)), cooltime = 30 * 1000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 600, 120 * 5, 450 + 18*vEhc.getV(0,0), 5, 120 * (40 + vEhc.getV(0,0)), cooltime = 30 * 1000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         
         Mercilesswind = core.DamageSkill("아이들 윔", 600, (500 + 20*vEhc.getV(4,4)) * 0.775, 10 * 3, cooltime = 10 * 1000).isV(vEhc,4,4).wrap(core.DamageSkillWrapper) #도트 데미지 9초간 초당 1000%
         MercilesswindDOT = core.DotSkill("아이들 윔(도트)", (500 + 20*vEhc.getV(4,4)), 9000).wrap(core.SummonSkillWrapper)
     
         #Summon Skills
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 5, 5)
-        HowlingGail = core.SummonSkill("하울링 게일", 780, 10 * 1000 / 33, 250 + 10*vEhc.getV(1,1), 2 * 3, 10000, cooltime = 20 * 1000).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) #딜레이 모름, 64���
+        HowlingGail = core.SummonSkill("하울링 게일", 630, 10 * 1000 / 33, 250 + 10*vEhc.getV(1,1), 2 * 3, 10000, cooltime = 20 * 1000).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) #딜레이 모름, 64���
         WindWall = core.SummonSkill("윈드 월", 720, 2000, (550 + vEhc.getV(2,2)*22) / 2, 5*3 , 45 * 1000, cooltime = 90 * 1000).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         
         ######   Skill Wrapper   #####


### PR DESCRIPTION
### 나이트워커

* 엘리멘탈: 다크니스 딜레이 1440 -> 900
* 쉐도우 서번트 딜레이 0 (펫버프)
* 쉐도우 배트 퍼뎀 590 -> 620
* 쉐도우 일루전 딜레이 990 -> 690
* 도미니언 딜레이 2680 -> 1890
* 쉐도우 스피어 쿨타임 버림 적용
* 쉐도우 스피어 거대 창 30렙 퍼뎀 1360 -> 880
* 쉐도우 바이트 딜레이 810 -> 630
* 레디 투 다이 딜레이 780 -> 1200 (2단계)

### 윈드브레이커

* 스톰 브링어 660 -> 0
* 핀포인트 피어스 900 -> 690
* 시그너스 팔랑크스 780 -> 600
* 하울링 게일 780 -> 630
* 크리티컬 리인포스 780 -> 600

### 소울마스터

* 셀레스티얼 댄스 700 -> 570
* 오라 웨폰 0 -> 720

### 스트라이커

* 연계 도중 팔랑크스 방향전환 가능, 타수 100% 적용
* 하이퍼 벽력-리인포스 대신 섬멸-이그노어 가드 사용
* 신뇌합일 딜레이 0 -> 540
* 오버드라이브 딜레이 540 -> 420

플위는 다른 pr에서 수정