### PR TITLE
fix: 다크나이트 스킬

### DIFF
--- a/dpmModule/jobs/darknight.py
+++ b/dpmModule/jobs/darknight.py
@@ -16,6 +16,9 @@ class JobGenerator(ck.JobGenerator):
         self.vEnhanceNum = 9
         self.ability_list = Ability_tool.get_ability_set('buff_rem', 'reuse', 'boss_pdamage')
         self.preEmptiveSkills = 2
+
+    def get_modifier_optimization_hint(self):
+        return core.CharacterModifier(boss_pdamage=10, armor_ignore=44)
         
     def get_passive_skill_list(self):
         WeaponMastery = core.InformedCharacterModifier("웨폰 마스터리",pdamage = 5)
@@ -33,7 +36,7 @@ class JobGenerator(ck.JobGenerator):
     def get_not_implied_skill_list(self):
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 49)
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)        
-        BiholdersBuff = core.InformedCharacterModifier("비홀더스 버프",att = 40+30, crit = 10)
+        BiholdersBuff = core.InformedCharacterModifier("비홀더스 버프",att = 40, crit = 10)
         
         return [WeaponConstant, Mastery, BiholdersBuff]
         
@@ -41,11 +44,13 @@ class JobGenerator(ck.JobGenerator):
         '''
         창 사용
         크오체 풀피 가정
-        비홀더 - 리인포스 / 버프 리인포스
+        비홀더 - 리인포스
+        리인카네이션 - 데미지
         궁그닐 - 리인포스, 이그노어 가드, 보스 킬러
         
         비홀더 임팩트 9타
-        피어스 사이클론 22타
+        피어스 사이클론 25타
+        다크 스피어 7*8타
         
         임페일-궁그닐-비홀더-파이널어택
 
@@ -54,28 +59,29 @@ class JobGenerator(ck.JobGenerator):
             
         
         #Buff skills
-        Booster = core.BuffSkill("부스터", 0, 180*1000, rem = True).wrap(core.BuffSkillWrapper)
-        CrossoverChain = core.BuffSkill("크로스 오버 체인", 0, 200*1000, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
+        Booster = core.BuffSkill("부스터", 0, 180*1000, rem = True).wrap(core.BuffSkillWrapper) # 펫버프
+        CrossoverChain = core.BuffSkill("크로스 오버 체인", 0, 200*1000, pdamage_indep = 20).wrap(core.BuffSkillWrapper) # 펫버프
         FinalAttack = core.DamageSkill("파이널 어택", 0, 80, 2*0.4).setV(vEhc, 3, 4, True).wrap(core.DamageSkillWrapper)
         BiholderDominant = core.SummonSkill("비홀더 도미넌트", 0, 10000, 210, 1, 99999*10000, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).wrap(core.SummonSkillWrapper)
-        BiholderShock = core.DamageSkill("비홀더 쇼크", 0, 215, 6, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).wrap(core.DamageSkillWrapper)
+        BiholderShock = core.DamageSkill("비홀더 쇼크", 0, 215+300, 6, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).wrap(core.DamageSkillWrapper)
         
         DarkImpail = core.DamageSkill("다크 임페일", 630, 280, 6).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        GoungnilDescentNoCooltime = core.DamageSkill("궁그닐 디센트(무한)", 600, 225, 12, modifier = core.CharacterModifier(armor_ignore = 30+20, pdamage = 20, boss_pdamage = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)    
-        GoungnilDescent = core.DamageSkill("궁그닐 디센트", 600, 225, 12, cooltime = 8000, modifier = core.CharacterModifier(armor_ignore = 30+20, pdamage = 20, boss_pdamage = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        GoungnilDescentNoCooltime = core.DamageSkill("궁그닐 디센트(무한)", 600, 225, 12, modifier = core.CharacterModifier(armor_ignore = 44, pdamage = 20, boss_pdamage = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)    
+        GoungnilDescent = core.DamageSkill("궁그닐 디센트", 600, 225, 12, cooltime = 8000, modifier = core.CharacterModifier(armor_ignore = 44, pdamage = 20, boss_pdamage = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
         Sacrifice = core.BuffSkill("새크리파이스", 1080, 30*1000, rem = True, red = True, cooltime = 70000, armor_ignore = 10, boss_pdamage = 10).wrap(core.BuffSkillWrapper)   #궁그닐 쿨 무시, 비홀더 공격시 쿨0.3감소
-        Reincarnation = core.BuffSkill("리인카네이션", 0, 40*1000, cooltime = 600000, rem = True, red = True).wrap(core.BuffSkillWrapper) #궁그닐 쿨 무시
+        Reincarnation = core.BuffSkill("리인카네이션", 0, 40*1000, cooltime = 600000, rem = True, red = True, pdamage_indep=30).wrap(core.BuffSkillWrapper) #궁그닐 쿨 무시
         
         #하이퍼
         DarkThurst = core.BuffSkill("다크 서스트", 900, 30000, cooltime = 120*1000, att = 80).wrap(core.BuffSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
-        DarkSpear = core.DamageSkill("다크 스피어", 990, 350+10*vEhc.getV(1,0), 7 * 8, cooltime = 10000, red = True, modifier = core.CharacterModifier(crit=100, armor_ignore=50)).isV(vEhc,1,0).wrap(core.DamageSkillWrapper)
-        BiholderImpact = core.SummonSkill("비홀더 임팩트", 0, 300, 100+vEhc.getV(0,2), 6, 3001, cooltime = 20000, red = True, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).isV(vEhc,0,2).wrap(core.SummonSkillWrapper)#onTick으로 0.3초씩
-        PierceCyclone = core.DamageSkill("피어스 사이클론(더미)", 90, 0, 0, cooltime = 180*1000).wrap(core.DamageSkillWrapper)
-        PierceCycloneTick = core.DamageSkill("피어스 사이클론", 9000/22, 400+16*vEhc.getV(3,3), 12, modifier = core.CharacterModifier(crit=100, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper) #22타
-        PierceCycloneEnd = core.DamageSkill("피어스 사이클론(종료)", 0, 1500+60*vEhc.getV(3,3), 15, modifier = core.CharacterModifier(crit=100, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)
+        #5차
+        DarkSpear = core.DamageSkill("다크 스피어", 750, 350+10*vEhc.getV(1,0), 7 * 8, cooltime = 10000, red = True, modifier = core.CharacterModifier(crit=100, armor_ignore=50)).isV(vEhc,1,0).wrap(core.DamageSkillWrapper)
+        BiholderImpact = core.SummonSkill("비홀더 임팩트", 0, 270, 100+vEhc.getV(0,2), 6, 2880, cooltime = 20000, red = True, modifier = core.CharacterModifier(pdamage = 150)).setV(vEhc, 2, 3, False).isV(vEhc,0,2).wrap(core.SummonSkillWrapper)#onTick으로 0.3초씩
+        PierceCyclone = core.DamageSkill("피어스 사이클론(더미)", 90, 0, 0, cooltime = 180*1000, red = True).wrap(core.DamageSkillWrapper)
+        PierceCycloneTick = core.DamageSkill("피어스 사이클론", 360, 400+16*vEhc.getV(3,3), 12, modifier = core.CharacterModifier(crit=100, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper) #25타
+        PierceCycloneEnd = core.DamageSkill("피어스 사이클론(종료)", 900, 1500+60*vEhc.getV(3,3), 15, modifier = core.CharacterModifier(crit=100, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)
         
         ######   Skill Wrapper   ######
     
@@ -89,6 +95,8 @@ class JobGenerator(ck.JobGenerator):
         DarkImpail.onAfter(FinalAttack)
         GoungnilDescentNoCooltime.onAfter(FinalAttack)
         GoungnilDescent.onAfter(FinalAttack)
+        GoungnilDescent.onConstraint(core.ConstraintElement("새크리 OFF", Sacrifice, Sacrifice.is_not_active))
+        GoungnilDescent.onConstraint(core.ConstraintElement("리인카 OFF", Reincarnation, Reincarnation.is_not_active))
         BasicAttack = core.OptionalElement(InfGoungnil, GoungnilDescentNoCooltime, DarkImpail)
         BasicAttackWrapped = core.DamageSkill('기본 공격',0,0,0).wrap(core.DamageSkillWrapper)
         BasicAttackWrapped.onAfter(BasicAttack)
@@ -96,13 +104,13 @@ class JobGenerator(ck.JobGenerator):
         BiholderShock.onAfter(Sacrifice.controller(300,'reduce_cooltime'))
         BiholderImpact.onTick(Sacrifice.controller(300,'reduce_cooltime'))
         
-        PierceCyclone_ = core.RepeatElement(PierceCycloneTick, 22)
+        PierceCyclone_ = core.RepeatElement(PierceCycloneTick, 25)
         PierceCyclone_.onAfter(PierceCycloneEnd)
         PierceCyclone.onAfter(PierceCyclone_)
 
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 2, 1)
-        for sk in [GoungnilDescent, PierceCycloneEnd]:
+        for sk in [GoungnilDescent, GoungnilDescentNoCooltime, DarkImpail, PierceCycloneEnd]:
             auraweapon_builder.add_aura_weapon(sk)
         AuraWeaponBuff, AuraWeaponCooltimeDummy = auraweapon_builder.get_buff()
         


### PR DESCRIPTION
* 일반 궁그닐이 새크리/리인카때 시전 안되도록 함
* 무한 궁그닐, 다크 임페일이 오라 웨폰 발동 가능하게 함
* 피어스 사이클론에 메르쿨감 적용
* 다크 스피어 딜레이에 공속반영
* 하이퍼 변경: 비홀더-버프 리인포스 -> 리인카네이션-데미지
* 새크리파이스, 궁그닐 고려한 optimization_hint 추가
* 비홀더 쇼크에 패시브로 강화되는 퍼뎀 300%p 추가
* 궁그닐 디센트의 하이퍼 방무 곱적용으로 변경
* 피어스 사이클론 22회 -> 25회
* 비홀더 임팩트 공격주기, 딜레이 변경 (확정됨)

fix https://github.com/oleneyl/maplestory_dpm_calc/issues/242