### PR TITLE
제로 태그 오류 임시조치

### DIFF
--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -125,7 +125,8 @@ class JobGenerator(ck.JobGenerator):
 
         #### 알파 ####
         MoonStrike = core.DamageSkill("문 스트라이크", 390, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        MoonStrikeTAG = core.DamageSkill("문 스트라이크(태그)", 0, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        #MoonStrikeTAG = core.DamageSkill("문 스트라이크(태그)", 0, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        MoonStrikeTAG = core.DamageSkill("문 스트라이크(태그)(오류)", 0, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
         PierceStrike = core.DamageSkill("피어스 쓰러스트", 510, 170, 6 ).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         PierceStrikeTAG = core.DamageSkill("피어스 쓰러스트(태그)", 0, 170, 6 ).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
@@ -137,7 +138,8 @@ class JobGenerator(ck.JobGenerator):
         ShadowStrikeAura = core.DamageSkill("쉐도우 스트라이크", 0, 310, 1)
         '''
         FlashAssault = core.DamageSkill("플래시 어썰터", 480, 165, 8 ).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        FlashAssaultTAG = core.DamageSkill("플래시 어썰터(태그)", 0, 165, 8 ).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        #FlashAssaultTAG = core.DamageSkill("플래시 어썰터(태그)", 0, 165, 8 ).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        FlashAssaultTAG = core.DamageSkill("플래시 어썰터(태그)(오류)", 0, 0, 0 ).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         
         ### Dummy Skills
         _SpinCutter = core.DamageSkill("스핀 커터", 630, 260, 10 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) 
@@ -176,7 +178,8 @@ class JobGenerator(ck.JobGenerator):
         
 
         UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        #UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)(오류)", 0, 0, 0, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
         AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)


### PR DESCRIPTION
#249
문 스트라이크(태그), 플래시 어썰터(태그), 어퍼 슬래시(태그)의 데미지 값을 0으로 해두었습니다.

어디까지나 임시조치이므로 휠윈드 끌기와 어파스 1회 씹힘은 아직 구현하지 않았습니다.

더 큰 문제는 알파와 베타가 각각 버프로 되어있다보니까 어시스킬이 버프에 영향을 받는다는 것입니다. 제로의 공격은 어떤 상태이냐에 상관없이 스킬 주인의 스펙을 따라야 합니다. 귀찮더라도 신궁처럼 각각 스펙을 modifier로 직접 적용해야 할 것 같습니다.

아래 로그는 `BetaMastery = core.CharacterModifier(pdamage_indep = 49)`를 `BetaMastery = core.CharacterModifier(pdamage_indep = -999)`로 수정하고 돌린 결과입니다.

```
At Time 11990.0, Skill [어드밴스드 스톰 브레이크] ... Damage [2263755081.5] ... Loss [0.0] ... Delay [690.0]
crit rate : 30.0, crit damage 10.3
pdamage : 90.0, pdamage_indep 280.6
stat_main : 185.8, stat_sub 2.0
pstat_main : 0.0, pstat_sub 0.0
stat_main_fixed : 0.0, stat_sub_fixed 0.0
boss_pdamage : 0.0, armor_ignore 32.0
att : 20.0, patt 4.0
Fixed stat : main 0.0, sub 0.0
damageFactor : 0.0

(중략)

At Time 15020.0, Skill [어드밴스드 스톰 브레이크(소환)] ... Damage [-4261246258.8] ... Loss [0.0] ... Delay [0.0]
crit rate : 5.0, crit damage -42.0
pdamage : 90.0, pdamage_indep -2653.3
stat_main : 185.8, stat_sub 2.0
pstat_main : 0.0, pstat_sub 0.0
stat_main_fixed : 0.0, stat_sub_fixed 0.0
boss_pdamage : 30.0, armor_ignore 2.9
att : 60.0, patt 4.0
Fixed stat : main 0.0, sub 0.0
damageFactor : -0.0
```