### PR TITLE
fix: 아델 스킬

### DIFF
--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -116,7 +116,7 @@ class JobGenerator(ck.JobGenerator):
         레조넌스 10초마다 사용
 
         코어 강화 순서
-        디바이드 - 오더(그레이브) - 테리토리(트레드) - 블로섬(스콜) - 임페일(레조넌스/마커) - 크리에이션(게더링) - 샤드 - 레조넌스
+        디바이드 - 오더(그레이브) - 테리토리(트레드) - 블로섬(스콜) - 임페일(레조넌스/마커) - 크리에이션(게더링) - 샤드(원더)
         인피니트 - 리스토어 - 루인 - 매서풀 - 오라웨폰 - (바오스)
 
         '''
@@ -251,7 +251,7 @@ class JobGenerator(ck.JobGenerator):
                     AuraWeaponBuff, AuraWeaponCooltimeDummy, MagicCircuitFullDrive, 
                     globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()] +\
                 [Resonance, Grave, Blossom, Marker, Ruin] +\
-                [Order, Shard, Territory, TerritoryEnd, Infinite, RuinFirstTick, RuinSecondTick, RestoreTick, Creation, ManaStorm] +\
+                [Order, Shard, Territory, TerritoryEnd, Infinite, RuinFirstTick, RuinSecondTick, RestoreTick, Creation, Scool, ManaStorm] +\
                 [] +\
                 [Divide])        
 

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -146,7 +146,7 @@ class JobGenerator(ck.JobGenerator):
         Grave = core.DamageSkill('그레이브', 630, 800+self._combat*20, 10, cooltime=-1).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) #한 번만 사용, 클라공속 840ms
         GraveDebuff = core.BuffSkill('그레이브(디버프)', 0, 999999999, pdamage=20, armor_ignore=10, cooltime=-1).wrap(core.BuffSkillWrapper)
 
-        Blossom = core.DamageSkill('블로섬', 330, 650+self._combat*6, 8, cooltime=20*1000*0.75, red=True).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper) # 50%결정. 클라공속 420ms
+        Blossom = core.DamageSkill('블로섬', 420, 650+self._combat*6, 8, cooltime=20*1000*0.75, red=True).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper) # 50%결정. 클라공속 420ms, 공속 안받음
         BlossomExceed = core.StackDamageSkillWrapper(
             core.DamageSkill('블로섬(초과)', 0, 650+self._combat*6, 8, cooltime=-1, modifier=core.CharacterModifier(pdamage_indep=-25)).setV(vEhc, 3, 2, False),
             Order,
@@ -210,7 +210,7 @@ class JobGenerator(ck.JobGenerator):
 
         # 게더링-블로섬
         Blossom.onConstraint(core.ConstraintElement('오더가 있을 때', Order, partial(Order.judge, 1, 1)))
-        Blossom.onBefore(Gathering)
+        Blossom.onBefores([Divide, Gathering]) # 게더링->디바이드->블로섬 순서, _befores는 리스트의 끝부터 실행됨
         Blossom.onAfter(BlossomExceed)
 
         Grave.onAfter(GraveDebuff)

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -26,8 +26,6 @@ class OrderWrapper(core.SummonSkillWrapper):
     def add(self):
         self.ether.vary(-100)
         self.queue = self.queue + [self.currentTime + self.REMAIN_TIME]
-        self.stack = len(self.queue) * 2
-        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
 
     def spend_time(self, time):
         self.currentTime += time
@@ -49,8 +47,7 @@ class OrderWrapper(core.SummonSkillWrapper):
         return core.TaskHolder(task, name = "오더 지속시간 지연")
         
     def judge(self, stack, direction):
-        if (self.stack-stack)*direction>=0:return True
-        else: return False
+        return (self.stack-stack)*direction>=0
 
     def _useTick(self):
         if self.onoff and self.tick <= 0:
@@ -159,7 +156,7 @@ class JobGenerator(ck.JobGenerator):
         BlossomExceed = core.StackDamageSkillWrapper(
             core.DamageSkill('블로섬(초과)', 0, 650+self._combat*6, 8, cooltime=-1, modifier=core.CharacterModifier(pdamage_indep=-25)).setV(vEhc, 3, 2, False),
             Order,
-            lambda order: order.stack * 0.8 - 1
+            lambda order: max(order.stack * 0.8 - 1, 0)
         )
 
         Marker = core.DamageSkill('마커', 690, 1000, 3*2, cooltime=60*1000, modifier=core.CharacterModifier(pdamage_indep=300)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) # 최종뎀 300% 증가, 임의위치 조각 5개, 1히트, 결정 5개, 생성/파쇄 각각 공격, 클라공속 900ms

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -123,7 +123,7 @@ class JobGenerator(ck.JobGenerator):
         passive_level = chtr.get_base_modifier().passive_level + self._combat
 
         ShardActive = core.DamageSkill("샤드(액티브)", 0, 80+30+115+225+passive_level*3, 3 * 5).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper) # 자동사용만, 최종 450*3
-        Shard = core.SummonSkill("샤드", 0, 8000, 80+30+115+225+passive_level*3, 3 * 5, 99999999).setV(vEhc, 6, 2, False).wrap(core.SummonSkillWrapper) # 8초마다 자동시전
+        Shard = core.DamageSkill("샤드", 0, 80+30+115+225+passive_level*3, 3 * 5, cooltime=8000).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper) # 8초마다 트리거 스킬 적중시 시전
 
         Ether = core.StackSkillWrapper(core.BuffSkill('에테르', 0, 9999999), 400)
         EtherTick = core.SummonSkill('에테르(자연 회복)', 0, 10020, 0, 0, 9999999).wrap(core.SummonSkillWrapper)
@@ -181,7 +181,7 @@ class JobGenerator(ck.JobGenerator):
         RuinFirstTick = core.SummonSkill('루인(소환)', 0, 160, 250 + vEhc.getV(2,2)*10, 6, 2000, cooltime=-1).isV(vEhc,2,2).wrap(core.SummonSkillWrapper) # 12번, 2초에 나누어 사용으로 가정
         RuinSecondTick = core.SummonSkill('루인(공격)', 0, 250, 450 + vEhc.getV(2,2)*18, 9, 2000, cooltime=-1).isV(vEhc,2,2).wrap(core.SummonSkillWrapper) # 8번, 2초에 나누어 사용으로 가정
 
-        Infinite = core.SummonSkill('인피니트', 540, 1080, 350 + vEhc.getV(0,0) * 14, 2 * 18, 30000, cooltime=180*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) #매 공격마다 5% 결정생성. 전분 기준 514회 타격 -> 평균 514/18 = 28회 공격(1080ms). 
+        Infinite = core.SummonSkill('인피니트', 540, 342, 350 + vEhc.getV(0,0) * 14, 2 * 6, 30000, cooltime=180*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) #매 공격마다 5% 결정생성. 전분 기준 517회 타격 -> 18개를 6개씩 묶어서 타격 가정. (30000-540)//342*6 = 516.
         Restore = core.BuffSkill('리스토어', 720, 30*1000, pdamage=15+vEhc.getV(1,1), cooltime=180*1000, red=True).isV(vEhc,1,1).wrap(core.BuffSkillWrapper) #소드 2개 증가, 에테르획득량 40+d(x/2)%증가
         RestoreTick = core.SummonSkill('리스토어(주기공격)', 0, 2970, 900+36*vEhc.getV(1,1), 3, 30*1000, cooltime=-1).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 11회 시전
 
@@ -240,7 +240,11 @@ class JobGenerator(ck.JobGenerator):
         # 크리에이션
         Divide.onAfter(core.OptionalElement(Creation.is_available, Creation))
 
+        # 원더
+        Divide.onAfter(core.OptionalElement(Shard.is_available, Shard))
+
         Creation.protect_from_running()
+        Shard.protect_from_running()
 
         return(Divide,
                 [globalSkill.maple_heros(chtr.level), ResonanceStack, GraveDebuff, WraithOfGod, Restore,

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -6,9 +6,49 @@ from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule, InactiveRule
 from . import globalSkill
 from .jobbranch import warriors
-from .jobclass import cygnus
 from .jobclass import flora
 from . import jobutils
+import math
+
+class OrderWrapper(core.SummonSkillWrapper):
+    def __init__(self, skill, ether: core.StackSkillWrapper):
+        super(OrderWrapper, self).__init__(skill)
+        self.ether = ether
+        self.condition = None
+        self.queue = []
+        self.stack = 0
+        self.currentTime = 0
+        self.REMAIN_TIME = 40000
+
+    def setCondition(self, condition):
+        self.condition = condition
+
+    def add(self):
+        self.ether.vary(-100)
+        self.queue = self.queue + [self.currentTime + self.REMAIN_TIME]
+        self.stack = len(self.queue) * 2
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
+
+    def spend_time(self, time):
+        self.currentTime += time
+        self.queue = [x for x in self.queue if x > self.currentTime]
+
+        if self.condition():
+            self.add()
+        
+        self.stack = len(self.queue) * 2
+        super(OrderWrapper, self).spend_time(time)
+        
+    def judge(self, stack, direction):
+        if (self.stack-stack)*direction>=0:return True
+        else: return False
+
+    def _useTick(self):
+        if self.onoff and self.tick <= 0:
+            self.tick += self.skill.delay
+            return core.ResultObject(0, self.get_modifier(), self.skill.damage, self.skill.hit * self.stack, sname = self.skill.name, spec = self.skill.spec)
+        else:
+            return core.ResultObject(0, self.disabledModifier, 0, 0, sname = self.skill.name, spec = self.skill.spec)
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -19,6 +59,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "아델"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+        self._combat = 0 # 임시 사용, vEhc에서 받아와야 함
 
     def get_ruleset(self):
         ruleset = RuleSet()
@@ -27,24 +68,24 @@ class JobGenerator(ck.JobGenerator):
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         # 매직 서킷: 앱솔 기준 15.4
         WEAPON_ATT = jobutils.get_weapon_att("튜너")
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         
-        MagicCircuit = core.InformedCharacterModifier("매직 서킷", att=WEAPON_ATT * 0.15)  #무기 마력의 25%, 최대치 가정.
+        MagicCircuit = core.InformedCharacterModifier("매직 서킷", att=WEAPON_ATT * 0.15)  #무기 공격력의 15%, 최대치 가정.
         Pace = core.InformedCharacterModifier("패이스", crit_damage=10, patt=10)
-        # Link skill : ignored
-        # Nobless = core.InformedCharacterModifier("노블레스", boss_pdamage=4)
         Rudiment = core.InformedCharacterModifier("루디먼트", att=30)
         Mastery = core.InformedCharacterModifier("마스터리", att=30)
         Train = core.InformedCharacterModifier("트레인", stat_main=60)
         Accent = core.InformedCharacterModifier("어센트", att=30, pdamage_indep=15, crit=20)
         Expert = core.InformedCharacterModifier("엑스퍼트", att=30)
-        Demolition = core.InformedCharacterModifier("데몰리션", pdamage_indep=30, armor_ignore=20)
-        Attain = core.InformedCharacterModifier("어테인", att=30, boss_pdamage=10, crit=20)
+        Demolition = core.InformedCharacterModifier("데몰리션", pdamage_indep=30+passive_level, armor_ignore=20+passive_level)
+        Attain = core.InformedCharacterModifier("어테인", att=30+passive_level, boss_pdamage=10+math.ceil(passive_level/2), crit=20+passive_level)
 
         return [MagicCircuit, Pace, Rudiment, Mastery, Train, Accent, Expert, Demolition, Attain]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 34)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5 + 0.5 * math.ceil(passive_level / 2))
 
         return [WeaponConstant, Mastery]
 
@@ -57,73 +98,120 @@ class JobGenerator(ck.JobGenerator):
         테리토리-퍼시스트
         블로섬-쿨타임 리듀스
 
-        전분 참조 : https://youtu.be/_VBcNu4Bw6c
+        전분 참조 : https://youtu.be/m2LX8otP-9w
 
         게더링-블로섬
 
-        오더의 칼 개수는 5으로 고정( 리스토어 한정 7)
-        게더링-블로섬 연계는 게더링 5히트 / 블로섬 3히트를 가정함
-        크리에이션은 평균 3자루의 칼이 공격하는 것을 가정함
+        게더링, 블로섬 80% 히트
+
+        레조넌스 10초마다 사용
 
         코어 강화 순서
         디바이드 - 오더(그레이브) - 테리토리(트레드) - 블로섬(스콜) - 임페일(레조넌스/마커) - 크리에이션(게더링) - 샤드 - 레조넌스
         인피니트 - 리스토어 - 루인 - 매서풀 - 오라웨폰 - (바오스)
 
         '''
