### PR TITLE
fix: 히어로 스킬

### DIFF
--- a/dpmModule/jobs/hero.py
+++ b/dpmModule/jobs/hero.py
@@ -22,8 +22,9 @@ from .jobbranch import warriors
 
 #ComboAttack
 class ComboAttackWrapper(core.StackSkillWrapper):
-    def __init__(self, skill, vEhc, combat = False):
+    def __init__(self, skill, desfortBuff, vEhc, combat = False):
         super(ComboAttackWrapper, self).__init__(skill, 10)
+        self.desfortBuff = desfortBuff
         self.vEhc = vEhc
         self.stack = 10  #Better point!
         self.tick = 12 + combat * 1
@@ -39,16 +40,19 @@ class ComboAttackWrapper(core.StackSkillWrapper):
         return core.TaskHolder(task, name = "인스팅트 토글")
         
     def vary(self, diff):
+        if diff > 0:
+            chance = 0.8 - self.instinct * 0.5
+            chanceDouble = chance * 0.8
+            diff = diff * (2 * chanceDouble + chance)
         self.stack += diff
-        if diff > 0 and not self.instinct : self.stack -= (diff * 0.2)
-        if diff > 0 and self.instinct : self.stack -= (diff * 0.7)
         self.stack = max(min(10,self.stack),0)
         return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
 
     def get_modifier(self):
-        return core.CharacterModifier(pdamage = 2 * self.stack * (1 + self.instinct * 0.01 * (5 + 0.5*self.vEhc.getV(1,1))), 
-                                            pdamage_indep = self.tick * self.stack * (1 + self.instinct * 0.01 * (5 + 0.5*self.vEhc.getV(1,1))),
-                                            att = 2 * self.stack * (1 + self.instinct * 0.01 * (5 + 0.5*self.vEhc.getV(1,1))))
+        multiplier = (1 + self.instinct * 0.01 * (5 + 0.5*self.vEhc.getV(1,1)))
+        return core.CharacterModifier(pdamage = 2 * self.stack * multiplier, 
+                                            pdamage_indep = self.tick * (self.stack + self.desfortBuff.is_active() * 6) * multiplier,
+                                            att = 2 * self.stack * multiplier)
 
 ######   Passive Skill   ######
 class JobGenerator(ck.JobGenerator):
@@ -70,12 +74,12 @@ class JobGenerator(ck.JobGenerator):
         WeaponMastery = core.InformedCharacterModifier("웨폰 마스터리",pdamage_indep = 10, pdamage = 5)   #도끼 사용
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
         
-        ChanceAttackBuff = core.InformedCharacterModifier("찬스 어택(버프)",crit = 20)
+        ChanceAttack = core.InformedCharacterModifier("찬스 어택(패시브)",crit = 20)
 
         CombatMastery = core.InformedCharacterModifier("컴뱃 마스터리",armor_ignore = 50)
-        AdvancedFinalAttackBuff = core.InformedCharacterModifier("어드밴스드 파이널 어택(버프)",att = 30)
+        AdvancedFinalAttack = core.InformedCharacterModifier("어드밴스드 파이널 어택(패시브)",att = 30)
         
-        return [WeaponMastery, PhisicalTraining, ChanceAttackBuff, CombatMastery, AdvancedFinalAttackBuff]
+        return [WeaponMastery, PhisicalTraining, ChanceAttack, CombatMastery, AdvancedFinalAttack]
 
     def get_not_implied_skill_list(self):
         WeaponConstant = core.InformedCharacterModifier("무기상수", pdamage_indep = 44)
