### PR TITLE
feat: 로그 과정 개선

### DIFF
--- a/dpmModule/jobs/bishop.py
+++ b/dpmModule/jobs/bishop.py
@@ -28,7 +28,7 @@ class SacredMarkWrapper(core.BuffSkillWrapper):
     def getFlow(self, diff, bonus = 0):
         def retftn():
             self.flow(diff, bonus)
-            return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = 'Sacred Mark', spec = 'frost effect control')
+            return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = 'Sacred Mark', spec = 'graph control')
         return core.Task(self, retftn)
         
     def getFlowHandler(self, diff, bonus):

--- a/dpmModule/jobs/blaster.py
+++ b/dpmModule/jobs/blaster.py
@@ -31,7 +31,7 @@ class RevolvingCannonMasteryWrapper(core.DamageSkillWrapper):
         if stack <= 0:
             return self._result_object_cache
         
-        return core.ResultObject(0, self.get_modifier(), self.skill.damage * multiplier, self.skill.hit, sname = self._id, spec = 'deal')
+        return core.ResultObject(0, self.get_modifier(), self.skill.damage * multiplier, self.skill.hit, sname = self._id, spec = 'damage')
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -23,7 +23,7 @@ class SoulTrapStackWrapper(core.StackSkillWrapper):
         # 디버프 추가, 최대 _max(10)개로 유지
         self.debuffQueue = ([self.currentTime] + self.debuffQueue)[:self._max]
         self.stack = len(self.debuffQueue)
-        return core.ResultObject(0, core.CharacterModifier(), 0, 0, '귀문진 디버프 변경')
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, '귀문진 디버프 변경', spec = 'graph control')
 
     def add_debuff(self):
         return core.TaskHolder(core.Task(self, self._add_debuff), name="귀문진 디버프 추가")

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -45,7 +45,7 @@ class LuminousStateController(core.BuffSkillWrapper):
             self.remain = 17 * (1 + 0.01* self.buff_rem) * 1000  #오더스?
             self.equalCallback()
             
-        return core.ResultObject(0, core.CharacterModifier(), 0, 0, '루미너스 스택 변경')     
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, '루미너스 스택 변경', spec = 'graph control')     
     
     def memorize(self):
         if self.state != LuminousStateController.EQUAL:

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -21,7 +21,7 @@ class MesoStack(core.DamageSkillWrapper, core.StackSkillWrapper):
         stack = self.stack
         self.stack = 0
         # 확인 필요
-        return core.ResultObject(0, mdf.copy(),  dmg, 2 * stack, sname = self._id, spec = 'deal')
+        return core.ResultObject(0, mdf.copy(),  dmg, 2 * stack, sname = self._id, spec = 'damage')
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -90,7 +90,7 @@ class JobGenerator(ck.JobGenerator):
 
         #Buff skills
         Booster = core.BuffSkill("부스터", 0, 200*1000, rem = True).wrap(core.BuffSkillWrapper)
-        FlipTheCoin = core.BuffSkill("플립 더 코인", 0, 24000, pdamage = 5*5, crit = 10*5).wrap(core.BuffSkillWrapper)
+        FlipTheCoin = core.BuffSkill("플립 더 코인", 0, 120*1000, pdamage = 5*5, crit = 10*5).wrap(core.BuffSkillWrapper)
         ShadowerInstinct = core.BuffSkill("섀도어 인스팅트", 900, 200*1000, rem = True, att = 40+30).wrap(core.BuffSkillWrapper)
         #StealPotion = core.BuffSkill("스틸 (포션)", 0, 180000, cooltime = -1, att = 30).wrap(core.BuffSkillWrapper)
         

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -25,7 +25,7 @@ class JaguerStack(core.DamageSkillWrapper, core.TimeStackSkillWrapper):
     def _use(self, skill_modifier):
         mdf = self.get_modifier()
         dmg = 60*self.getStack() + int(self.level/3)
-        return core.ResultObject(0, mdf, dmg, 1, sname = self._id, spec = 'deal')
+        return core.ResultObject(0, mdf, dmg, 1, sname = self._id, spec = 'damage')
 
     def is_usable(self):
         return False

--- a/dpmModule/util/dpmgenerator.py
+++ b/dpmModule/util/dpmgenerator.py
@@ -26,7 +26,7 @@ class IndividualDPMGenerator():
     def set_runtime(self, time):
         self.runtime = time
 
-    def get_dpm(self, ulevel = 6000, level=None, weaponstat = [4,9], printFlag = False, restricted = True, default_modifier=core.CharacterModifier()):
+    def get_dpm(self, ulevel = 6000, level=None, weaponstat = [4,9], printFlag = False, statistics = False, restricted = True, default_modifier=core.CharacterModifier()):
         #TODO target을 동적으로 생성할 수 있도록.
         target = self.template(maplejobs.weaponList[self.job])
         if level is not None:
@@ -47,7 +47,8 @@ class IndividualDPMGenerator():
         control = core.Simulator(sche, target, analytics) #시뮬레이터에 스케줄러, 캐릭터, 애널리틱을 연결하고 생성합니다.
         control.set_default_modifier(default_modifier)
         control.start_simulation(self.runtime)
-        control.analytics.statistics()
+        if statistics:
+            control.analytics.statistics()
         return control.getDPM(restricted=restricted)
 
     def get_detailed_dpm(self, ulevel = 6000, weaponstat = [4,9]):

--- a/test.py
+++ b/test.py
@@ -23,6 +23,7 @@ def get_args():
     parser.add_argument('--ulevel', type=int, default=6000)
     parser.add_argument('--time', type=int, default=1800)
     parser.add_argument('--log', action='store_true')
+    parser.add_argument('--stat', action='store_true')
     parser.add_argument('--task',default='dpm')
 
     return parser.parse_args()
@@ -54,7 +55,8 @@ def dpm(args):
             dpm = parser.get_dpm(ulevel = args.ulevel,
             level = args.level,
             weaponstat = weaponstat,
-            printFlag=args.log)
+            printFlag=args.log,
+            statistics=args.stat or args.log)
         except:
             raise
         finally:


### PR DESCRIPTION
fix https://github.com/oleneyl/maplestory_dpm_calc/issues/102

* calculation_process 로그에 Spec을 함께 표시
  * 소환 스킬의 Damage가 0일때 summon인지, graph control인지 구분이 필요했음
* 무의미한 Use가 statistics에 포함되지 않게 함
* 스킬의 사용횟수, 타수, 데미지를 모두 표시
* 소환수의 소환 횟수와 공격 횟수 따로 표시
* 버프, 공격, 소환 스킬 순서대로 표시, 각 범주 내에서 이름순 정렬해서 표시
* test.py에 --stat 플래그 추가, 점유율만 보고 싶을때 사용

결과 예시

![image](https://user-images.githubusercontent.com/12782606/91306806-0aedb180-e7e8-11ea-8348-8c2479a6cae8.png)
