### PR TITLE
fix: 유니온 점령 로직

### DIFF
--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -59,7 +59,6 @@ class OrderWrapper(core.SummonSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 10
         self.jobtype = "str"
         self.jobname = "아델"

--- a/dpmModule/jobs/aran.py
+++ b/dpmModule/jobs/aran.py
@@ -21,7 +21,6 @@ from ..execution.rules import RuleSet, InactiveRule, ConditionRule
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
         self.jobtype = "str"
         self.jobname = "아란"
         self.vEnhanceNum = 13

--- a/dpmModule/jobs/archmageFb.py
+++ b/dpmModule/jobs/archmageFb.py
@@ -14,7 +14,7 @@ from .jobbranch import magicians
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
+        self.buffrem = (0, 40)
         self.jobtype = "int"
         self.jobname = "아크메이지불/독"
         self.vEnhanceNum = 13

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -23,7 +23,7 @@ class FrostEffectWrapper(core.StackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
+        self.buffrem = (0, 40)
         self.jobtype = "int"
         self.jobname = "아크메이지썬/콜"
         self.ability_list = Ability_tool.get_ability_set('buff_rem', 'crit', 'boss_pdamage')

--- a/dpmModule/jobs/battlemage.py
+++ b/dpmModule/jobs/battlemage.py
@@ -16,7 +16,6 @@ from .jobbranch import magicians
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "int"
         self.jobname = "배틀메이지"
         self.vEnhanceNum = 10

--- a/dpmModule/jobs/bishop.py
+++ b/dpmModule/jobs/bishop.py
@@ -48,7 +48,7 @@ class SacredMarkWrapper(core.BuffSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
+        self.buffrem = (0, 40)
         self.jobtype = "int"
         self.jobname = "비숍"
         self.vEnhanceNum = 8

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -83,7 +83,6 @@ class GuidedArrowWrapper(bowmen.GuidedArrowWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "dex"
         self.jobname = "보우마스터"
         self.vEnhanceNum = 11

--- a/dpmModule/jobs/cadena.py
+++ b/dpmModule/jobs/cadena.py
@@ -53,7 +53,6 @@ class WeaponVarietyStackWrapper(core.StackSkillWrapper): # TODO: 굳이 관리�
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 11
         self.jobtype = "luk"
         self.jobname = "카데나"

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -11,7 +11,6 @@ from . import jobutils
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "str"
         self.jobname = "캐논슈터"
         self.vEnhanceNum = 16

--- a/dpmModule/jobs/captain.py
+++ b/dpmModule/jobs/captain.py
@@ -11,7 +11,6 @@ from . import jobutils
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "dex"
         self.jobname = "캡틴"
         self.vEnhanceNum = 14

--- a/dpmModule/jobs/darknight.py
+++ b/dpmModule/jobs/darknight.py
@@ -11,7 +11,7 @@ from .jobbranch import warriors
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
+        self.buffrem = (7, 7)
         self.jobtype = "str"
         self.jobname = "다크나이트"
         self.vEnhanceNum = 9

--- a/dpmModule/jobs/demonavenger.py
+++ b/dpmModule/jobs/demonavenger.py
@@ -14,7 +14,6 @@ from .jobclass import demon
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "str"
         self.jobname = "데몬어벤져"
         self.vEnhanceNum = 12

--- a/dpmModule/jobs/demonslayer.py
+++ b/dpmModule/jobs/demonslayer.py
@@ -11,7 +11,6 @@ from . import jobutils
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "str"
         self.jobname = "데몬슬레이어"
         self.vEnhanceNum = 15

--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -14,7 +14,6 @@ from . import jobutils
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "luk"
         self.jobname = "듀얼블레이드"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -42,7 +42,6 @@ class SoulTrapStackWrapper(core.StackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "str"
         self.jobname = "은월"
         self.vEnhanceNum = 15

--- a/dpmModule/jobs/flamewizard.py
+++ b/dpmModule/jobs/flamewizard.py
@@ -11,7 +11,6 @@ from .jobbranch import magicians
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "int"
         self.jobname = "플레임위자드"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')

--- a/dpmModule/jobs/hero.py
+++ b/dpmModule/jobs/hero.py
@@ -58,7 +58,6 @@ class ComboAttackWrapper(core.StackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "str"
         self.jobname = "히어로"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'mess')

--- a/dpmModule/jobs/hoyoung.py
+++ b/dpmModule/jobs/hoyoung.py
@@ -19,7 +19,6 @@ def AnimaGoddessBlessWrapper(vEhc, num1, num2):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "luk"
         self.jobname = "호영"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'buff_rem', 'mess')

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -45,7 +45,6 @@ class KinesisStackWrapper(core.StackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
         self.vEnhanceNum = 13
         self.jobtype = "int"
         self.jobname = "키네시스"

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -112,7 +112,7 @@ class LightAndDarknessWrapper(core.DamageSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
+        self.buffrem = (0, 40)
         self.vEnhanceNum = 13
         self.jobtype = "int"
         self.jobname = "루미너스"

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -47,7 +47,6 @@ class MultipleOptionWrapper(core.SummonSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 14
         self.jobtype = "dex"
         self.jobname = "메카닉"

--- a/dpmModule/jobs/mercedes.py
+++ b/dpmModule/jobs/mercedes.py
@@ -36,7 +36,6 @@ class ElementalGhostWrapper(core.BuffSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 11
         self.jobtype = "dex"
         self.jobname = "메르세데스"

--- a/dpmModule/jobs/michael.py
+++ b/dpmModule/jobs/michael.py
@@ -13,7 +13,6 @@ from .jobbranch import warriors
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 9
         self.jobtype = "str"
         self.jobname = "미하일"

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -16,7 +16,6 @@ from .jobbranch import warriors
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 10
         self.jobtype = "str"
         self.jobname = "팔라딘"

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -65,7 +65,6 @@ class RelicChargeStack(core.StackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.jobtype = "dex"
         self.jobname = "패스파인더"
         self.vEnhanceNum = 11

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -15,7 +15,7 @@ from .jobbranch import thieves
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
+        self.buffrem = (12, 12)
         self.vEnhanceNum = 14
         self.jobtype = "luk"
         self.jobname = "팬텀"

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -26,7 +26,6 @@ class MesoStack(core.DamageSkillWrapper, core.StackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 10
         self.jobtype = "luk"
         self.jobname = "섀도어"

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -12,7 +12,6 @@ from .jobbranch import bowmen
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 10
         self.jobtype = "dex"
         self.jobname = "신궁"

--- a/dpmModule/jobs/soulmaster.py
+++ b/dpmModule/jobs/soulmaster.py
@@ -11,7 +11,6 @@ from .jobbranch import warriors
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 10
         self.jobtype = "str"
         self.jobname = "소울마스터"

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -26,7 +26,6 @@ class LightningWrapper(core.StackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
         self.vEnhanceNum = 10
         self.jobtype = "str"
         self.jobname = "스트라이커"

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -46,7 +46,6 @@ class EnergyChargeWrapper(core.StackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 10
         self.jobtype = "str"
         self.jobname = "바이퍼"

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -36,7 +36,6 @@ class JaguerStack(core.DamageSkillWrapper, core.TimeStackSkillWrapper):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 11
         self.jobtype = "dex"
         self.jobname = "와일드헌터"

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -11,7 +11,6 @@ from .jobclass import cygnus
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = False
         self.vEnhanceNum = 10
         self.jobtype = "dex"
         self.jobname = "윈드브레이커"

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -55,7 +55,6 @@ def beta_enrage(target, vlevel):
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
-        self.buffrem = True
         self.vSkillNum = 5
         self.vEnhanceNum = 13
         self.jobtype = "str"

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -333,7 +333,7 @@ class ExtendedCharacterModifier(CharacterModifier):
 
     def log(self):
         txt = super(ExtendedCharacterModifier, self).log()
-        txt + "buff_rem : %.1f, summon_rem : %.1f\n" % (self.buff_rem, self.summon_rem)
+        txt += "buff_rem : %.1f, summon_rem : %.1f\n" % (self.buff_rem, self.summon_rem)
         txt += "cooltime_reduce : %.1f pcooltime_reduce : %.1f\n" % (self.cooltime_reduce, self.pcooltime_reduce)
         txt += "reuse_chance : %.1f prop_ignore : %.1f\n" % (self.reuse_chance, self.prop_ignore)
         txt += "additional_target : %d passive_level : %d\n" % (self.additional_target, self.passive_level)


### PR DESCRIPTION
* 200레벨 캐릭터 개수 연산 방식을 변경
* 기본적으로 배치된 칸만큼 슬롯 빼는 과정 추가
* 버프 지속시간을 bool이 아닌 (min, max) 형태로 표현, 최소 min 칸을 채우고 여유가 남으면 max까지 채우도록 함
* ExMDF에 누락된 로그 추가
* 버프 지속시간을 사용하지 않음에도 사용으로 표시된 직업들 수정