### PR TITLE
feat: statistics에 스킬별 통합 점유율 표시

### DIFF
--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1,6 +1,7 @@
 from .graph import EvaluativeGraphElement, DynamicVariableOperation, DynamicVariableInstance, AbstractDynamicVariableInstance
 from .abstract import AbstractScenarioGraph, AbstractVEnhancer, AbstractVBuilder
 from functools import partial
+from collections import defaultdict
 import math
 
 NOTWANTTOEXECUTE = 99999999
@@ -1700,6 +1701,8 @@ class Analytics():
             use = len(skillLog)
             print(f"{name} Used {use}")
 
+        shareDict = defaultdict(int)
+
         print("\n===Damage Skills===")
         damageList = list(filter(lambda log: log["result"].spec == "damage", self.logList))
         names = getSkillNames(damageList)
@@ -1709,6 +1712,7 @@ class Analytics():
             hit = sum(map(lambda log: log["result"].hit, skillLog))
             damage = sum(map(lambda log: log["deal"], skillLog))
             share = damage / self.total_damage * 100
+            shareDict[name.split('(')[0]] += share
             print(f"{name} Used {use}")
             print(f"Hit {hit} Damage {damage}")
             print(f"Share {share:.4f}%")
@@ -1723,9 +1727,15 @@ class Analytics():
             hit = sum(map(lambda log: log["result"].hit, skillLog))
             damage = sum(map(lambda log: log["deal"], skillLog))
             share = damage / self.total_damage * 100
+            shareDict[name.split('(')[0]] += share
             print(f"{name} Summoned {summon}")
             print(f"Used {use} Hit {hit} Damage {damage}")
             print(f"Share {share:.4f}%")
+
+        print("\n===Skill Share===")
+        for name, share in sorted(shareDict.items(), key=lambda x: x[1], reverse = True):
+            if share > 0:
+                print(f"{name}, {share:.4f}%")
 
         #self.log("Percent damage per second is %.2f" % (100*self.total_damage / self.character.get_modifier().get_damage_factor() / self.totalTimeInitial * 1000))
 


### PR DESCRIPTION
여는 괄호 ( 으로 스킬명을 split해서 같은 이름인 경우 합쳐지게 하고, 점유율 순으로 정렬합니다.

스킬명을 작성할 때 점유율이 합쳐져서 나오게 하고 싶은 경우 괄호 앞의 스킬 이름이 똑같아야 합니다.

ex)
암살 1타, 암살 2타 (x)
암살(1타), 암살(2타) (o)

블레이드 토네이도, 블레이드토네이도(소환) (x)
블레이드 토네이도, 블레이드 토네이도(소환) (o)

이 점에 유의해야 합니다.