-        GATHERING_HIT = 5
-        BLOSSOM_HIT = 3
-        CREATION_HIT = 3
-        ShardActive = core.DamageSkill("샤드(액티브)", 0, 80+30+115+225, 3 * 5).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper) # 자동사용만, 최종 450*3
-        Shard = core.SummonSkill("샤드", 0, 8000, 80+30+115+225, 3 * 5, 99999999).setV(vEhc, 6, 2, False).wrap(core.SummonSkillWrapper) # 8초마다 자동시전
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
 
-        # Ether = core.StackSkillWrapper('에테르', 300)
-        Resonance = core.DamageSkill("레조넌스", 690, (120+125+265) * (1.15**6), 6, cooltime=10*1000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) # 클라공속 900ms, 스택 유지를 위해 10초마다 사용함
+        ShardActive = core.DamageSkill("샤드(액티브)", 0, 80+30+115+225+passive_level*3, 3 * 5).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper) # 자동사용만, 최종 450*3
+        Shard = core.SummonSkill("샤드", 0, 8000, 80+30+115+225+passive_level*3, 3 * 5, 99999999).setV(vEhc, 6, 2, False).wrap(core.SummonSkillWrapper) # 8초마다 자동시전
+
+        Ether = core.StackSkillWrapper(core.BuffSkill('에테르', 0, 9999999), 400)
+        EtherTick = core.SummonSkill('에테르(자연 회복)', 0, 10020, 0, 0, 9999999).wrap(core.SummonSkillWrapper)
+
+        Resonance = core.DamageSkill("레조넌스", 690, (120+125+265+passive_level*3) * (1.15**6), 6, cooltime=10*1000, red=True).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) # 클라공속 900ms, 스택 유지를 위해 10초마다 사용함
 
         ResonanceStack = core.BuffSkill('레조넌스(스택)', 0, 30*1000, cooltime=-1, pdamage_indep=15, armor_ignore=15).wrap(core.BuffSkillWrapper) # 최종뎀 5, 방무 5, 최대3회. 상시 중첩으로 가정
 
