### PR TITLE
윈드브레이커 쓸만한 컴뱃 오더스 반영

### DIFF
--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -22,10 +22,10 @@ class JobGenerator(ck.JobGenerator):
         ElementalExpert = core.InformedCharacterModifier("엘리멘탈 엑스퍼트", patt = 10)
         ElementalHarmony = core.InformedCharacterModifier("엘리멘탈 하모니", stat_main = self.chtr.level // 2)
         
-        WhisperOfWind = core.InformedCharacterModifier("위스퍼 오브 윈드",att = 20)
+        WhisperOfWind = core.InformedCharacterModifier("위스퍼 오브 윈드", att = 20)
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝", stat_main = 30, stat_sub = 30)
         
-        WindBlessingPassive = core.InformedCharacterModifier("윈드 블레싱(패시브)",pstat_main = 15, patt = 10 + self.combat*1)
+        WindBlessingPassive = core.InformedCharacterModifier("윈드 블레싱(패시브)", pstat_main = 15, patt = 10 + self.combat*1)
         BowExpert = core.InformedCharacterModifier("보우 엑스퍼트", att = 30 + self.combat*1, crit_damage = 20, pdamage_indep = 25 + self.combat*1, boss_pdamage = 40 + self.combat*1)
         return [ElementalExpert, ElementalHarmony, WhisperOfWind, PhisicalTraining, BowExpert, WindBlessingPassive]
 
@@ -47,23 +47,24 @@ class JobGenerator(ck.JobGenerator):
         
         '''
         #Buff skills
-        Storm = core.BuffSkill("엘리멘트(스톰)", 0, 200 * 1000, pdamage = 10, rem = True).wrap(core.BuffSkillWrapper)#딜레이 모름
-        SylphsAid = core.BuffSkill("실프스 에이드", 0, 200 * 1000, att = 20, crit = 10, rem = True).wrap(core.BuffSkillWrapper)#딜레이 모름
+        Storm = core.BuffSkill("엘리멘트(스톰)", 0, 200 * 1000, pdamage = 10, rem = True).wrap(core.BuffSkillWrapper) #딜레이 모름
+        SylphsAid = core.BuffSkill("실프스 에이드", 0, 200 * 1000, att = 20, crit = 10, rem = True).wrap(core.BuffSkillWrapper) #딜레이 모름
         Albatross = core.BuffSkill("알바트로스 맥시멈", 0, 200 * 1000, att = 50 + combat*1, pdamage = 25, armor_ignore = 15, crit = 25, rem = True).wrap(core.BuffSkillWrapper)  #900 -> 690
         SharpEyes = core.BuffSkill("샤프 아이즈", 660, 300 * 1000, crit = 20 + combat*1, crit_damage = 15 + combat*1, rem = True).wrap(core.BuffSkillWrapper)
-        GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
+        GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60 * 1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
         StormBringerDummy = core.BuffSkill("스톰 브링어(버프)", 0, 200 * 1000).wrap(core.BuffSkillWrapper)  #딜레이 계산 필요
         # 하이퍼: 데미지 증가, 확률 10% 증가, 타수 증가
-        TriflingWhim = core.DamageSkill("트라이플링 윔", 0, (290+3*combat)*0.8+(390+3*combat)*0.2, 2*(0.5+0.1), modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        TriflingWhim = core.DamageSkill("트라이플링 윔", 0, (290 + combat*3) * 0.8 + (390 + combat*3) * 0.2, 2 * (0.5 + 0.1), modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         StormBringer = core.DamageSkill("스톰 브링어", 0, 500, 0.3).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
     
         # 핀포인트 피어스
-        PinPointPierce = core.DamageSkill("핀포인트 피어스", 690, 340, 2, cooltime=30 * 1000).wrap(core.DamageSkillWrapper)
-        PinPointPierceDebuff = core.BuffSkill("핀포인트 피어스(버프)", 0, 30 * 1000, cooltime=-1, pdamage=15, armor_ignore=15).wrap(core.BuffSkillWrapper)
+        PinPointPierce = core.DamageSkill("핀포인트 피어스", 690, 340, 2, cooltime = 30 * 1000).wrap(core.DamageSkillWrapper)
+        PinPointPierceDebuff = core.BuffSkill("핀포인트 피어스(버프)", 0, 30 * 1000, cooltime = -1, pdamage = 15, armor_ignore = 15).wrap(core.BuffSkillWrapper)
 
         #Damage Skills
-        SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 +combat*3, 1, modifier = core.CharacterModifier(pdamage = 127.36, boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)# 코강렙 20이상 가정.
+        # 하이퍼: 데미지 증가, 보스 데미지 증가
+        SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + combat*3, 1, modifier = core.CharacterModifier(pdamage = 127.36 + combat*(134.358881 - 127.36), boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #코강렙 20이상 가정. 쓸컴뱃 사용 시 증가하는 데미지 20%->21%에 따른 추가 데미
         
         CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 600, 120 * 5, 450 + 18*vEhc.getV(0,0), 5, 120 * (40 + vEhc.getV(0,0)), cooltime = 30 * 1000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         
@@ -72,8 +73,8 @@ class JobGenerator(ck.JobGenerator):
     
         #Summon Skills
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 5, 5)
-        HowlingGail = core.SummonSkill("하울링 게일", 630, 10 * 1000 / 33, 250 + 10*vEhc.getV(1,1), 2 * 3, 10000, cooltime = 20 * 1000).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) #딜레이 모름, 64���
-        WindWall = core.SummonSkill("윈드 월", 720, 2000, (550 + vEhc.getV(2,2)*22) / 2, 5*3 , 45 * 1000, cooltime = 90 * 1000).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
+        HowlingGail = core.SummonSkill("하울링 게일", 630, 10 * 1000 / 33, 250 + 10*vEhc.getV(1, 1), 2 * 3, 10000, cooltime = 20 * 1000).isV(vEhc, 1, 1).wrap(core.SummonSkillWrapper) #딜레이 모름, 허수아비/1스택 기준 64타 (총 66타)
+        WindWall = core.SummonSkill("윈드 월", 720, 2000, (550 + vEhc.getV(2, 2)*22) / 2, 5 * 3 , 45 * 1000, cooltime = 90 * 1000).isV(vEhc, 2, 2).wrap(core.SummonSkillWrapper)
         
         ######   Skill Wrapper   #####
         
@@ -83,7 +84,7 @@ class JobGenerator(ck.JobGenerator):
         SongOfHeaven.onAfters([TriflingWhim, StormBringer])
         PinPointPierce.onAfters([PinPointPierceDebuff, TriflingWhim, StormBringer])
         #Summon
-        CygnusPalanks.onTicks([core.RepeatElement(TriflingWhim,5), core.RepeatElement(StormBringer,5)])
+        CygnusPalanks.onTicks([core.RepeatElement(TriflingWhim, 5), core.RepeatElement(StormBringer, 5)])
         HowlingGail.onTicks([core.RepeatElement(TriflingWhim, 2), core.RepeatElement(StormBringer, 2)])
 
         Mercilesswind.onAfter(MercilesswindDOT)

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -64,7 +64,7 @@ class JobGenerator(ck.JobGenerator):
 
         #Damage Skills
         # 하이퍼: 데미지 증가, 보스 데미지 증가
-        SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + combat*3, 1, modifier = core.CharacterModifier(pdamage = (((1.2 + combat*0.01)**4 - 1) * 100 + 20), boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #코강렙 20이상 가정.
+        SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + combat*3, 1, modifier = core.CharacterModifier(pdamage = ((1.2 + combat*0.01)**4 - 1) * 100 + 20, boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #코강렙 20이상 가정.
         
         CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 600, 120 * 5, 450 + 18*vEhc.getV(0,0), 5, 120 * (40 + vEhc.getV(0,0)), cooltime = 30 * 1000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -64,7 +64,7 @@ class JobGenerator(ck.JobGenerator):
 
         #Damage Skills
         # 하이퍼: 데미지 증가, 보스 데미지 증가
-        SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + combat*3, 1, modifier = core.CharacterModifier(pdamage = 127.36 + combat*(134.358881 - 127.36), boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #코강렙 20이상 가정. 쓸컴뱃 사용 시 증가하는 데미지 20%->21%에 따른 추가 데미
+        SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + combat*3, 1, modifier = core.CharacterModifier(pdamage = (((1.2 + combat*0.01)**4 - 1) * 100 + 20), boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #코강렙 20이상 가정.
         
         CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 600, 120 * 5, 450 + 18*vEhc.getV(0,0), 5, 120 * (40 + vEhc.getV(0,0)), cooltime = 30 * 1000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         


### PR DESCRIPTION
쓸컴뱃 사용 시 천공의 노래 타겟수에 따른 추가 데미지가 20%에서 21%로 증가하여 하이퍼 포함 총 추가 데미지는 127.36%에서 134.358881%로 증가하는 점을 반영했습니다.
모든 스킬에 쓸컴뱃 수치를 반영했습니다.
일정하지 않은 formatting을 일부 수정했습니다.