### PR TITLE
fix: 보우마스터 스킬

### DIFF
--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -90,8 +90,8 @@ class JobGenerator(ck.JobGenerator):
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
         #Damage Skills
-        AdvancedQuibberAttack = core.DamageSkill("마법 화살", 0, 260, 0.6).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
-        AdvancedQuibberAttack_ArrowRain = core.DamageSkill("마법 화살(애로우 레인)", 0, 260, 1).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        AdvancedQuibberAttack = core.DamageSkill("어드밴스드 퀴버", 0, 260, 0.6).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        AdvancedQuibberAttack_ArrowRain = core.DamageSkill("어드밴스드 퀴버(애로우 레인)", 0, 260, 1).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
         AdvancedFinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 210, 0.7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         ArrowOfStorm = ArrowOfStormWrapper(core.DamageSkill("폭풍의 시", 120, (350+combat*3)*0.75, 1+1, modifier = core.CharacterModifier(pdamage = 30, boss_pdamage = 10)).setV(vEhc, 0, 2, True))
@@ -113,7 +113,7 @@ class JobGenerator(ck.JobGenerator):
         QuibberFullBurst = core.SummonSkill("퀴버 풀버스트", 780, 2 * 1000 / 6, 750 + 30 * vEhc.getV(2,2), 3, 30 * 1000, cooltime = -1).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         QuibberFullBurstDOT = core.DotSkill("독화살", 220, 30*1000).wrap(core.SummonSkillWrapper)
     
-        ImageArrow = core.SummonSkill("잔영의 시", 720, 270, 400+16*vEhc.getV(1,1), 3, 3000, cooltime=30000, red = True).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 11 * 3타
+        ImageArrow = core.SummonSkill("잔영의 시", 720, 240, 400+16*vEhc.getV(1,1), 3, 3000-360, cooltime=30000, red = True).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 11 * 3타, 준비 360ms
         ImageArrowPassive = core.DamageSkill("잔영의 시(패시브)", 0, 400+16*vEhc.getV(1,1), 3 * 2 * 0.1).isV(vEhc,1,1).wrap(core.DamageSkillWrapper) # 10회당 1번 생성, 생성당 3타씩 2회 공격
     
         ######   Skill Wrapper   ######
@@ -127,7 +127,7 @@ class JobGenerator(ck.JobGenerator):
 
         ArrowOfStorm.onAfter(AdvancedQuibberAttack)
         ArrowOfStorm.onAfter(AdvancedFinalAttack)
-        ArrowOfStorm.onAfter(core.OptionalElement(ImageArrow.is_not_active, ImageArrowPassive, name="액티브 OFF"))
+        ArrowOfStorm.onAfter(core.OptionalElement(ImageArrow.is_not_active, ImageArrowPassive, name="잔영의 시 액티브 OFF"))
         
         ArrowRain.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack_ArrowRain])
         ImageArrow.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack])
@@ -139,7 +139,8 @@ class JobGenerator(ck.JobGenerator):
         ### Exports ###
         return(ArrowOfStorm,
                 [globalSkill.maple_heros(chtr.level),
-                    SoulArrow, AdvancedQuibber, SharpEyes, ElusionStep, Preparation, EpicAdventure, ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff,
+                    SoulArrow, AdvancedQuibber, SharpEyes, ElusionStep, Preparation, EpicAdventure,
+                    ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff, QuibberFullBurstDOT,
                     globalSkill.soul_contract()] +\
                 [] +\
                 [Evolve, ArrowFlatter, ArrowRain, Pheonix, GuidedArrow, QuibberFullBurst, ImageArrow] +\

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -129,8 +129,9 @@ class JobGenerator(ck.JobGenerator):
         ArrowOfStorm.onAfter(AdvancedFinalAttack)
         ArrowOfStorm.onAfter(core.OptionalElement(ImageArrow.is_not_active, ImageArrowPassive, name="잔영의 시 액티브 OFF"))
         
-        ArrowRain.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack_ArrowRain])
+        ArrowRain.onTick(AdvancedQuibberAttack_ArrowRain)
         ImageArrow.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack])
+        GuidedArrow.onTick(AdvancedQuibberAttack)
         
         ArrowRainBuff.onAfter(ArrowRain)
         QuibberFullBurstBuff.onAfter(QuibberFullBurstDOT)

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -35,9 +35,9 @@ class JobGenerator(ck.JobGenerator):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5)
 
         ExtremeArchery = core.InformedCharacterModifier("익스트림 아처리",att = 40, pdamage_indep = 30)
-        MortalBlow = core.InformedCharacterModifier("모탈 블로우",pdamage = 80/9)   #확률성을 변형적용... 패치 필요할듯
+        MortalBlow = core.InformedCharacterModifier("모탈 블로우",pdamage = 80/10)   #확률성을 변형적용... 패치 필요할듯
 
-        ArmorPiercing = core.InformedCharacterModifier("아머 피어싱",pdamage_indep = 10, armor_ignore = 5)
+        ArmorPiercing = core.InformedCharacterModifier("아머 피어싱",pdamage_indep = 100/8, armor_ignore = 50/8) # 가동률 약 1/8, 잠재 쿨감 1초당 분모 0.5씩 빼야함
         
         return [WeaponConstant, Mastery,  MortalBlow, ExtremeArchery, ArmorPiercing]
 