-        #12초마다 발동
-        Creation = core.SummonSkill('크리에이션', 0, 9500 - 8000, 200+240+270, CREATION_HIT, 99999999).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper) # 직접시전시 270ms 기본공속
+        Creation = core.StackDamageSkillWrapper(
+            core.DamageSkill('크리에이션', 0, 200+240+270+passive_level*3, 1, cooltime = 1500, red=True).setV(vEhc, 5, 2, False),
+            Ether,
+            lambda ether: min(ether.stack // 100, 3) * 2
+        ) # 직접시전시 270ms 기본공속
 
-        Territory = core.SummonSkill('테리토리', 420, 405, 100+300, 4, 7000+4000, rem=False, cooltime=30*1000).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper) # 27회 타격, 클라공속540ms
-        TerritoryEnd = core.DamageSkill('테리토리(종료)', 0, 550+300, 12).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        Territory = core.SummonSkill('테리토리', 420, 405, 100+300+passive_level*5, 4, 7000+4000, rem=False, cooltime=30*1000, red=True).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper) # 27회 타격, 클라공속540ms
+        TerritoryEnd = core.DamageSkill('테리토리(종료)', 0, 550+300+passive_level*5, 12, cooltime=-1).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
 
-        Gathering = core.DamageSkill('게더링', 0, 260+300, 4 * GATHERING_HIT, cooltime=12*1000).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper) # 칼 불러오기. 블라섬과 연계됨, 딜레이 0 가정
+        Order = OrderWrapper(core.SummonSkill('오더', 0, 1140, 240+120+passive_level*3, 2, 99999999).setV(vEhc, 1, 2, False), Ether) # 15% 에테르 결정, 시전딜레이 없음으로 가정, 공격주기 1140ms(인피니트로부터 추정됨)
 