@@ -88,14 +92,24 @@ class JobGenerator(ck.JobGenerator):
         '''
         코강 순서:
         레블 - 파택 - 업라이징 - 샤우트 - 인사이징 - 패닉
+
+        어드밴스드 콤보-리인포스, 보스 킬러 / 어드밴스드 파이널 어택-보너스 찬스 / 레이징 블로우-리인포스, 보너스 어택
         
+        콤보 카운터 증가 확률
+        64% - 2개
+        16% - 1개
+        20% - 0개
+
+        인스팅트 시
+        24% - 2개
+        6%  - 1개
+        70% - 0개
         '''
         #combat = True
         ######   Skill   ######
         #Buff skills
         Fury = core.BuffSkill("분노", 0, 200*1000, att = 30, rem = True).wrap(core.BuffSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
-        ComboAttack = ComboAttackWrapper(core.BuffSkill("콤보어택", 0, 999999 * 1000), vEhc, combat)
         
         #Damage Skills
         Panic = core.DamageSkill("패닉", 720, 1150, 1, cooltime = 40000).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
@@ -105,7 +119,7 @@ class JobGenerator(ck.JobGenerator):
         RaisingBlowInrage = core.DamageSkill("레이징 블로우(인레이지)", 600, 215, 6, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)  #이걸 사용함.
         RaisingBlowInrageFinalizer = core.DamageSkill("레이징 블로우(인레이지)(최종타)", 0, 215, 2, modifier = core.CharacterModifier(pdamage = 20, crit = 100)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)  #이걸 사용함. 둘을 연결해야 함.
         
-        Insizing = core.DamageSkill("인사이징", 660, 576, 4, cooltime = 30 * 1000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)    #870->640 오더스 적용 필요함.
+        Insizing = core.DamageSkill("인사이징", 660, 576, 4, cooltime = 30 * 1000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)    # 오더스 적용 필요함.
         InsizingBuff = core.BuffSkill("인사이징(버프)", 0, 30 * 1000, cooltime = -1, pdamage = 25).wrap(core.BuffSkillWrapper)
         InsizingDot = core.DotSkill("인사이징(도트)", 165, 30 * 1000).wrap(core.SummonSkillWrapper)
     
@@ -114,16 +128,17 @@ class JobGenerator(ck.JobGenerator):
         RisingRage = core.DamageSkill("레이지 업라이징", 750, 500, 8, cooltime = 10*1000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
 
         Valhalla = core.BuffSkill("발할라", 900, 30 * 1000, cooltime = 150 * 1000, crit = 30, att = 50).wrap(core.BuffSkillWrapper)
-        SwordOfBurningSoul = core.SummonSkill("소드 오브 버닝 소울", 820, 1000, (315+12*vEhc.getV(0,0)), 6, (60+0.5*vEhc.getV(0,0)) * 1000, cooltime = 120 * 1000, modifier = core.CharacterModifier(crit = 50)).isV(vEhc, 0, 0).wrap(core.SummonSkillWrapper)       #시전 딜레이 모름.
+        SwordOfBurningSoul = core.SummonSkill("소드 오브 버닝 소울", 810, 1000, (315+12*vEhc.getV(0,0)), 6, (60+vEhc.getV(0,0)//2) * 1000, cooltime = 120 * 1000, modifier = core.CharacterModifier(crit = 50)).isV(vEhc, 0, 0).wrap(core.SummonSkillWrapper)
         
         ComboDesfort = core.DamageSkill("콤보 데스폴트", 1260, 800 + 32*vEhc.getV(2,3), 7, cooltime = 20 * 1000).isV(vEhc, 2, 3).wrap(core.DamageSkillWrapper)
-        ComboDesfortBuff = core.BuffSkill("콤보 데스폴트 종료 지시자", 0, 5 * 1000, pdamage_indep = 48.6, rem = False, cooltime = -1).isV(vEhc, 2, 3).wrap(core.BuffSkillWrapper)
+        ComboDesfortBuff = core.BuffSkill("콤보 데스폴트(버프)", 0, 5 * 1000, rem = False, cooltime = -1).isV(vEhc, 2, 3).wrap(core.BuffSkillWrapper)
         
         ComboInstinct = core.BuffSkill("콤보 인스팅트", 360, 30 * 1000, cooltime = 240 * 1000, rem = False, red = True).isV(vEhc, 1, 1).wrap(core.BuffSkillWrapper)
         ComboInstinctFringe = core.DamageSkill("콤보 인스팅트 균열", 0, 200 + 8*vEhc.getV(1,1), 18).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper)
         ComboInstinctOff = core.BuffSkill("콤보 인스팅트 종료", 0, 1, cooltime = -1).wrap(core.BuffSkillWrapper)
 
         ######   Skill Wrapper   ######
+        ComboAttack = ComboAttackWrapper(core.BuffSkill("콤보어택", 0, 999999 * 1000), ComboDesfortBuff, vEhc, combat)
         
         #Final attack type
         ComboInstinct.onAfter(ComboInstinctOff.controller(30 * 1000))
@@ -134,14 +149,17 @@ class JobGenerator(ck.JobGenerator):
         #레이징 블로우
         RaisingBlowInrage.onAfters([InstinctFringeUse, RaisingBlowInrageFinalizer, AdvancedFinalAttack, ComboAttack.stackController(1)])
 
-        RisingRage.onAfter(ComboAttack.stackController(1))
+        RisingRage.onAfters([AdvancedFinalAttack, ComboAttack.stackController(1)])
     
-        Insizing.onAfters([InsizingBuff, InsizingDot, AdvancedFinalAttack, ComboAttack.stackController(-2)])
+        Insizing.onBefore(ComboAttack.stackController(-1))
+        Insizing.onAfters([InsizingBuff, InsizingDot, AdvancedFinalAttack])
     
-        ComboDesfort.onAfters([ComboDesfortBuff, ComboAttack.stackController(-6)])    #is_usable() 콜로 체크 필수.
+        ComboDesfort.onBefores([ComboDesfortBuff, ComboAttack.stackController(-6)]) # TODO: 데스폴트 데미지에 콤보 카운터 어떻게 적용되는지 확인 필요
+        ComboDesfort.onAfter(AdvancedFinalAttack)
+        ComboDesfort.onConstraint(core.ConstraintElement("콤보 6개 이상", ComboAttack, partial(ComboAttack.judge, 6, 1)))
 
-        Panic.onAfter(PanicBuff)
-        Panic.onAfter(ComboAttack.stackController(-2))
+        Panic.onBefore(ComboAttack.stackController(-2))
+        Panic.onAfters([PanicBuff, AdvancedFinalAttack])
         
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 3, 2)


### PR DESCRIPTION
* 어드밴스드 콤보로 인해 콤보가 2개씩 찰 확률 적용
* 데스폴트 상태에서의 콤보 카운터 최종뎀 정확히 적용 (최종뎀 한정 +6스택 판정)
* 사용 하이퍼 명시
* 소드 오브 버닝 소울의 사용 딜레이 수정
* 소드 오브 버닝 소울의 지속시간 소수점 버림
* 레이지 업라이징에 파이널 어택 발동
* 콤보 데스폴트에 파이널 어택 발동
* 패닉에 파이널 어택 발동
* 콤보 카운터를 소모하는 스킬들이 먼저 소모한 다음 공격함
* 콤보 데스폴트의 버프 시간이 딜레이 후가 아닌 사용과 함께 돌아가기 시작함
* 콤보 데스폴트가 콤보 카운터 6개 이상일때만 사용 가능