### PR TITLE
fix: 일리움 스킬

### DIFF
--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -56,6 +56,65 @@ class SoulOfCrystalWrapper(core.BuffSkillWrapper):
         task = core.Task(self, self.turnOff)
         return core.TaskHolder(task, name = "소오크 흡수")
 
+class RiyoWrapper(core.SummonSkillWrapper):
+    """
+    1단계:60%의 데미지로 공격, 10회 공격 시 공격력 강화
+    2단계:100%의 데미지로 공격, 10회 공격 시 공격력 강화
+    3단계:200%의 데미지로 공격, 20회 공격 시 초기화
+    크리스탈 스킬: 데우스의 패시브로 각 단계의 데미지 +100%p
+    """
+    def __init__(self, skill):
+        super(RiyoWrapper, self).__init__(skill)
+        self.hit = 0
+
+    def _use(self, rem = 0, red = 0):
+        self.hit = 0
+        return super(RiyoWrapper, self)._use(rem, red)
+    
+    def _useTick(self):
+        if self.onoff and self.tick <= 0:
+            if self.hit < 10:
+                damage = 160
+            if self.hit < 20:
+                damage = 200
+            else:
+                damage = 300
+            self.hit += 1
+            if self.hit >= 40:
+                self.hit = 0
+            
+            self.tick += self.skill.delay
+            return core.ResultObject(0, self.get_modifier(), damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
+        else:
+            return core.ResultObject(0, self.disabledModifier, 0, 0, sname = self.skill.name, spec = self.skill.spec)
+
+class GramHolderWrapper(core.SummonSkillWrapper):
+    """
+    공격 준비 중 크리스탈 차지가 3 이상 충전되거나 글로리 윙 상태라면 최종 데미지 2배로 증가
+    """
+    def __init__(self, skill):
+        self.chargeBefore = 0
+        self.crystalCharge = None
+        self.gloryWing = None
+        super(GramHolderWrapper, self).__init__(skill)
+    
+    def registerCrystalCharge(self, skill):
+        self.crystalCharge = skill
+
+    def registerGloryWing(self, skill):
+        self.gloryWing = skill
+    
+    def _useTick(self):
+        if self.onoff and self.tick <= 0:
+            modifier = self.get_modifier()
+            if self.gloryWing.is_active() or self.crystalCharge.judge(self.chargeBefore + 3, 1):
+                modifier = modifier + core.CharacterModifier(pdamage_indep = 100)
+            
+            self.tick += self.skill.delay
+            return core.ResultObject(0, modifier, self.skill.damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
+        else:
+            return core.ResultObject(0, self.disabledModifier, 0, 0, sname = self.skill.name, spec = self.skill.spec)
+    
 class JobGenerator(ck.JobGenerator):
     def __init__(self, vEhc = None):
         super(JobGenerator, self).__init__(vEhc = vEhc)
@@ -130,12 +189,12 @@ class JobGenerator(ck.JobGenerator):
         
         Craft_Longinus = core.DamageSkill("크래프트:롱기누스", 600+180, 950, 8, cooltime = 15000).wrap(core.DamageSkillWrapper) # 자체딜레이 600 + 자벨린-오브 연계 취소 180
         
-        Riyo = core.SummonSkill("리요", 0, 500, 240, 1, 180000).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper) # 최초 사용 이후로는 항상 데우스 종료때 딜레이 없이 리필됨
+        Riyo = RiyoWrapper(core.SummonSkill("리요", 0, 510, 240, 1, 180000).setV(vEhc, 3, 2, False)) # 최초 사용 이후로는 항상 데우스 종료때 딜레이 없이 리필됨
         Machina = core.SummonSkill("마키나", 0, 1980, 250, 4, 180000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)    # 최초 사용 이후로는 항상 데우스 종료때 딜레이 없이 리필됨
         
         CrystalSkill_MortalSwing = core.DamageSkill("크리스탈 스킬:모탈스윙", 0, 600, 10, cooltime = -1).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)    #30
         CrystalSkill_Deus = core.SummonSkill("크리스탈 스킬:데우스", 30, 4800, 500, 5+1, 30*1000, cooltime = -1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)   #90, 7타
