### PR TITLE
feat: 쿨타임 고정 감소 로직 적용

### DIFF
--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -16,15 +16,16 @@ class ArmorPiercingWrapper(core.BuffSkillWrapper):
     '''
     아머 피어싱 - 적 방어율만큼 최종뎀 추가, 방무+50%. 쿨타임 9초, 공격마다 1초씩 감소, 최소 재발동 대기시간 1초
     '''
-    def __init__(self, combat):
+    def __init__(self, combat, chtr):
         self.piercingModifier = core.CharacterModifier(pdamage_indep = 300 * (1 + combat * 0.05), armor_ignore = 50 * (1 + combat * 0.02))
         self.emptyModifier = core.CharacterModifier()
-        skill = core.BuffSkill("아머 피어싱", 0, 0, 9000)
+        self.skill_modifier = chtr.get_skill_modifier()
+        skill = core.BuffSkill("아머 피어싱", 0, 0, 9000, red=True)
         super(ArmorPiercingWrapper, self).__init__(skill)
 
     def check(self):
         if self.available:
-            self.cooltimeLeft = self.skill.cooltime # TODO: 쿨감 적용 어떻게???
+            self.cooltimeLeft = self.calculate_cooltime(self.skill_modifier)
             self.available = False
             return self.piercingModifier
 