@@ -45,50 +45,50 @@ class JobGenerator(ck.JobGenerator):
         '''
         잔영의시 : 500ms마다 타격(초당 2회)
         애로우 레인 : 떨어질 때마다 6번씩( = 2500/6 ~ 420ms)
-        
-        폭풍의 시 계산속도 향상을 위해 공속 3배 감소해서 계산하며 실제로는 제대로 계산되고 있음
-        
+                
         코강 순서:
         폭시-파택-언카블-퀴버-플래터-피닉스
-        
-        
+
+        하이퍼: 폭풍의 시 3종 / 샤프 아이즈-이그노어 가드, 크리티컬 레이트
+                
         '''
         ######   Skill   ######
         #Buff skills
-        SoulArrow = core.BuffSkill("소울 애로우", 0, 300 * 1000, att = 30).wrap(core.BuffSkillWrapper) #딜레이 모름
+        SoulArrow = core.BuffSkill("소울 애로우", 0, 300 * 1000, att = 30).wrap(core.BuffSkillWrapper) # 펫버프
         AdvancedQuibber = core.BuffSkill("어드밴스드 퀴버", 0, 30 * 1000, crit_damage = 8).wrap(core.BuffSkillWrapper)   #쿨타임 무시 가능, 딜레이 없앰
-        SharpEyes = core.BuffSkill("샤프 아이즈", 1080, 300 * 1000, crit = 20 + combat*1, crit_damage = 15 + combat*1).wrap(core.BuffSkillWrapper)
-        ElusionStep = core.BuffSkill("일루젼 스탭", 0, 300 * 1000, rem = True, stat_main = 80).wrap(core.BuffSkillWrapper)
+        SharpEyes = core.BuffSkill("샤프 아이즈", 690, 300 * 1000, crit = 20 + 5 + combat*1, crit_damage = 15 + combat*1, armor_ignore = 5).wrap(core.BuffSkillWrapper)
+        ElusionStep = core.BuffSkill("일루젼 스탭", 0, 300 * 1000, rem = True, stat_main = 80).wrap(core.BuffSkillWrapper) # 펫버프
         Preparation = core.BuffSkill("프리퍼레이션", 900, 30 * 1000, cooltime = 90 * 1000, att = 50, boss_pdamage = 20).wrap(core.BuffSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
         #ArmorPiercing = core.BuffSkill("아머 피어싱", ?, ?) #쿨 9초, 적 방어율만큼 최종뎀 1회 한정 증가, 방무 50%, 타격마다 1초 감소, 쿨타임 최대 감소량 1초
         
         #Damage Skills
-        AdvancedQuibberAttack = core.DamageSkill("어드밴스드 퀴버", 0, 260, 0.6).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
-        AdvancedFinalAttack = core.DamageSkill("파이널 어택", 0, 210, 0.7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        AdvancedQuibberAttack = core.DamageSkill("마법 화살", 0, 260, 0.6).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        AdvancedQuibberAttack_ArrowRain = core.DamageSkill("마법 화살(애로우 레인)", 0, 260, 1).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        AdvancedFinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 210, 0.7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         ArrowOfStorm = core.DamageSkill("폭풍의 시", 120, 350*0.75, 1+1, modifier = core.CharacterModifier(pdamage = 30, boss_pdamage = 10)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)  #오더스 적용 필요, 아머 피어싱, 
-        ArrowFlatter = core.SummonSkill("애로우 플래터", 600, 1000 / 4.5, 85+90, 1, 30 * 1000).setV(vEhc, 4, 2, True).wrap(core.SummonSkillWrapper)
+        ArrowFlatter = core.SummonSkill("애로우 플래터", 600, 210, 85+90+combat*3, 1, 30 * 1000, modifier = core.CharacterModifier(pdamage = 30)).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper) # 딜레이 모름
         # 작성중
         #GrittyGust = core.DamageSkill("윈드 오브 프레이", ?, 500, 81, cooltime = 15 * 1000, red = true).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         #GrittyGustDOT = core.SummonSkill("윈드 오브 프레이(도트)", 0, 1000, 200, 1, 10*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
-        #TODO : 애로우 레인(조건부 파이널어택)
-        # 최신 패치내용과 일치하는지 재확인 필요
-        ArrowRainBuff = core.BuffSkill("애로우 레인(버프)", 720, (40+vEhc.getV(0,0))*1000, cooltime = 120 * 1000, red = True, pdamage = 15+(vEhc.getV(0,0)//2)).isV(vEhc,0,0).wrap(core.BuffSkillWrapper) #딜레이 모름
-        ArrowRain = core.SummonSkill("애로우 레인", 0, 840, 600+vEhc.getV(0,0)*24, 8, (40+vEhc.getV(0,0))*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        
+        ArrowRainBuff = core.BuffSkill("애로우 레인(버프)", 810, (40+vEhc.getV(0,0))*1000, cooltime = 120 * 1000, red = True, pdamage = 15+(vEhc.getV(0,0)//2)).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        ArrowRain = core.SummonSkill("애로우 레인", 0, 1440, 600+vEhc.getV(0,0)*24, 8, (40+vEhc.getV(0,0))*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 5초마다 3.5회 공격, 대략 1440ms당 1회
         
         #Summon Skills
-        Pheonix = core.SummonSkill("피닉스", 900, 2670, 390, 1, 220 * 1000).setV(vEhc, 5, 3, True).wrap(core.SummonSkillWrapper)
+        Pheonix = core.SummonSkill("피닉스", 0, 2670, 390, 1, 220 * 1000).setV(vEhc, 5, 3, True).wrap(core.SummonSkillWrapper) # 이볼브가 끝나면 자동으로 소환되므로 딜레이 0
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)
         Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(5,5)))*1000).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
         
         #잔영의시 미적용
-        QuibberFullBurst = core.SummonSkill("퀴버 풀버스트", 780, 3 * 1000 / 6, 750 + 30 * vEhc.getV(2,2), 3, 30 * 1000, cooltime = 120 * 1000).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
-        QuibberFullBurstBuff = core.BuffSkill("퀴버 풀버스트(버프)", 0, 30 * 1000, cooltime=-1, red = False, patt=(10+int(vEhc.getV(2,2)*0.5))).wrap(core.BuffSkillWrapper)
+        QuibberFullBurstBuff = core.BuffSkill("퀴버 풀버스트(버프)", 0, 30 * 1000, cooltime = 120 * 1000, red = True, patt=(5+int(vEhc.getV(2,2)*0.5))).wrap(core.BuffSkillWrapper)
+        QuibberFullBurst = core.SummonSkill("퀴버 풀버스트", 780, 2 * 1000 / 6, 750 + 30 * vEhc.getV(2,2), 3, 30 * 1000, cooltime = -1).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         QuibberFullBurstDOT = core.DotSkill("독화살", 220, 30*1000).wrap(core.SummonSkillWrapper)
     
-        ImageArrow = core.SummonSkill("잔영의 시", 720, 500, 400+16*vEhc.getV(1,1), 3, 30000).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)
+        ImageArrow = core.SummonSkill("잔영의 시", 720, 270, 400+16*vEhc.getV(1,1), 3, 3000, cooltime=30000, red = True).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 11 * 3타
+        ImageArrowPassive = core.DamageSkill("잔영의 시(패시브)", 0, 400+16*vEhc.getV(1,1), 3 * 2 * 0.1).isV(vEhc,1,1).wrap(core.DamageSkillWrapper) # 10회당 1번 생성, 생성당 3타씩 2회 공격
     
         ######   Skill Wrapper   ######
         #GrittyGust.onAfter(GrittyGustDOT)
@@ -97,22 +97,25 @@ class JobGenerator(ck.JobGenerator):
         Pheonix.onConstraint(core.ConstraintElement("이볼브 사용시 사용 금지", Evolve, Evolve.is_not_active))
             
     
-        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 20) #Maybe need to sync
+        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 22.5) #Maybe need to sync
     
         ArrowOfStorm.onAfter(AdvancedQuibberAttack)
         ArrowOfStorm.onAfter(AdvancedFinalAttack)
