### PR TITLE
메카닉 로봇 마스터리 상수 정의, 공용코드 적용

### DIFF
--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -62,6 +62,7 @@ class JobGenerator(ck.JobGenerator):
         '''
         #Constants
         ROBOT_SUMMON_REMAIN = 1 + chtr.summonRemain + 0.4
+        ROBOT_MASTERY = core.CharacterModifier(pdamage_indep = 108 + combat * 3)
 
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 180 * 1000, rem = True).wrap(core.BuffSkillWrapper)    #딜레이 모름
@@ -75,18 +76,18 @@ class JobGenerator(ck.JobGenerator):
         
         #로봇들 :: 로봇당 총뎀6%, 어빌리티 적용 시 7%
         
-        Robolauncher = core.SummonSkill("로봇 런처(:RM7)", 630, 1000, (250+135)*(2.08+combat*0.03), 1, 60*1000*ROBOT_SUMMON_REMAIN).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        RobolauncherFinal = core.DamageSkill("로봇 런처(:RM7)(폭발)", 0, 400*(2.08+combat*0.03), 1, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        Robolauncher = core.SummonSkill("로봇 런처(:RM7)", 630, 1000, (250+135), 1, 60*1000*ROBOT_SUMMON_REMAIN, modifier = ROBOT_MASTERY).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        RobolauncherFinal = core.DamageSkill("로봇 런처(:RM7)(폭발)", 0, 400, 1, modifier = ROBOT_MASTERY, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         RobolauncherBuff = core.BuffSkill("로봇 런처(:RM7)(버프)", 0, 60*1000*ROBOT_SUMMON_REMAIN, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
         #MagneticField = core.SummonSkill("마그네틱 필드", ?, ?, 200, 60*1000, cooltime = 180*1000) 자폭 550% V.getEhc(2, vEnhance[0])
         
         SupportWaver = core.SummonSkill("서포트 웨이버", 630, 80000*ROBOT_SUMMON_REMAIN, 0, 0, 80*1000*ROBOT_SUMMON_REMAIN).wrap(core.SummonSkillWrapper)
         SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*ROBOT_SUMMON_REMAIN, pdamage_indep=16, pdamage = 7, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)
-        SupportWaverFinal = core.DamageSkill("서포트 웨이버(폭발)", 0, 1100*(2.08+combat*0.03), 1, cooltime = -1).wrap(core.DamageSkillWrapper)
+        SupportWaverFinal = core.DamageSkill("서포트 웨이버(폭발)", 0, 1100, 1, modifier = ROBOT_MASTERY, cooltime = -1).wrap(core.DamageSkillWrapper)
         
-        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500*(2.08+combat*0.03), 3, 30*1000*ROBOT_SUMMON_REMAIN, cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
+        RoboFactory = core.SummonSkill("로봇 팩토리", 630, 3000, 500, 3, 30*1000*ROBOT_SUMMON_REMAIN, modifier = ROBOT_MASTERY, cooltime=60*1000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
         RoboFactoryBuff = core.BuffSkill("로봇 팩토리(버프)", 0, 30*1000*ROBOT_SUMMON_REMAIN, cooltime = -1, pdamage = 7).wrap(core.BuffSkillWrapper)
-        RoboFactoryFinal = core.DamageSkill("로봇 팩토리(폭발)", 0, 1000*(2.08+combat*0.03), 1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        RoboFactoryFinal = core.DamageSkill("로봇 팩토리(폭발)", 0, 1000, 1, modifier = ROBOT_MASTERY).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         
         BomberTime = core.BuffSkill("봄버 타임", 990, 10*1000, cooltime = 100*1000).wrap(core.BuffSkillWrapper)
         DistortionField = core.SummonSkill("디스토션 필드", 690, 4000/15, 350, 2, 4000-1, cooltime = 8000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)
@@ -95,10 +96,10 @@ class JobGenerator(ck.JobGenerator):
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("건")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
-    
-        RegistanceLineInfantry = core.SummonSkill("레지스탕스 라인 인팬트리", 360, 1000, (215+8*vEhc.getV(3, 3))*(2.08+combat*0.03), 9, 10*1000, cooltime = 25000).isV(vEhc,3, 3).wrap(core.SummonSkillWrapper) # 메카닉은 인팬트리에 로봇 마스터리 최종뎀이 적용됨
-        MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1901, (200+8*vEhc.getV(2,1))*(2.08+combat*0.03), 6, (75+2*vEhc.getV(2,1))*1000, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper) # 원래 공격주기는 1500이나, 미사일로 인해 손실되는 타수를 보정하기 위해 1901로 기입함.
-        MultipleOptionMissle = core.SummonSkill("멀티플 옵션(미사일)", 0, 8000, (350+10*vEhc.getV(2,1))*(2.08+combat*0.03), 24, (75+2*vEhc.getV(2,1))*1000, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
+
+        RegistanceLineInfantry = resistance.ResistanceLineInfantryWrapper(vEhc, 3, 3, ROBOT_MASTERY) # 메카닉은 인팬트리에 로봇 마스터리 최종뎀이 적용됨
+        MultipleOptionGattling = core.SummonSkill("멀티플 옵션(개틀링)", 780, 1901, (200+8*vEhc.getV(2,1)), 6, (75+2*vEhc.getV(2,1))*1000, modifier = ROBOT_MASTERY, cooltime = 200 * 1000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper) # 원래 공격주기는 1500이나, 미사일로 인해 손실되는 타수를 보정하기 위해 1901로 기입함.
+        MultipleOptionMissle = core.SummonSkill("멀티플 옵션(미사일)", 0, 8000, (350+10*vEhc.getV(2,1)), 24, (75+2*vEhc.getV(2,1))*1000, modifier = ROBOT_MASTERY, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         
         MicroMissle = core.DamageSkill("마이크로 미사일 컨테이너", 540, 375+17*vEhc.getV(0,0), (30 + vEhc.getV(0,0) // 3) * 5, cooltime = 25000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         BusterCall_ = core.DamageSkill("메탈아머 전탄발사", 8500/37, 400+16*vEhc.getV(4,4), 11).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)


### PR DESCRIPTION
* 로봇 마스터리 최종뎀 수치를 깔끔하게 정리했습니다.
* 레지스탕스 라인 인팬트리가 공용 코드를 사용하도록 변경했습니다.

테스트 결과 변경 전과 동일한 수치가 나옵니다.