-        Order = core.SummonSkill('오더', 0, 1140, 240+120, 2 * 5, 99999999).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper) # 15% 에테르 결정, 시전딜레이 없음으로 가정, 공격주기 1140ms(인피니트로부터 추정됨)
+        Gathering = core.StackDamageSkillWrapper(
+            core.DamageSkill('게더링', 0, 260+300+passive_level*3, 4, cooltime=12*1000, red=True).setV(vEhc, 5, 2, False),
+            Order,
+            lambda order: order.stack * 0.8
+        ) # 칼 불러오기. 블라섬과 연계됨, 딜레이 0 가정
 
-        Divide = core.DamageSkill('디바이드', 600, 375, 6, modifier=core.CharacterModifier(pdamage=20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #트리거 스킬, 클라공속 780ms
+        Divide = core.DamageSkill('디바이드', 600, 375+self._combat*3, 6, modifier=core.CharacterModifier(pdamage=20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #트리거 스킬, 클라공속 780ms
 
-        Grave = core.DamageSkill('그레이브', 630, 800, 10, cooltime=-1).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) #한 번만 사용, 클라공속 840ms
+        # TODO: 쿨마다 사용하는게 나을 수 있음
+        Grave = core.DamageSkill('그레이브', 630, 800+self._combat*20, 10, cooltime=-1).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) #한 번만 사용, 클라공속 840ms
         GraveDebuff = core.BuffSkill('그레이브(디버프)', 0, 999999999, pdamage=20, armor_ignore=10, cooltime=-1).wrap(core.BuffSkillWrapper)
 
-        Blossom = core.DamageSkill('블로섬', 300, 650 * 0.75, 8 * BLOSSOM_HIT, cooltime=20*1000*0.75).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper) # 50%결정. 클라공속 600ms
+        Blossom = core.DamageSkill('블로섬', 330, 650+self._combat*6, 8, cooltime=20*1000*0.75, red=True).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper) # 50%결정. 클라공속 420ms
+        BlossomExceed = core.StackDamageSkillWrapper(
+            core.DamageSkill('블로섬(초과)', 0, 650+self._combat*6, 8, cooltime=-1, modifier=core.CharacterModifier(pdamage_indep=-25)).setV(vEhc, 3, 2, False),
+            Order,
+            lambda order: order.stack * 0.8 - 1
+        )
 