-        CrystalSkill_Deus_Satelite = core.SummonSkill("크리스탈 스킬:데우스(위성)", 0, 500, 240, 1+1, 30*1000, cooltime = -1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
+        CrystalSkill_Deus_Satelite = RiyoWrapper(core.SummonSkill("크리스탈 스킬:데우스(위성)", 0, 510, 240, 1+1, 30*1000, cooltime = -1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False))
         
         LonginusZone = core.DamageSkill("롱기누스 존", 690, 1500, 12, cooltime = 180*1000)    #안씀
         
@@ -154,14 +213,15 @@ class JobGenerator(ck.JobGenerator):
         GloryWing_Craft_Javelin_Fragment = core.DamageSkill("글로리 윙:자벨린(매직 미사일)", 0, 250, 3*3, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
 
         #5차 스킬들
-        OverloadMana = OverloadMana = magicians.OverloadManaWrapper(vEhc, 0, 3)
-        GramHolder = core.SummonSkill("그람홀더", 0, 3000, 1000+25*vEhc.getV(4,3), 6, 40000, cooltime = 180000, modifier = core.CharacterModifier(pdamage_indep = 100)).isV(vEhc,4,3).wrap(core.SummonSkillWrapper) # 클라 딜레이 없음
+        OverloadMana = magicians.OverloadManaWrapper(vEhc, 0, 3)
+        GramHolder = GramHolderWrapper(core.SummonSkill("그람홀더", 0, 3000, 1000+25*vEhc.getV(4,3), 6, 40000, cooltime = 180000).isV(vEhc,4,3)) # 클라 딜레이 없음
         
         MagicCircuitFullDrive = core.BuffSkill("매직 서킷 풀드라이브", 720, (30+vEhc.getV(3,2))*1000, pdamage = (20 + vEhc.getV(3,2)), cooltime = 200*1000).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
         MagicCircuitFullDriveStorm = core.SummonSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 4000, 500+20*vEhc.getV(3,2), 3, (30+vEhc.getV(3,2))*1000, cooltime = -1).wrap(core.SummonSkillWrapper)
         
-        CrystalIgnitionInit = core.DamageSkill("크리스탈 이그니션(시전)", 960, 0, 0, cooltime = 180*1000).wrap(core.DamageSkillWrapper)
-        CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 10000/62, 750 + 30*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper)
+        CrystalIgnitionInit = core.DamageSkill("크리스탈 이그니션(시전)", 720, 0, 0, cooltime = 180*1000).wrap(core.DamageSkillWrapper)
+        CrystalIgnition = core.DamageSkill("크리스탈 이그니션", 150, 750 + 30*vEhc.getV(2,1), 4, modifier = core.CharacterModifier(boss_pdamage = 20)).isV(vEhc,2,1).wrap(core.DamageSkillWrapper)
+        CrystalIgnitionEnd = core.DamageSkill("크리스탈 이그니션(종료)", 630, 0, 0, cooltime = -1).wrap(core.DamageSkillWrapper)
         Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼", 0, 1000+40*vEhc.getV(2,1), 5, cooltime = 1000, modifier = core.CharacterModifier(boss_pdamage = 20)).wrap(core.DamageSkillWrapper) #1초마다 시전됨.
  
         SoulOfCrystal = SoulOfCrystalWrapper(core.BuffSkill("소울 오브 크리스탈", 510*2, 30*1000, cooltime=40*1000).isV(vEhc,1,0))
@@ -194,7 +254,9 @@ class JobGenerator(ck.JobGenerator):
         
         GloryWing_Craft_Javelin.onAfter(GloryWing_Craft_Javelin_Fragment)
         
-        CrystalIgnitionInit.onAfter(core.RepeatElement(CrystalIgnition, 62))
+        CrystalIgnitionRepeat = core.RepeatElement(CrystalIgnition, 62)
+        CrystalIgnitionInit.onAfter(CrystalIgnitionRepeat)
+        CrystalIgnitionRepeat.onAfter(CrystalIgnitionEnd)
         CrystalIgnition.onAfter(Reaction_Spectrum_Trigger)
 
         CrystalSkill_Deus.onAfter(CrystalSkill_Deus_Satelite)
@@ -218,6 +280,9 @@ class JobGenerator(ck.JobGenerator):
         
         SoulOfCrystal.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
         Machina.onConstraint(core.ConstraintElement("글로리윙 미사용중", GloryWingUse, GloryWingUse.is_not_active))
+
+        GramHolder.registerCrystalCharge(CrystalCharge)
+        GramHolder.registerGloryWing(GloryWingUse)
         
         #기본공격 설정
         BasicAttack = core.OptionalElement(GloryWingUse.is_active, GloryWing_Craft_Javelin, Craft_Javelin_AfterOrb, name = "기본공격(글로리 윙 여부 판단)")


### PR DESCRIPTION
* 리요/데우스의 위성 공격력 변동 구현
  * 리요는 별 영향이 없으나, 데우스는 지속시간이 짧아 평균으로 적용하면 오차가 생겼음
* 그람홀더의 최종 데미지 조건을 정확히 적용
  * 기존에는 항상 100%로 했으나, 크리스탈 이그니션 10초간은 차지가 쌓이지 않기에 기대 피해량이 약간 내려감
* 크리스탈 이그니션의 선딜/공격간격/후딜을 정확하게 반영