@@ -141,7 +142,7 @@ class JobGenerator(ck.JobGenerator):
         Preparation = core.BuffSkill("프리퍼레이션", 900, 30 * 1000, cooltime = 90 * 1000, att = 50, boss_pdamage = 20).wrap(core.BuffSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
 
-        ArmorPiercing = ArmorPiercingWrapper(combat)
+        ArmorPiercing = ArmorPiercingWrapper(combat, chtr)
     
         #Damage Skills
         AdvancedQuibberAttack = core.DamageSkill("어드밴스드 퀴버", 0, 260, 0.6, modifier=MortalBlow).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/jobclass/heroes.py
+++ b/dpmModule/jobs/jobclass/heroes.py
@@ -29,7 +29,7 @@ class FridWrapper(core.BuffSkillWrapper):
             self.state -= 6        
         self.skill = self.skillList[self.state]
         self.timeLeft = self.skill.remain * (1 + 0.01*skill_modifier.buff_rem * self.skill.rem)
-        self.cooltimeLeft = self.skill.cooltime * (1 - 0.01*skill_modifier.pcooltime_reduce* self.skill.red)
+        self.cooltimeLeft = self.calculate_cooltime(skill_modifier)
         self.onoff = True
         if self.cooltimeLeft > 0:
             self.available = False

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1151,13 +1151,18 @@ class AbstractSkillWrapper(GraphElement):
         pcooltime_reduce = skill_modifier.pcooltime_reduce # 쿨감%
         cooltime_reduce = skill_modifier.cooltime_reduce # 쿨감+ (ms)
         
-        cd = max(cooltime * (1 - 0.01*pcooltime_reduce), 1000) # 쿨감%부터 적용, 최소 1초까지
+        if cooltime * (1 - 0.01*pcooltime_reduce) <= 1000: # 쿨감%부터 적용, 최소 1초까지
+            cd = min(cooltime, 1000)
+        else:
+            cd = cooltime * (1 - 0.01*pcooltime_reduce)
+        
         if cd - cooltime_reduce <= 10000:
             cooltime_cap = min(10000, cd)
             cdr_left = (cooltime_reduce - (cd - cooltime_cap)) / 1000 # 10초 이하에서 쿨감되는 수치 계산
             cdr_applied = cooltime_cap * (1 - cdr_left * 0.05) # 1초당 5%씩 감소
         else:
             cdr_applied = cd - cooltime_reduce
+        
         return max(cdr_applied, min(cd, 5000)) # 5초까지 감소, 단 이미 스킬쿨이 5초 아래였을 경우 그대로 사용
 
 class BuffSkillWrapper(AbstractSkillWrapper):

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1143,6 +1143,23 @@ class AbstractSkillWrapper(GraphElement):
         if (self.timeLeft - time) * direction > 0 : return True
         else: return False
 
+    def calculate_cooltime(self, skill_modifier: SkillModifier):
+        if self.skill.red == False:
+            return self.skill.cooltime
+            
+        cooltime = self.skill.cooltime
+        pcooltime_reduce = skill_modifier.pcooltime_reduce # 쿨감%
+        cooltime_reduce = skill_modifier.cooltime_reduce # 쿨감+ (ms)
+        
+        cd = max(cooltime * (1 - 0.01*pcooltime_reduce), 1000) # 쿨감%부터 적용, 최소 1초까지
+        if cd - cooltime_reduce <= 10000:
+            cooltime_cap = min(10000, cd)
+            cdr_left = (cooltime_reduce - (cd - cooltime_cap)) / 1000 # 10초 이하에서 쿨감되는 수치 계산
+            cdr_applied = cooltime_cap * (1 - cdr_left * 0.05) # 1초당 5%씩 감소
+        else:
+            cdr_applied = cd - cooltime_reduce
+        return max(cdr_applied, min(cd, 5000)) # 5초까지 감소, 단 이미 스킬쿨이 5초 아래였을 경우 그대로 사용
+
 class BuffSkillWrapper(AbstractSkillWrapper):
     def __init__(self, skill : BuffSkill, name = None):
         self._disabledResultobjectCache = ResultObject(0, CharacterModifier(), 0, 0, sname = skill.name, spec = 'graph control')
@@ -1185,7 +1202,7 @@ class BuffSkillWrapper(AbstractSkillWrapper):
     
     def _use(self, skill_modifier) -> ResultObject:
         self.timeLeft = self.skill.remain * (1 + 0.01*skill_modifier.buff_rem * self.skill.rem)
-        self.cooltimeLeft = self.skill.cooltime * (1 - 0.01*skill_modifier.pcooltime_reduce* self.skill.red)
+        self.cooltimeLeft = self.calculate_cooltime(skill_modifier)
         self.onoff = True
         if self.cooltimeLeft > 0:
             self.available = False
@@ -1292,7 +1309,7 @@ class DamageSkillWrapper(AbstractSkillWrapper):
             self.available = True
         
     def _use(self, skill_modifier):
-        self.cooltimeLeft = self.skill.cooltime * (1-0.01*skill_modifier.pcooltime_reduce*self.skill.red)
+        self.cooltimeLeft = self.calculate_cooltime(skill_modifier)
         if self.cooltimeLeft > 0:
             self.available = False
         return ResultObject(self.skill.delay, self.get_modifier(), self.skill.damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
@@ -1308,7 +1325,7 @@ class StackDamageSkillWrapper(DamageSkillWrapper):
         self.fn = fn
         
     def _use(self, skill_modifier):
-        self.cooltimeLeft = self.skill.cooltime * (1-0.01*skill_modifier.pcooltime_reduce*self.skill.red)
+        self.cooltimeLeft = self.calculate_cooltime(skill_modifier)
         if self.cooltimeLeft > 0:
             self.available = False
 
@@ -1365,7 +1382,7 @@ class SummonSkillWrapper(AbstractSkillWrapper):
         self.tick = 0
         self.onoff = True
         self.timeLeft = self.skill.remain * (1+0.01*skill_modifier.summon_rem*self.skill.rem)
-        self.cooltimeLeft = self.skill.cooltime * (1-0.01*skill_modifier.pcooltime_reduce*self.skill.red)
+        self.cooltimeLeft = self.calculate_cooltime(skill_modifier)
         if self.cooltimeLeft > 0:
             self.available = False
         return ResultObject(self.skill.summondelay, self.disabledModifier, 0, 0, sname = self.skill.name, spec = self.skill.spec)


### PR DESCRIPTION
* AbstractSkillWrapper에 calculate_cooltime 추가해서 사용
* 여러 엣지 케이스 (5초, 10초, 12초 등)에 대해 테스트 완료
* 보우마스터의 아머 피어싱에 쿨감 적용