-        Marker = core.DamageSkill('마커', 690, 1000 * (4), 3 * (1), cooltime=60*1000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) # 최종뎀 300% 증가, 임의위치 조각 5개, 1히트, 결정 5개, 클라공속 900ms
+        Marker = core.DamageSkill('마커', 690, 1000, 3*2, cooltime=60*1000, modifier=core.CharacterModifier(pdamage_indep=300)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) # 최종뎀 300% 증가, 임의위치 조각 5개, 1히트, 결정 5개, 생성/파쇄 각각 공격, 클라공속 900ms
         Scool = core.DamageSkill('스콜', 690, 1000, 12, cooltime=180*1000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper) #바인드. 클라공속 900ms
         WraithOfGod = core.BuffSkill("레이스 오브 갓", 0, 60*1000, pdamage = 10, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
 
         # 5차
 
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 4, 4)
-        for sk in [Divide]:
+        magic_curcuit_full_drive_builder = flora.MagicCircuitFullDriveBuilder(vEhc, 3, 3)
+        for sk in [Divide, Resonance]:
             auraweapon_builder.add_aura_weapon(sk)
+            magic_curcuit_full_drive_builder.add_trigger(sk)
         AuraWeaponBuff, AuraWeaponCooltimeDummy = auraweapon_builder.get_buff()
+        MagicCircuitFullDrive, ManaStorm = magic_curcuit_full_drive_builder.get_skill()
 
-        MagicCircuitFullDrive = core.BuffSkill("매직 서킷 풀드라이브", 720, (30+vEhc.getV(3,3))*1000, pdamage = (20 + vEhc.getV(3,3)), cooltime = 200*1000).isV(vEhc,3,3).wrap(core.BuffSkillWrapper)
-
-        Ruin = core.DamageSkill('루인(시전)', 780, 0, 0, cooltime=60*1000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper) # 4초에 나누어서 시전되는 것으로 가정
+        # TODO: 5차 스킬 딜레이 공속 적용여부 테스트
+        Ruin = core.DamageSkill('루인(시전)', 780, 0, 0, cooltime=60*1000, red=True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper) # 4초에 나누어서 시전되는 것으로 가정
         RuinFirstTick = core.SummonSkill('루인(소환)', 0, 160, 250 + vEhc.getV(2,2)*10, 6, 2000, cooltime=-1).isV(vEhc,2,2).wrap(core.SummonSkillWrapper) # 12번, 2초에 나누어 사용으로 가정
         RuinSecondTick = core.SummonSkill('루인(공격)', 0, 250, 450 + vEhc.getV(2,2)*18, 9, 2000, cooltime=-1).isV(vEhc,2,2).wrap(core.SummonSkillWrapper) # 8번, 2초에 나누어 사용으로 가정
 