+        ArrowOfStorm.onAfter(ImageArrowPassive)
         
-        ArrowRain.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack])
+        ArrowRain.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack_ArrowRain])
         ImageArrow.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack])
         
         ArrowRainBuff.onAfter(ArrowRain)
-        QuibberFullBurst.onAfter(QuibberFullBurstDOT)
-        QuibberFullBurst.onAfter(QuibberFullBurstBuff)
+        QuibberFullBurstBuff.onAfter(QuibberFullBurstDOT)
+        QuibberFullBurstBuff.onAfter(QuibberFullBurst)
+
+        ImageArrowPassive.onConstraint(core.ConstraintElement("액티브 OFF", ImageArrow, ImageArrow.is_not_active))
     
         ### Exports ###
         return(ArrowOfStorm,
                 [globalSkill.maple_heros(chtr.level),
-                    SoulArrow, AdvancedQuibber, Preparation, EpicAdventure, ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff, 
+                    SoulArrow, AdvancedQuibber, SharpEyes, ElusionStep, Preparation, EpicAdventure, ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff, 
                     globalSkill.soul_contract()] +\
                 [] +\
                 [Evolve, ArrowFlatter, ArrowRain, Pheonix, GuidedArrow, QuibberFullBurst, ImageArrow] +\

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -3,6 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import RuleSet, ConcurrentRunRule
 from . import globalSkill
 from .jobbranch import bowmen
 
@@ -49,6 +50,12 @@ class JobGenerator(ck.JobGenerator):
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(pdamage = 18)
 
+    def get_ruleset(self):
+        ruleset = RuleSet()
+        ruleset.add_rule(ConcurrentRunRule("프리퍼레이션", "퀴버 풀버스트"), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule("소울 컨트랙트", "퀴버 풀버스트"), RuleSet.BASE)
+        return ruleset
+
     def get_passive_skill_list(self):
         CriticalShot = core.InformedCharacterModifier("크리티컬 샷",crit = 40)
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
@@ -78,7 +85,8 @@ class JobGenerator(ck.JobGenerator):
         폭시-파택-언카블-퀴버-플래터-피닉스
 
         하이퍼: 폭풍의 시 3종 / 샤프 아이즈-이그노어 가드, 크리티컬 레이트
-                
+        
+        프리퍼레이션, 엔버링크를 120초 주기에 맞춰 사용
         '''
         ######   Skill   ######
         #Buff skills

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -7,7 +7,35 @@ from . import globalSkill
 from .jobbranch import bowmen
 
 #TODO : 5차 신스킬 적용
-#TODO : 윈드 오브 프레이 추가
+class ArrowOfStormWrapper(core.DamageSkillWrapper):
+    '''
+    모탈 블로우 - 9회 공격 후 다음 공격은 데미지+80%
+    아머 피어싱 - 적 방어율만큼 최종뎀 추가, 방무+50%. 쿨타임 9초, 공격마다 1초씩 감소, 최소 재발동 대기시간 1초
+    '''
+    def __init__(self, skill):
+        super(ArrowOfStormWrapper, self).__init__(skill)
+        self.mortalBlowCount = 0
+        self.armorPiercingCooltime = 0
+
+    def spend_time(self, time):
+        self.armorPiercingCooltime -= time
+        super(ArrowOfStormWrapper, self).spend_time(time)
+        
+    def _use(self, rem = 0, red = 0):
+        modifier = self.get_modifier()
+        if self.mortalBlowCount >= 9:
+            modifier += core.CharacterModifier(pdamage = 80)
+            self.mortalBlowCount = 0
+        else:
+            self.mortalBlowCount += 1
+
+        if self.armorPiercingCooltime <= 0:
+            modifier += core.CharacterModifier(pdamage_indep = 300, armor_ignore = 50) # 적 방어율 300 가정
+            self.armorPiercingCooltime = 9000 * (1 - 0.01 * red)
+        elif self.armorPiercingCooltime > 1000:
+            self.armorPiercingCooltime = max(self.armorPiercingCooltime - 1000, 1000)
+        
+        return core.ResultObject(self.skill.delay, modifier, self.skill.damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -17,6 +45,9 @@ class JobGenerator(ck.JobGenerator):
         self.vEnhanceNum = 11
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+
+    def get_modifier_optimization_hint(self):
+        return core.CharacterModifier(pdamage = 18)
 
     def get_passive_skill_list(self):
         CriticalShot = core.InformedCharacterModifier("크리티컬 샷",crit = 40)
@@ -35,11 +66,8 @@ class JobGenerator(ck.JobGenerator):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5)
 
         ExtremeArchery = core.InformedCharacterModifier("익스트림 아처리",att = 40, pdamage_indep = 30)
-        MortalBlow = core.InformedCharacterModifier("모탈 블로우",pdamage = 80/10)   #확률성을 변형적용... 패치 필요할듯
-
-        ArmorPiercing = core.InformedCharacterModifier("아머 피어싱",pdamage_indep = 100/8, armor_ignore = 50/8) # 가동률 약 1/8, 잠재 쿨감 1초당 분모 0.5씩 빼야함
         
-        return [WeaponConstant, Mastery,  MortalBlow, ExtremeArchery, ArmorPiercing]
+        return [WeaponConstant, Mastery, ExtremeArchery]
 
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
@@ -61,18 +89,16 @@ class JobGenerator(ck.JobGenerator):
         Preparation = core.BuffSkill("프리퍼레이션", 900, 30 * 1000, cooltime = 90 * 1000, att = 50, boss_pdamage = 20).wrap(core.BuffSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
-        #ArmorPiercing = core.BuffSkill("아머 피어싱", ?, ?) #쿨 9초, 적 방어율만큼 최종뎀 1회 한정 증가, 방무 50%, 타격마다 1초 감소, 쿨타임 최대 감소량 1초
-        
         #Damage Skills
         AdvancedQuibberAttack = core.DamageSkill("마법 화살", 0, 260, 0.6).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
         AdvancedQuibberAttack_ArrowRain = core.DamageSkill("마법 화살(애로우 레인)", 0, 260, 1).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
         AdvancedFinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 210, 0.7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
-        ArrowOfStorm = core.DamageSkill("폭풍의 시", 120, 350*0.75, 1+1, modifier = core.CharacterModifier(pdamage = 30, boss_pdamage = 10)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)  #오더스 적용 필요, 아머 피어싱, 
+        ArrowOfStorm = ArrowOfStormWrapper(core.DamageSkill("폭풍의 시", 120, (350+combat*3)*0.75, 1+1, modifier = core.CharacterModifier(pdamage = 30, boss_pdamage = 10)).setV(vEhc, 0, 2, True))
         ArrowFlatter = core.SummonSkill("애로우 플래터", 600, 210, 85+90+combat*3, 1, 30 * 1000, modifier = core.CharacterModifier(pdamage = 30)).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper) # 딜레이 모름
-        # 작성중
-        #GrittyGust = core.DamageSkill("윈드 오브 프레이", ?, 500, 81, cooltime = 15 * 1000, red = true).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        #GrittyGustDOT = core.SummonSkill("윈드 오브 프레이(도트)", 0, 1000, 200, 1, 10*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        
+        GrittyGust = core.DamageSkill("윈드 오브 프레이", 720, 500, 8, cooltime = 15 * 1000).setV(vEhc, 6, 2, True).wrap(core.DamageSkillWrapper)
+        GrittyGustDOT = core.DotSkill("윈드 오브 프레이(도트)", 200, 10*1000).wrap(core.SummonSkillWrapper)
         
         ArrowRainBuff = core.BuffSkill("애로우 레인(버프)", 810, (40+vEhc.getV(0,0))*1000, cooltime = 120 * 1000, red = True, pdamage = 15+(vEhc.getV(0,0)//2)).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         ArrowRain = core.SummonSkill("애로우 레인", 0, 1440, 600+vEhc.getV(0,0)*24, 8, (40+vEhc.getV(0,0))*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 5초마다 3.5회 공격, 대략 1440ms당 1회
@@ -91,17 +117,17 @@ class JobGenerator(ck.JobGenerator):
         ImageArrowPassive = core.DamageSkill("잔영의 시(패시브)", 0, 400+16*vEhc.getV(1,1), 3 * 2 * 0.1).isV(vEhc,1,1).wrap(core.DamageSkillWrapper) # 10회당 1번 생성, 생성당 3타씩 2회 공격
     
         ######   Skill Wrapper   ######
-        #GrittyGust.onAfter(GrittyGustDOT)
+        GrittyGust.onAfter(GrittyGustDOT)
+
         #이볼브 연계 설정
         Evolve.onAfter(Pheonix.controller(1))
         Pheonix.onConstraint(core.ConstraintElement("이볼브 사용시 사용 금지", Evolve, Evolve.is_not_active))
             
-    
         CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 22.5) #Maybe need to sync
-    
+
         ArrowOfStorm.onAfter(AdvancedQuibberAttack)
         ArrowOfStorm.onAfter(AdvancedFinalAttack)
-        ArrowOfStorm.onAfter(ImageArrowPassive)
+        ArrowOfStorm.onAfter(core.OptionalElement(ImageArrow.is_not_active, ImageArrowPassive, name="액티브 OFF"))
         
         ArrowRain.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack_ArrowRain])
         ImageArrow.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack])
@@ -110,12 +136,10 @@ class JobGenerator(ck.JobGenerator):
         QuibberFullBurstBuff.onAfter(QuibberFullBurstDOT)
         QuibberFullBurstBuff.onAfter(QuibberFullBurst)
 
-        ImageArrowPassive.onConstraint(core.ConstraintElement("액티브 OFF", ImageArrow, ImageArrow.is_not_active))
-    
         ### Exports ###
         return(ArrowOfStorm,
                 [globalSkill.maple_heros(chtr.level),
-                    SoulArrow, AdvancedQuibber, SharpEyes, ElusionStep, Preparation, EpicAdventure, ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff, 
+                    SoulArrow, AdvancedQuibber, SharpEyes, ElusionStep, Preparation, EpicAdventure, ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff,
                     globalSkill.soul_contract()] +\
                 [] +\
                 [Evolve, ArrowFlatter, ArrowRain, Pheonix, GuidedArrow, QuibberFullBurst, ImageArrow] +\

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -109,7 +109,7 @@ class JobGenerator(ck.JobGenerator):
         Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(5,5)))*1000).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
         
         #잔영의시 미적용
-        QuibberFullBurstBuff = core.BuffSkill("퀴버 풀버스트(버프)", 0, 30 * 1000, cooltime = 120 * 1000, red = True, patt=(5+int(vEhc.getV(2,2)*0.5))).wrap(core.BuffSkillWrapper)
+        QuibberFullBurstBuff = core.BuffSkill("퀴버 풀버스트(버프)", 0, 30 * 1000, cooltime = 120 * 1000, red = True, patt=(5+int(vEhc.getV(2,2)*0.5)), crit_damage=8).wrap(core.BuffSkillWrapper) # 독화살 크뎀을 이쪽에 합침
         QuibberFullBurst = core.SummonSkill("퀴버 풀버스트", 780, 2 * 1000 / 6, 750 + 30 * vEhc.getV(2,2), 3, 30 * 1000, cooltime = -1).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         QuibberFullBurstDOT = core.DotSkill("독화살", 220, 30*1000).wrap(core.SummonSkillWrapper)
     

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -125,6 +125,7 @@ class JobGenerator(ck.JobGenerator):
         AdvancedQuibberAttack_ArrowRain = core.DamageSkill("어드밴스드 퀴버(애로우 레인)", 0, 260, 1, modifier=MortalBlow).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
         AdvancedFinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 210, 0.7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
+        # TODO: 폭풍의 시 선딜 반영해야 함
         ArrowOfStorm = ArrowOfStormWrapper(core.DamageSkill("폭풍의 시", 120, (350+combat*3)*0.75, 1+1, modifier = core.CharacterModifier(pdamage = 30, boss_pdamage = 10) + MortalBlow).setV(vEhc, 0, 2, True), ArmorPiercing, combat)
         ArrowFlatter = core.SummonSkill("애로우 플래터", 600, 210, 85+90+combat*3, 1, 30 * 1000, modifier = core.CharacterModifier(pdamage = 30)).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper) # 딜레이 모름
         

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -1,3 +1,6 @@
+"""Advisor : 저격장(레드)
+"""
+
 from ..kernel import core
 from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
@@ -7,32 +10,51 @@ from ..execution.rules import RuleSet, ConcurrentRunRule
 from . import globalSkill
 from .jobbranch import bowmen
 
-#TODO : 5차 신스킬 적용
-class ArrowOfStormWrapper(core.DamageSkillWrapper):
+class ArmorPiercingWrapper(core.BuffSkillWrapper):
     '''
-    모탈 블로우 - 9회 공격 후 다음 공격은 데미지+80%
     아머 피어싱 - 적 방어율만큼 최종뎀 추가, 방무+50%. 쿨타임 9초, 공격마다 1초씩 감소, 최소 재발동 대기시간 1초
     '''
-    def __init__(self, skill, combat):
-        super(ArrowOfStormWrapper, self).__init__(skill)
-        self.armorPiercingCooltime = 0
-        self.combat = combat
+    def reduce_cooltime(self, time):
+        if self.cooltimeLeft > 1000:
+            self.cooltimeLeft = max(self.cooltimeLeft - time, 1000)
+        return self._result_object_cache
 
-    def spend_time(self, time):
-        self.armorPiercingCooltime -= time
-        super(ArrowOfStormWrapper, self).spend_time(time)
+class ArrowOfStormWrapper(core.DamageSkillWrapper):
+    def __init__(self, skill, armorPiercing):
+        super(ArrowOfStormWrapper, self).__init__(skill)
+        self.armorPiercing = armorPiercing
         
     def _use(self, rem = 0, red = 0):
         modifier = self.get_modifier()
-
-        if self.armorPiercingCooltime <= 0:
-            modifier += core.CharacterModifier(pdamage_indep = 300 * (1 + self.combat * 0.05), armor_ignore = 50 * (1 + self.combat * 0.02)) # 적 방어율 300 가정
-            self.armorPiercingCooltime = 9000 * (1 - 0.01 * red)
-        elif self.armorPiercingCooltime > 1000:
-            self.armorPiercingCooltime = max(self.armorPiercingCooltime - 1000, 1000)
+        if self.armorPiercing.is_available():
+            modifier += self.armorPiercing.get_modifier_forced()
+            self.armorPiercing._use()
+        else:
+            self.armorPiercing.reduce_cooltime(1000)
         
         return core.ResultObject(self.skill.delay, modifier, self.skill.damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
 
+class GuidedArrowWrapper(bowmen.GuidedArrowWrapper):
+    def __init__(self, vEhc, num1, num2, armorPiercing):
+        super(GuidedArrowWrapper, self).__init__(vEhc, num1, num2)
+        self.armorPiercing = armorPiercing
+            
+    def _useTick(self):
+        if self.onoff and self.tick <= 0:
+            self.tick += self.skill.delay
+
+            modifier = self.get_modifier()
+            if self.armorPiercing.is_available():
+                modifier += self.armorPiercing.get_modifier_forced()
+                self.armorPiercing._use()
+            else:
+                self.armorPiercing.reduce_cooltime(1000)
+            
+            return core.ResultObject(0, modifier, self.skill.damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
+        else:
+            return core.ResultObject(0, self.disabledModifier, 0, 0, sname = self.skill.name, spec = self.skill.spec)
+
+#TODO : 5차 신스킬 적용
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
@@ -68,9 +90,8 @@ class JobGenerator(ck.JobGenerator):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5)
 
         ExtremeArchery = core.InformedCharacterModifier("익스트림 아처리",att = 40, pdamage_indep = 30)
-        MortalBlow = core.InformedCharacterModifier("모탈 블로우",pdamage = 80/10)   #확률성을 변형적용... 패치 필요할듯
         
-        return [WeaponConstant, Mastery, ExtremeArchery, MortalBlow]
+        return [WeaponConstant, Mastery, ExtremeArchery]
 
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
@@ -84,6 +105,8 @@ class JobGenerator(ck.JobGenerator):
         
         프리퍼레이션, 엔버링크를 120초 주기에 맞춰 사용
         '''
+        MortalBlow = core.CharacterModifier(pdamage = 80/10) # 반응하는 스킬이 정해져있음. Issue # 247 참고.
+
         ######   Skill   ######
         #Buff skills
         SoulArrow = core.BuffSkill("소울 애로우", 0, 300 * 1000, att = 30).wrap(core.BuffSkillWrapper) # 펫버프
@@ -92,33 +115,35 @@ class JobGenerator(ck.JobGenerator):
         ElusionStep = core.BuffSkill("일루젼 스탭", 0, 300 * 1000, rem = True, stat_main = 80).wrap(core.BuffSkillWrapper) # 펫버프
         Preparation = core.BuffSkill("프리퍼레이션", 900, 30 * 1000, cooltime = 90 * 1000, att = 50, boss_pdamage = 20).wrap(core.BuffSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
+
+        ArmorPiercing = ArmorPiercingWrapper(core.BuffSkill("아머 피어싱", 0, 0, 9000, pdamage_indep = 300 * (1 + self.combat * 0.05), armor_ignore = 50 * (1 + self.combat * 0.02)))
     
         #Damage Skills
-        AdvancedQuibberAttack = core.DamageSkill("어드밴스드 퀴버", 0, 260, 0.6).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
-        AdvancedQuibberAttack_ArrowRain = core.DamageSkill("어드밴스드 퀴버(애로우 레인)", 0, 260, 1).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        AdvancedQuibberAttack = core.DamageSkill("어드밴스드 퀴버", 0, 260, 0.6, modifier=MortalBlow).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        AdvancedQuibberAttack_ArrowRain = core.DamageSkill("어드밴스드 퀴버(애로우 레인)", 0, 260, 1, modifier=MortalBlow).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
         AdvancedFinalAttack = core.DamageSkill("어드밴스드 파이널 어택", 0, 210, 0.7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
-        ArrowOfStorm = ArrowOfStormWrapper(core.DamageSkill("폭풍의 시", 120, (350+combat*3)*0.75, 1+1, modifier = core.CharacterModifier(pdamage = 30, boss_pdamage = 10)).setV(vEhc, 0, 2, True), combat)
+        ArrowOfStorm = ArrowOfStormWrapper(core.DamageSkill("폭풍의 시", 120, (350+combat*3)*0.75, 1+1, modifier = core.CharacterModifier(pdamage = 30, boss_pdamage = 10) + MortalBlow).setV(vEhc, 0, 2, True), ArmorPiercing)
         ArrowFlatter = core.SummonSkill("애로우 플래터", 600, 210, 85+90+combat*3, 1, 30 * 1000, modifier = core.CharacterModifier(pdamage = 30)).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper) # 딜레이 모름
         
-        GrittyGust = core.DamageSkill("윈드 오브 프레이", 720, 500, 8, cooltime = 15 * 1000).setV(vEhc, 6, 2, True).wrap(core.DamageSkillWrapper)
+        GrittyGust = core.DamageSkill("윈드 오브 프레이", 720, 500, 8, cooltime = 15 * 1000, modifier=MortalBlow).setV(vEhc, 6, 2, True).wrap(core.DamageSkillWrapper)
         GrittyGustDOT = core.DotSkill("윈드 오브 프레이(도트)", 200, 10*1000).wrap(core.SummonSkillWrapper)
         
         ArrowRainBuff = core.BuffSkill("애로우 레인(버프)", 810, (40+vEhc.getV(0,0))*1000, cooltime = 120 * 1000, red = True, pdamage = 15+(vEhc.getV(0,0)//2)).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
-        ArrowRain = core.SummonSkill("애로우 레인", 0, 1440, 600+vEhc.getV(0,0)*24, 8, (40+vEhc.getV(0,0))*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 5초마다 3.5회 공격, 대략 1440ms당 1회
+        ArrowRain = core.SummonSkill("애로우 레인", 0, 1440, 600+vEhc.getV(0,0)*24, 8, (40+vEhc.getV(0,0))*1000, cooltime = -1, modifier=MortalBlow).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 5초마다 3.5회 공격, 대략 1440ms당 1회
         
         #Summon Skills
         Pheonix = core.SummonSkill("피닉스", 0, 2670, 390, 1, 220 * 1000).setV(vEhc, 5, 3, True).wrap(core.SummonSkillWrapper) # 이볼브가 끝나면 자동으로 소환되므로 딜레이 0
-        GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)
+        GuidedArrow = GuidedArrowWrapper(vEhc, 4, 4, ArmorPiercing)
         Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(5,5)))*1000).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
         
         #잔영의시 미적용
         QuibberFullBurstBuff = core.BuffSkill("퀴버 풀버스트(버프)", 0, 30 * 1000, cooltime = 120 * 1000, red = True, patt=(5+int(vEhc.getV(2,2)*0.5)), crit_damage=8).wrap(core.BuffSkillWrapper) # 독화살 크뎀을 이쪽에 합침
-        QuibberFullBurst = core.SummonSkill("퀴버 풀버스트", 780, 2 * 1000 / 6, 750 + 30 * vEhc.getV(2,2), 3, 30 * 1000, cooltime = -1).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
+        QuibberFullBurst = core.SummonSkill("퀴버 풀버스트", 780, 2 * 1000 / 6, 750 + 30 * vEhc.getV(2,2), 3, 30 * 1000, cooltime = -1, modifier=MortalBlow).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         QuibberFullBurstDOT = core.DotSkill("독화살", 220, 30*1000).wrap(core.SummonSkillWrapper)
     
-        ImageArrow = core.SummonSkill("잔영의 시", 720, 240, 400+16*vEhc.getV(1,1), 3, 3000-360, cooltime=30000, red = True).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 11 * 3타, 준비 360ms
-        ImageArrowPassive = core.DamageSkill("잔영의 시(패시브)", 0, 400+16*vEhc.getV(1,1), 3 * 2 * 0.1).isV(vEhc,1,1).wrap(core.DamageSkillWrapper) # 10회당 1번 생성, 생성당 3타씩 2회 공격
+        ImageArrow = core.SummonSkill("잔영의 시", 720, 240, 400+16*vEhc.getV(1,1), 3, 3000, cooltime=30000, red = True).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 13 * 3타
+        ImageArrowPassive = core.SummonSkill("잔영의 시(패시브)", 0, 2580, 400+16*vEhc.getV(1,1), 3.5*3, 9999999).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 3~4 * 3타, 잔시 쿨동안 11회 사용
     
         ######   Skill Wrapper   ######
         GrittyGust.onAfter(GrittyGustDOT)
@@ -131,23 +156,25 @@ class JobGenerator(ck.JobGenerator):
 
         ArrowOfStorm.onAfter(AdvancedQuibberAttack)
         ArrowOfStorm.onAfter(AdvancedFinalAttack)
-        ArrowOfStorm.onAfter(core.OptionalElement(ImageArrow.is_not_active, ImageArrowPassive, name="잔영의 시 액티브 OFF"))
         
         ArrowRainBuff.onAfter(ArrowRain)
         ArrowRain.onTick(AdvancedQuibberAttack_ArrowRain)
-        ImageArrow.onTicks([AdvancedFinalAttack, AdvancedQuibberAttack])
+
+        ImageArrow.onAfter(ImageArrowPassive.controller(3000))
+        ImageArrow.onTick(AdvancedFinalAttack)
+
         GuidedArrow.onTick(AdvancedQuibberAttack)
         
         QuibberFullBurstBuff.onAfter(QuibberFullBurstDOT)
         QuibberFullBurstBuff.onAfter(QuibberFullBurst)
 
-        QuibberFullBurst.onTick(AdvancedQuibberAttack)
+        ArmorPiercing.protect_from_running()
 
         ### Exports ###
         return(ArrowOfStorm,
                 [globalSkill.maple_heros(chtr.level),
-                    SoulArrow, AdvancedQuibber, SharpEyes, ElusionStep, Preparation, EpicAdventure,
-                    ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff, QuibberFullBurstDOT,
+                    SoulArrow, AdvancedQuibber, SharpEyes, ElusionStep, Preparation, EpicAdventure, ArmorPiercing,
+                    ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff, QuibberFullBurstDOT, ImageArrowPassive,
                     globalSkill.soul_contract()] +\
                 [] +\
                 [Evolve, ArrowFlatter, ArrowRain, Pheonix, GuidedArrow, QuibberFullBurst, ImageArrow] +\

--- a/dpmModule/jobs/jobbranch/bowmen.py
+++ b/dpmModule/jobs/jobbranch/bowmen.py
@@ -4,7 +4,7 @@ from ...kernel.core import CharacterModifier as MDF
 from ...character import characterKernel as ck
 from functools import partial
 
-# 보마 = 20 (샤프 아이즈)
+# 보마 = 22.5 (샤프 아이즈 + 샤프 아이즈-크리티컬 레이트)
 # 메르 = 10 (쓸만한 샤프 아이즈)
 # 패파 = 20 (샤프 아이즈)
 # 신궁 = 20+20 (샤프 아이즈 + 불스아이)
@@ -13,7 +13,7 @@ from functools import partial
 # bonus = 직업별 보정 수치. self.char.get_modifier()가 패시브만 적용된 수치를 반환하므로, 버프 스킬로 오르는 크확을 따로 표시해줘야 한다.
 class CriticalReinforceWrapper(core.BuffSkillWrapper):
     def __init__(self, vEhc, character : ck.AbstractCharacter, num1, num2, bonus):
-        skill = core.BuffSkill("크리티컬 리인포스", 600, 30 * 1000, cooltime = 120 * 1000).isV(vEhc, num1, num2)
+        skill = core.BuffSkill("크리티컬 리인포스", 600, 30 * 1000, cooltime = 120 * 1000, red=True).isV(vEhc, num1, num2)
         super(CriticalReinforceWrapper, self).__init__(skill)
         self.char = character
         self.inhancer = (20 + vEhc.getV(num1, num2))*0.01

--- a/dpmModule/jobs/jobbranch/bowmen.py
+++ b/dpmModule/jobs/jobbranch/bowmen.py
@@ -25,6 +25,7 @@ class CriticalReinforceWrapper(core.BuffSkillWrapper):
         else:
             return self.disabledModifier
 
-def GuidedArrowWrapper(vEhc, num1, num2):
-    GuidedArrow = core.SummonSkill("가이디드 애로우", 720, 330, 400+16*vEhc.getV(num1, num2), 1, 30 * 1000, cooltime = 60 * 1000).isV(vEhc,num1, num2).wrap(core.SummonSkillWrapper)
-    return GuidedArrow
+class GuidedArrowWrapper(core.SummonSkillWrapper):
+    def __init__(self, vEhc, num1, num2):
+        skill = core.SummonSkill("가이디드 애로우", 720, 510, 400+16*vEhc.getV(num1, num2), 1, 510 * 90, cooltime = 60 * 1000).isV(vEhc,num1, num2)
+        super(GuidedArrowWrapper, self).__init__(skill)


### PR DESCRIPTION
### 1~4차
* 샤프 아이즈, 일루젼 스텝 사용하지 않던것 수정
* 샤프 아이즈 딜레이 다른 궁수와 통일
* 애로우 플래터 공격주기 210ms
* 이볼브 끝나면 피닉스 자동으로 나오므로, 피닉스 딜레이 제거
* 모탈 블로우가 적용되는 스킬에만 뎀퍼 적용
* 어드밴스드 퀴버가 발동하는 스킬을 정확히 반영
* 아머 피어싱의 컴뱃 수치 입력
* 아머 피어싱을 폭풍의 시, 가이디드 애로우에만 적용
* 폭풍의 시 선딜 적용

### 하이퍼
* 샤프 아이즈 하이퍼 적용
* 애로우 플래터가 폭풍의 시-리인포스 받는것 적용
* 윈드 오브 프레이 스킬 생성
  * 딜사이클에 들어가진 않음

### 5차
* 5차 스킬들에 메르쿨감 적용
* 애로우 레인의 마법 화살 확률 2배 적용
* 애로우 레인 시전 딜레이 720 -> 810
* 애로우 레인 공격주기 1.2.332 패치 기준으로 변경
* 애로우 레인은 파이널 어택 발동 안되는것 검증됨, 코드에 적용
* 퀴버 풀버스트의 공퍼가 과도하게 적용된것 수정
* 퀴버 풀버스트가 버프->공격 순으로 사용되게 함
* 퀴버 풀버스트의 불화살 공격주기를 총 90타가 나오게 수정 (기존 60타)
* 퀴버 풀버스트의 독화살 데미지가 안들어가던것 수정
* 독화살에 중독된 적은 크뎀+8%, 퀴버 풀버스트의 효과로 취급하는 것으로 적용해둠
* 잔영의 시 액티브/패시브 분리, 퍼뎀 타수 수정
* 잔영의 시 액티브가 12회 공격하던것 14회로 수정
* 잔영의 시 패시브를 적당한 주기의 소환수로 취급, 약 3~4회 공격
* 가이디드 애로우가 마법 화살을 발동함

### 딜사이클
* 90초 쿨인 프리퍼레이션, 엔버링크를 120초 주기에 맞춰 사용

https://github.com/oleneyl/maplestory_dpm_calc/issues/240