### PR TITLE
fix: 비숍 스킬

### DIFF
--- a/dpmModule/jobs/archmageFb.py
+++ b/dpmModule/jobs/archmageFb.py
@@ -111,7 +111,7 @@ class JobGenerator(ck.JobGenerator):
         PoisonNovaDOT = core.DotSkill("도트(포이즌 노바)", 300+12*vEhc.getV(2,1), 20000).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         
         
-        Infinity = adventurer.InfinityWrapper()
+        Infinity = adventurer.InfinityWrapper(combat)
         
         Paralyze.onAfters([MeteorPassive, Ignite, ParalyzeDOT.controller(1)])
         TeleportMastery.onAfter(TeleportMasteryDOT.controller(1))

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -126,7 +126,7 @@ class JobGenerator(ck.JobGenerator):
         BlizzardPassive = core.DamageSkill("블리자드 패시브", 0, (220+4*combat) * (0.6+0.01*combat), 1).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
         
         #special skills
-        Infinity = adventurer.InfinityWrapper()
+        Infinity = adventurer.InfinityWrapper(combat)
         FrostEffect = core.BuffSkill("프로스트 이펙트", 0, 999999 * 1000).wrap(FrostEffectWrapper)
         
         ######   Skill Wrapper   ######

--- a/dpmModule/jobs/bishop.py
+++ b/dpmModule/jobs/bishop.py
@@ -98,7 +98,7 @@ class JobGenerator(ck.JobGenerator):
 
         PeaceMakerInit = core.DamageSkill("피스메이커(시전)", 750, 0, 0, cooltime = 10 * 1000, red = True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         PeaceMaker = core.DamageSkill("피스메이커", 0, 350 + 14*vEhc.getV(0,0), 4, cooltime = -1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
-        PeaceMakerFinal = core.DamageSkill("피스메이커(폭발)", 0, 500 + 20*vEhc.getV(0,0), 8).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        PeaceMakerFinal = core.DamageSkill("피스메이커(폭발)", 0, 500 + 20*vEhc.getV(0,0), 8, cooltime = -1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         PeaceMakerFinalBuff = core.BuffSkill("피스메이커(버프)", 0, (8 + SERVERLAG)*1000, pdamage = (5 + vEhc.getV(0,0) // 5) + (12 - PEACEMAKER_HIT), cooltime = -1).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
     
         #Summoning skill

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -9,11 +9,12 @@ from ...character import characterKernel as ck
 # 3% 증가로 알고있는데... 확인필요
 
 class InfinityWrapper(core.BuffSkillWrapper):
-    def __init__(self, serverlag = 3):
-        skill = core.BuffSkill("인피니티", 600, 40000, cooltime = 180 * 1000, rem = True, red = True)
+    def __init__(self, combat, serverlag = 3):
+        skill = core.BuffSkill("인피니티", 600, (40+combat)*1000, cooltime = 180 * 1000, rem = True, red = True)
         super(InfinityWrapper, self).__init__(skill)
         self.passedTime = 0
         self.serverlag = serverlag
+        self.combat = combat
         
     def spend_time(self, time):
         if self.onoff:
@@ -22,7 +23,7 @@ class InfinityWrapper(core.BuffSkillWrapper):
             
     def get_modifier(self):
         if self.onoff:
-            return core.CharacterModifier(pdamage_indep = (70 + 3 * (self.passedTime // ((4+self.serverlag)*1000))) )
+            return core.CharacterModifier(pdamage_indep = (70 + self.combat + 3 * (self.passedTime // ((4+self.serverlag)*1000))) )
         else:
             return core.CharacterModifier()
         
@@ -48,10 +49,3 @@ def BlitzShieldWrappers(vEhc, num1, num2):
 def EvolveWrapper(vEhc, num1, num2):
     Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(num1, num2)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(num1, num2)))*1000).isV(vEhc,num1, num2).wrap(core.SummonSkillWrapper)
     return Evolve
-
-'''
-얼티밋 다크 사이트
-MP 850 소비, 30초 동안 다크 사이트 중 공격 및 스킬 사용 시 은신이 해제되지 않음
-다크 사이트 중 공격 시 최종 데미지 15%[기본 10%에서 5레벨마다 1% 증가한다.] 증가, 어드밴스드 다크 사이트의 최종 데미지 증가와 합적용
-재사용 대기시간 195초[(220-스킬 레벨)초]
-'''

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -12,6 +12,7 @@ class JaguerStack(core.DamageSkillWrapper, core.TimeStackSkillWrapper):
     def __init__(self, level, vEhc):
         self.level = level
         self.modifier = core.CharacterModifier()
+        self._runtime_modifier_list = []
         skill = core.DamageSkill("어나더 바이트", 0, 0, 0, cooltime=-1).setV(vEhc, 1, 2, False)
         super(core.DamageSkillWrapper, self).__init__(skill, 3)
         

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1532,8 +1532,14 @@ class DamageSkillWrapper(AbstractSkillWrapper):
     def __init__(self, skill : DamageSkill, modifier = CharacterModifier(), name = None):
         super(DamageSkillWrapper, self).__init__(skill, name = name)
         self.modifier = modifier
-        self.runtime_modifier_list = []
+        self._runtime_modifier_list = []
         self.accessible_boss_state = AccessibleBossState.NO_FLAG
+    
+    def get_link(self):
+        li = super(DamageSkillWrapper, self).get_link()
+        for sk, _ in self._runtime_modifier_list:
+            li.append([self, sk, "modifier"])
+        return li
 
     def set_disabled_and_time_left(self, time):
         self.cooltimeLeft = time
@@ -1555,12 +1561,12 @@ class DamageSkillWrapper(AbstractSkillWrapper):
         
     def get_modifier(self) -> CharacterModifier:
         modifier = self.skill.get_modifier() + self.modifier
-        for skill, fn in self.runtime_modifier_list:
+        for skill, fn in self._runtime_modifier_list:
             modifier += fn(skill)
         return modifier
 
     def add_runtime_modifier(self, skill: AbstractSkillWrapper, fn):
-        self.runtime_modifier_list.append((skill, fn))
+        self._runtime_modifier_list.append((skill, fn))
         
 class StackDamageSkillWrapper(DamageSkillWrapper):
     def __init__(self, skill : DamageSkill, stack_skill: AbstractSkillWrapper, fn, modifier = CharacterModifier(), name = None):
@@ -1586,6 +1592,7 @@ class SummonSkillWrapper(AbstractSkillWrapper):
         self.tick = 0
         self.onoff = False
         self.modifier = modifier
+        self._runtime_modifier_list = []
         self.disabledModifier = CharacterModifier()
         self._onTick = []
         self.accessible_boss_state = AccessibleBossState.NO_FLAG
@@ -1595,6 +1602,8 @@ class SummonSkillWrapper(AbstractSkillWrapper):
         li = super(SummonSkillWrapper, self).get_link()
         for el in self._onTick:
             li.append([self, el, "tick"])
+        for sk, _ in self._runtime_modifier_list:
+            li.append([self, sk, "modifier"])
         return li
         
     def set_disabled_and_time_left(self, time):
@@ -1648,10 +1657,15 @@ class SummonSkillWrapper(AbstractSkillWrapper):
         
     def onTicks(self, tasklist):
         self._onTick += tasklist
+
+    def add_runtime_modifier(self, skill: AbstractSkillWrapper, fn):
+        self._runtime_modifier_list.append((skill, fn))
     
     def get_modifier(self):
-        retMdf = self.skill.get_modifier() + self.modifier
-        return retMdf
+        modifier = self.skill.get_modifier() + self.modifier
+        for skill, fn in self._runtime_modifier_list:
+            modifier += fn(skill)
+        return modifier
             
 class Simulator(object):
     __slots__ = 'scheduler', 'character', 'analytics', '_modifier_cache_and_time', '_default_modifier'

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1532,6 +1532,7 @@ class DamageSkillWrapper(AbstractSkillWrapper):
     def __init__(self, skill : DamageSkill, modifier = CharacterModifier(), name = None):
         super(DamageSkillWrapper, self).__init__(skill, name = name)
         self.modifier = modifier
+        self.runtime_modifier_list = []
         self.accessible_boss_state = AccessibleBossState.NO_FLAG
 
     def set_disabled_and_time_left(self, time):
@@ -1553,7 +1554,13 @@ class DamageSkillWrapper(AbstractSkillWrapper):
         #return delay, mdf, dmg, self.cascade
         
     def get_modifier(self) -> CharacterModifier:
-        return self.skill.get_modifier() + self.modifier
+        modifier = self.skill.get_modifier() + self.modifier
+        for skill, fn in self.runtime_modifier_list:
+            modifier += fn(skill)
+        return modifier
+
+    def add_runtime_modifier(self, skill: AbstractSkillWrapper, fn):
+        self.runtime_modifier_list.append((skill, fn))
         
 class StackDamageSkillWrapper(DamageSkillWrapper):
     def __init__(self, skill : DamageSkill, stack_skill: AbstractSkillWrapper, fn, modifier = CharacterModifier(), name = None):


### PR DESCRIPTION
* 프레이가 사용 시점의 주스탯을 따라 최종뎀이 적용되게 함
  * 고정 스탯이 계산에 빠져있던 버그 함께 해결함
* 전 스킬 컴뱃/패시브 레벨 수치 입력
  * 인피니티에 컴뱃 적용, 모험가 법사도 일부 변경
* 벤전스 엔젤레이 방깎 적용
* 피스메이커 3히트 기준으로 변경
* 헤븐즈도어 딜레이 수정, 딜사이클에 추가
* 엔젤 오브 리브라 공격주기 수정
* 소환수 표식 매커니즘 변경
  * DamageSkillWrapper에 다른 스킬의 상태를 참조해 modifier가 변경되는 기능 추가
  * SacredMark 수치에 따라 최종뎀 적용되게 함
* 어드밴스드 블레스 빠진것 추가