-        Infinite = core.SummonSkill('인피니트', 540, 1140, 350 + vEhc.getV(0,0) * 14, 2 * 18, 30000, cooltime=180*1000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) #매 공격마다 5% 결정생성. 전분 기준 522회 타격 -> 평균 522/20 = 26회 공격(1140ms). 
-        Restore = core.BuffSkill('리스토어', 720, 30*1000, pdamage=15+vEhc.getV(1,1), cooltime=180*1000).isV(vEhc,1,1).wrap(core.BuffSkillWrapper) #소드 2개 증가, 에테르획득량 40%증가
+        Infinite = core.SummonSkill('인피니트', 540, 1080, 350 + vEhc.getV(0,0) * 14, 2 * 18, 30000, cooltime=180*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) #매 공격마다 5% 결정생성. 전분 기준 514회 타격 -> 평균 514/18 = 28회 공격(1080ms). 
+        Restore = core.BuffSkill('리스토어', 720, 30*1000, pdamage=15+vEhc.getV(1,1), cooltime=180*1000, red=True).isV(vEhc,1,1).wrap(core.BuffSkillWrapper) #소드 2개 증가, 에테르획득량 40+d(x/2)%증가
         RestoreTick = core.SummonSkill('리스토어(주기공격)', 0, 2970, 900+36*vEhc.getV(1,1), 3, 30*1000, cooltime=-1).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 11회 시전
-        OrderRestore = core.SummonSkill('오더(리스토어)', 0, 1140, 240+120, 2 * 1, 30*1000, cooltime=-1).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper) # 15% 에테르 결정, 시전딜레이 없음으로 가정, 공격주기 1140ms(인피니트로부터 추정됨)
 
         # 딜 사이클 정의
 
+        # 에테르
+        Ether.set_stack(400)
+        RESTORE_MULTIPLIER = 1 + (40 + vEhc.getV(1,1) // 2) / 100
+        EtherTick.onTick(core.OptionalElement(
+            Restore.is_active,
+            Ether.stackController(5*RESTORE_MULTIPLIER),
+            Ether.stackController(5)
+        ))
+        Divide.onAfter(core.OptionalElement(
+            Restore.is_active,
+            Ether.stackController(10*RESTORE_MULTIPLIER),
+            Ether.stackController(10)
+        ))
+        Resonance.onAfter(core.OptionalElement( # 레조넌스-엑스트라 힐링
+            Restore.is_active,
+            Ether.stackController(20*RESTORE_MULTIPLIER),
+            Ether.stackController(20)
+        ))
+
+        # 오더
+        def use_order():
+            if Ether.judge(100, -1):
+                return False
+            if Order.judge(4, -1): # 2쌍 이하면 사용
+                return True
+            if Restore.is_active() and Order.judge(6, -1): # 리스토어중 3쌍 이하면 사용
+                return True
+            return False
+        Order.setCondition(use_order)
+
         # 게더링-블로섬
+        Blossom.onConstraint(core.ConstraintElement('오더가 있을 때', Order, partial(Order.judge, 1, 1)))
         Blossom.onBefore(Gathering)
+        Blossom.onAfter(BlossomExceed)
 
         Grave.onAfter(GraveDebuff)
         Grave.set_disabled_and_time_left(1)
@@ -134,20 +222,24 @@ class JobGenerator(ck.JobGenerator):
 
         # 리스토어
         Restore.onAfter(RestoreTick)
-        Restore.onAfter(OrderRestore)
 
         # 테리토리
-        Territory.onAfter(TerritoryEnd)
+        Territory.onAfter(TerritoryEnd.controller(7000+4000))
 
         # 레조넌스
         Resonance.onAfter(ResonanceStack)
+
+        # 크리에이션
+        Divide.onAfter(core.OptionalElement(Creation.is_available, Creation))
+
+        Creation.protect_from_running()
 
         return(Divide,
                 [globalSkill.maple_heros(chtr.level), ResonanceStack, GraveDebuff, WraithOfGod, Restore,
                     AuraWeaponBuff, AuraWeaponCooltimeDummy, MagicCircuitFullDrive, 
                     globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()] +\
                 [Resonance, Grave, Blossom, Marker, Ruin] +\
-                [Order, Shard, Territory, Infinite, RuinFirstTick, RuinSecondTick, RestoreTick, OrderRestore, Creation] +\
+                [Order, Shard, Territory, TerritoryEnd, Infinite, RuinFirstTick, RuinSecondTick, RestoreTick, Creation, ManaStorm] +\
                 [] +\
                 [Divide])        
 

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -123,7 +123,7 @@ class JobGenerator(ck.JobGenerator):
         passive_level = chtr.get_base_modifier().passive_level + self._combat
 
         ShardActive = core.DamageSkill("샤드(액티브)", 0, 80+30+115+225+passive_level*3, 3 * 5).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper) # 자동사용만, 최종 450*3
-        Shard = core.DamageSkill("샤드", 0, 80+30+115+225+passive_level*3, 3 * 5, cooltime=8000).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper) # 8초마다 트리거 스킬 적중시 시전
+        Shard = core.DamageSkill("샤드", 0, 80+30+115+225+passive_level*3, 3 * 5, cooltime=8000, red=True).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper) # 8초마다 트리거 스킬 적중시 시전
 
         Ether = core.StackSkillWrapper(core.BuffSkill('에테르', 0, 9999999), 400)
         EtherTick = core.SummonSkill('에테르(자연 회복)', 0, 10020, 0, 0, 9999999).wrap(core.SummonSkillWrapper)

--- a/dpmModule/jobs/jobclass/flora.py
+++ b/dpmModule/jobs/jobclass/flora.py
@@ -13,11 +13,15 @@ def FloraGoddessBlessWrapper(vEhc, num1, num2, WEAPON_ATT):
 class MagicCircuitFullDriveBuilder():
     def __init__(self, vEhc, num1, num2, mana = 100):
         # 마나 최대치 유지 가정, 비율에 따라 수치가 어떻게 변동되는지 확인 필요
-        # 마력 폭풍 발생 시 데미지 증가량 갱신하지 않음
+        # 마력 폭풍 발생 시 데미지 증가량 갱신 미적용중
         self.MANA = mana
-        self.MagicCircuitFullDriveBuff = core.BuffSkill("매직 서킷 풀드라이브 (버프)", 720, 30+vEhc.getV(num1, num2), cooltime = 200*1000, pdamage= (20+vEhc.getV(num1, num2)) * (self.MANA/100)).wrap(core.BuffSkillWrapper)
-        self.ManaStorm = core.SummonSkill("매직 서킷 풀드라이브 (마나 폭풍)", 0, 4000, 500+20*vEhc.getV(num1, num2), 3, 30+vEhc.getV(num1, num2), cooltime = -1).wrap(core.SummonSkillWrapper)
-        self.MagicCircuitFullDriveBuff.onAfter(self.ManaStorm)
+        self.MagicCircuitFullDriveBuff = core.BuffSkill("매직 서킷 풀드라이브(버프)", 540, (30+vEhc.getV(num1, num2))*1000, cooltime=200*1000, red=True, pdamage=(20+vEhc.getV(num1, num2)) * (self.MANA/100)).wrap(core.BuffSkillWrapper)
+        self.ManaStorm = core.DamageSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 500+20*vEhc.getV(num1, num2), 3, cooltime = 4000).wrap(core.DamageSkillWrapper)
+        self.UseManaStorm = core.OptionalElement(lambda: self.MagicCircuitFullDriveBuff.is_active() and self.ManaStorm.is_available(), self.ManaStorm)
+        self.ManaStorm.protect_from_running()
+        
+    def add_trigger(self, trigger_skill):
+        trigger_skill.onAfter(self.UseManaStorm)
 
     def get_skill(self):
         return self.MagicCircuitFullDriveBuff, self.ManaStorm

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1244,7 +1244,7 @@ class StackSkillWrapper(BuffSkillWrapper):
         else: return False
 
 class TimeStackSkillWrapper(AbstractSkillWrapper):
-    def __init__(self, skill, max_, modifier = CharacterModifier(), name = None):
+    def __init__(self, skill, max_, name = None):
         super(TimeStackSkillWrapper, self).__init__(skill, name = name)
         self.stack = 0
         self._max = max_
@@ -1301,6 +1301,23 @@ class DamageSkillWrapper(AbstractSkillWrapper):
         
     def get_modifier(self) -> CharacterModifier:
         return self.skill.get_modifier() + self.modifier
+        
+class StackDamageSkillWrapper(DamageSkillWrapper):
+    def __init__(self, skill : DamageSkill, stack_skill: AbstractSkill, fn, modifier = CharacterModifier(), name = None):
+        super(StackDamageSkillWrapper, self).__init__(skill, modifier = modifier, name = name)
+        self.stack_skill = stack_skill
+        self.fn = fn
+        
+    def _use(self, skill_modifier):
+        self.cooltimeLeft = self.skill.cooltime * (1-0.01*skill_modifier.pcooltime_reduce*self.skill.red)
+        if self.cooltimeLeft > 0:
+            self.available = False
+
+        stack = self.fn(self.stack_skill)
+        if stack <= 0:
+            return ResultObject(self.skill.delay, self.get_modifier(), 0, 0, sname = self.skill.name, spec = self.skill.spec)
+
+        return ResultObject(self.skill.delay, self.get_modifier(), self.skill.damage, self.skill.hit * stack, sname = self.skill.name, spec = self.skill.spec)
 
         
 class SummonSkillWrapper(AbstractSkillWrapper):

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1240,8 +1240,7 @@ class StackSkillWrapper(BuffSkillWrapper):
         return TaskHolder(task, name = name)
         
     def judge(self, stack, direction):
-        if (self.stack-stack)*direction>=0:return True
-        else: return False
+        return (self.stack-stack)*direction>=0
 
 class TimeStackSkillWrapper(AbstractSkillWrapper):
     def __init__(self, skill, max_, name = None):
@@ -1303,7 +1302,7 @@ class DamageSkillWrapper(AbstractSkillWrapper):
         return self.skill.get_modifier() + self.modifier
         
 class StackDamageSkillWrapper(DamageSkillWrapper):
-    def __init__(self, skill : DamageSkill, stack_skill: AbstractSkill, fn, modifier = CharacterModifier(), name = None):
+    def __init__(self, skill : DamageSkill, stack_skill: AbstractSkillWrapper, fn, modifier = CharacterModifier(), name = None):
         super(StackDamageSkillWrapper, self).__init__(skill, modifier = modifier, name = name)
         self.stack_skill = stack_skill
         self.fn = fn


### PR DESCRIPTION
## 코어
* 특정 스킬의 스택을 참조해 타수가 변동되는 StackDamageSkillWrapper 도입

## 캐릭터
* 에테르 게이지 구현, 평균으로 적용하던 스킬들 전부 변경
* 오더스 수치 입력 (아직 사용 x)
* 쿨감 적용

## 오더
* 사용시 에테르 게이지 소모, 지속시간 40초 구현

## 크리에이션
* 에테르 게이지를 실시간으로 반영해 타수 변동됨

## 게더링-블로섬
* 블로섬의 딜레이가 공속 영향 안받는것 확인, 420ms로 변경
* 블로섬 1개는 데미지 100% 들어가는것 반영
* 게더링, 블로섬 데미지가 오더 개수를 실시간으로 반영, 80% 히트 가정함
* 게더링-디바이드-블로섬 순서로 사용하도록 함
* 게더링-블로섬 도중 오더 공격하지 않게 함
* 게더링-블로섬 도중 오더 잔여시간이 바뀌지 않게 함

## 테리토리
* 테리토리 막타가 시작이 아닌 끝날때 터지게 함

## 마커
* 마커가 생성/파쇄 각각 공격하는것 반영

## 인피니트
* 인피니트 공격주기, 타수 전분에 맞춤

## 로직 변경
* 크리에이션을 SummonSkill이 아닌 디바이드 이후 조건부로 사용되는 DamageSkill로 변경
* 샤드를 크리에이션과 같이 트리거 스킬에 반응하는 공격으로 변경
* 매직 서킷 풀드라이브의 마력 폭풍을 오라 웨폰과 같은 로직으로 변경

## 딜사이클
* 그레이브 쿨마다 사용하도록 변경
* 스콜 딜사이클에 추가

fix #119 
fix #252 
fix #253 