### PR TITLE
fix: 아이템

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -86,7 +86,7 @@ class AbstractCharacter():
             item = item_dict[key]
             if item == None:
                 raise TypeError(key + " item is missing")
-            self.itemlist[key] = item_dict[key]            
+            self.itemlist[key] = item_dict[key]
             self.add_item_modifier(item_dict[key])
 
 
@@ -324,53 +324,56 @@ class ItemedCharacter(AbstractCharacter):
         super(ItemedCharacter, self).__init__(level)
         
         #6 items for armor
-        self.itemlist["head"] = Item()
-        self.itemlist["glove"] = Item()
-        self.itemlist["top"] = Item()
-        self.itemlist["bottom"] =Item()
-        self.itemlist["shoes"] = Item()
-        self.itemlist["cloak"] = Item()
+        self.itemlist["head"] = None
+        self.itemlist["glove"] = None
+        self.itemlist["top"] = None
+        self.itemlist["bottom"] =None
+        self.itemlist["shoes"] = None
+        self.itemlist["cloak"] = None
 
         #13 items for accessory
         
-        self.itemlist["eye"] = Item()
-        self.itemlist["face"] = Item()
-        self.itemlist["ear"] = Item()
-        self.itemlist["belt"] = Item()
-        self.itemlist["ring1"] = Item()
-        self.itemlist["ring2"] = Item()
-        self.itemlist["ring3"] = Item()
-        self.itemlist["ring4"] = Item()
-        self.itemlist["shoulder"] = Item()
-        self.itemlist["pendant1"] = Item()
-        self.itemlist["pendant2"] = Item()
-        self.itemlist["pocket"] = Item()
-        self.itemlist["badge"] = Item()
+        self.itemlist["eye"] = None
+        self.itemlist["face"] = None
+        self.itemlist["ear"] = None
+        self.itemlist["belt"] = None
+        self.itemlist["ring1"] = None
+        self.itemlist["ring2"] = None
+        self.itemlist["ring3"] = None
+        self.itemlist["ring4"] = None
+        self.itemlist["shoulder"] = None
+        self.itemlist["pendant1"] = None
+        self.itemlist["pendant2"] = None
+        self.itemlist["pocket"] = None
+        self.itemlist["badge"] = None
         
         # 3 items for weapon
         
-        self.itemlist["weapon"] = Item()
-        self.itemlist["subweapon"] = Item()
-        self.itemlist["emblem"] = Item()
+        self.itemlist["weapon"] = None
+        self.itemlist["subweapon"] = None
+        self.itemlist["emblem"] = None
         
         #2 items for else
         
-        self.itemlist["medal"] = Item()
-        self.itemlist["heart"] = Item()
-        self.itemlist["title"] = Item()
-        self.itemlist["pet"] = Item()
+        self.itemlist["medal"] = None
+        self.itemlist["heart"] = None
+        self.itemlist["title"] = None
+        self.itemlist["pet"] = None
         
     def set_weapon_potential(self, li):
         if len(li) > 9: 
             raise TypeError("무기 잠재능력은 최대 9개입니다.")
-        itemOrder = ["weapon", "subweapon", "emblem"]    
+        itemOrder = ["weapon", "subweapon", "emblem"]
         
         for i in range(3):
             ptnl = ExMDF()
             for j in range((len(li) - i - 1) // 3):
                 ptnl  = ptnl + li[i+j*3]
-                
-            self.itemlist[itemOrder[i]].set_potential(ptnl)
+
+            item = self.itemlist[itemOrder[i]]
+            self.remove_item_modifier(item)
+            item.set_potential(ptnl)
+            self.add_item_modifier(item)
 
     def print_items(self):
         for item in self.itemlist:

--- a/dpmModule/item/Absolab.py
+++ b/dpmModule/item/Absolab.py
@@ -1,10 +1,11 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
-Head = it.Item(name="앱솔랩스 모자", stat_main = 45, stat_sub = 45, att = 3, armor_ignore = 10, level = 160)
-Glove = it.Item(name="앱솔랩스 장갑", stat_main = 20, stat_sub = 20, att = 5, level = 160)
-Shoes = it.Item(name="앱솔랩스 신발", stat_main = 20, stat_sub = 20, att = 5, level = 160)
-Cloak = it.Item(name="앱솔랩스 망토", stat_main = 15, stat_sub = 15, att = 2, level = 160)
-Shoulder = it.Item(name="앱솔랩스 견장", stat_main = 14, stat_sub = 14, att = 10, level = 160)
+Head = it.Item(name="앱솔랩스 모자", level = 160, main_option = ExMDF(stat_main = 45, stat_sub = 45, att = 3, armor_ignore = 10))
+Glove = it.Item(name="앱솔랩스 장갑", level = 160, main_option = ExMDF(stat_main = 20, stat_sub = 20, att = 5))
+Shoes = it.Item(name="앱솔랩스 신발", level = 160, main_option = ExMDF(stat_main = 20, stat_sub = 20, att = 5))
+Cloak = it.Item(name="앱솔랩스 망토", level = 160, main_option = ExMDF(stat_main = 15, stat_sub = 15, att = 2))
+Shoulder = it.Item(name="앱솔랩스 견장", level = 160, main_option = ExMDF(stat_main = 14, stat_sub = 14, att = 10))
 
 # 업횟 11+1
 # 일반적인 템셋에서 카벨 모자를 사용할 직업은 제로뿐이므로 앱솔/아케인 무기 착용으로 가정
@@ -23,7 +24,7 @@ _valueMap = [[103, [0,16,23,32,42,53]],
                 [97,[0,13,18,25,33,42]],
                 [203,[0,11,23,38,56,76]]]#Need blade & Zero weapon
 
-WeaponFactory = it.WeaponFactoryClass(160, _valueMap, modifier = it.ExMDF(stat_main = 60, stat_sub = 60, pdamage = 30, armor_ignore = 10))
+WeaponFactory = it.WeaponFactoryClass(160, _valueMap, modifier = it.ExMDF(stat_main = 60, stat_sub = 60, boss_pdamage = 30, armor_ignore = 10))
 
 
 class Factory():

--- a/dpmModule/item/Arcane.py
+++ b/dpmModule/item/Arcane.py
@@ -1,10 +1,11 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
-Head = it.Item(name="아케인셰이드 모자", stat_main = 65, stat_sub = 65, att = 7, armor_ignore = 15, level = 200)
-Glove = it.Item(name="아케인셰이드 장갑", stat_main = 40, stat_sub = 40, att = 9, level = 200)
-Shoes = it.Item(name="아케인셰이드 신발", stat_main = 40, stat_sub = 40, att = 9, level = 200)
-Cloak = it.Item(name="아케인셰이드 망토", stat_main = 35, stat_sub = 35, att = 6, level = 200)
-Shoulder = it.Item(name="아케인셰이드 견장", stat_main = 35, stat_sub = 35, att = 20, level = 200)
+Head = it.Item(name="아케인셰이드 모자", level = 200, main_option=ExMDF(stat_main = 65, stat_sub = 65, att = 7, armor_ignore = 15))
+Glove = it.Item(name="아케인셰이드 장갑", level = 200, main_option = ExMDF(stat_main = 40, stat_sub = 40, att = 9))
+Shoes = it.Item(name="아케인셰이드 신발", level = 200, main_option = ExMDF(stat_main = 40, stat_sub = 40, att = 9))
+Cloak = it.Item(name="아케인셰이드 망토", level = 200, main_option = ExMDF(stat_main = 35, stat_sub = 35, att = 6))
+Shoulder = it.Item(name="아케인셰이드 견장", level = 200, main_option = ExMDF(stat_main = 35, stat_sub = 35, att = 20))
 
 _valueMap = [[149, [0,27,40,55,72,92]],
                 [216,[0,39,58,79,104,133]],
@@ -19,7 +20,7 @@ _valueMap = [[149, [0,27,40,55,72,92]],
                 [140,[0,0,0,0,0,0]],
                 [295,[0,18,40,65,95,131]]]
 
-WeaponFactory = it.WeaponFactoryClass(200, _valueMap, modifier = it.ExMDF(stat_main = 100, stat_sub = 100, pdamage = 30, armor_ignore = 20))
+WeaponFactory = it.WeaponFactoryClass(200, _valueMap, modifier = it.ExMDF(stat_main = 100, stat_sub = 100, boss_pdamage = 30, armor_ignore = 20))
 
 
 class Factory():

--- a/dpmModule/item/BossAccesory.py
+++ b/dpmModule/item/BossAccesory.py
@@ -1,46 +1,47 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
 #No upgrade
 
 #자쿰 얼장(응축된 힘의 결정석)...(5)
-Face110 = it.Item(name="응축된 힘의 결정석", stat_main = 5, stat_sub = 5, att = 5, level = 110)
+Face110 = it.Item(name="응축된 힘의 결정석", level = 110, main_option = ExMDF(stat_main = 5, stat_sub = 5, att = 5))
 #자쿰 눈장....(3)
-Eye100 = it.Item(name="아쿠아틱 레터 눈장식", stat_main = 6, stat_sub = 6, att = 1, level = 100)
+Eye100 = it.Item(name="아쿠아틱 레터 눈장식", level = 100, main_option = ExMDF(stat_main = 6, stat_sub = 6, att = 1))
 #자쿰 벨트....(3)
-Belt150 =  it.Item(name="분노한 자쿰의 벨트", stat_main = 18, stat_sub = 18, att = 1, level = 150)
+Belt150 =  it.Item(name="분노한 자쿰의 벨트", level = 150, main_option = ExMDF(stat_main = 18, stat_sub = 18, att = 1))
 
 #매그너스 숄더..(1)
-Shoulder120 =  it.Item(name="로얄 블랙메탈 숄더", stat_main = 10, stat_sub = 10, att = 6, level = 120)
+Shoulder120 =  it.Item(name="로얄 블랙메탈 숄더", level = 120, main_option = ExMDF(stat_main = 10, stat_sub = 10, att = 6))
 #매그너스 뱃지..(0)
-Badge130 =  it.Item(name="크리스탈 웬투스 뱃지", stat_main = 10, stat_sub = 10, att = 5, level = 130)
+Badge130 =  it.Item(name="크리스탈 웬투스 뱃지", level = 130, main_option = ExMDF(stat_main = 10, stat_sub = 10, att = 5))
 
 #힐라 -> 미사용, 무시
 
 #파풀 눈장..(5)
-Eye145 =  it.Item(name="파풀라투스 마크", stat_main = 8, stat_sub = 8, att = 1, level = 140) # 145제는 140제와 같은 강화 테이블 사용
+Eye145 =  it.Item(name="파풀라투스 마크", level = 140, main_option = ExMDF(stat_main = 8, stat_sub = 8, att = 1)) # 145제는 140제와 같은 강화 테이블 사용
 
 #반레온보장..(2)
-Ring120 =  it.Item(name="고귀한 이피아의 반지", stat_main = 5, stat_sub = 5, att = 2, level = 120)
+Ring120 =  it.Item(name="고귀한 이피아의 반지", level = 120, main_option = ExMDF(stat_main = 5, stat_sub = 5, att = 2))
 
 #혼테일 귀고리...(6)
-Ear130 =  it.Item(name="데아 시두스 이어림", stat_main = 5, stat_sub = 5, att = 2, level = 130)
+Ear130 =  it.Item(name="데아 시두스 이어림", level = 130, main_option = ExMDF(stat_main = 5, stat_sub = 5, att = 2))
 #혼테일 링...(2)
-Ring110 =  it.Item(name="실버블라썸 링", stat_main = 5, stat_sub = 5, att = 2, level = 110)
+Ring110 =  it.Item(name="실버블라썸 링", level = 110, main_option = ExMDF(stat_main = 5, stat_sub = 5, att = 2))
 #혼테일 목걸이..(0) -> 알발린상태로 계산 필요
 
 #아카이럼 매커...(2)
-Pendant120 =  it.Item(name="매커네이터 펜던트", stat_main = 10, stat_sub = 10, att = 1, level = 120)
+Pendant120 =  it.Item(name="매커네이터 펜던트", level = 120, main_option = ExMDF(stat_main = 10, stat_sub = 10, att = 1))
 
 #아카이럼 도미...(6 or 0) 파편작 가정
-Pendant140 =  it.Item(name="도미네이터 펜던트", stat_main = 5, stat_sub = 5, att = 5, level = 140)
-Pendant140Fragment = it.Item(name="도미네이터 펜던트", stat_main = 23, stat_sub = 23, att = 23, level = 140)
+Pendant140 =  it.Item(name="도미네이터 펜던트", level = 140, main_option = ExMDF(stat_main = 5, stat_sub = 5, att = 5))
+Pendant140Fragment = it.Item(name="도미네이터 펜던트", level = 140, main_option = ExMDF(stat_main = 23, stat_sub = 23, att = 23))
 
 #핑크빈 포켓 ... 0
-Pocket140 = it.Item(name="핑크빛 성배", stat_main = 5, stat_sub = 5, att = 5, level = 140)
+Pocket140 = it.Item(name="핑크빛 성배", level = 140, main_option = ExMDF(stat_main = 5, stat_sub = 5, att = 5))
 #핑크빈 벨트 ... 3
-Belt140 =  it.Item(name="골든 클로버 벨트", stat_main = 15, stat_sub = 15, att = 1, level = 140)
+Belt140 =  it.Item(name="골든 클로버 벨트", level = 140, main_option = ExMDF(stat_main = 15, stat_sub = 15, att = 1))
 #핑크빈 얼장 ... 5
-Eye135 = it.Item(name="블랙빈 마크", stat_main = 7, stat_sub = 7, att = 1, level = 130) # 135제는 130제와 같은 강화 테이블 사용
+Eye135 = it.Item(name="블랙빈 마크", level = 130, main_option = ExMDF(stat_main = 7, stat_sub = 7, att = 1)) # 135제는 130제와 같은 강화 테이블 사용
 
 
 

--- a/dpmModule/item/Darkness.py
+++ b/dpmModule/item/Darkness.py
@@ -1,10 +1,11 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
-Face = it.Item(name="루즈 컨트롤 머신 마크", stat_main = 10, stat_sub = 10, att = 10, level = 160)#160 // 5
-Eye = it.Item(name="마력이 깃든 안대", stat_main = 15, stat_sub = 15, att = 3, level = 160)#160 // 3
-Belt = it.Item(name="몽환의 벨트", stat_main = 50, stat_sub = 50, att = 6, level = 200)#200 // 3
-Pendant = it.Item(name="고통의 근원", stat_main = 10, stat_sub = 10, att = 5, level = 160)#160 // 5
-Pocket = it.Item(name="저주받은 #의 마도서", stat_main = 20, stat_sub = 10, att = 10, level = 160)#160
+Face = it.Item(name="루즈 컨트롤 머신 마크", level = 160, main_option = ExMDF(stat_main = 10, stat_sub = 10, att = 10))#160 // 5
+Eye = it.Item(name="마력이 깃든 안대", level = 160, main_option = ExMDF(stat_main = 15, stat_sub = 15, att = 3))#160 // 3
+Belt = it.Item(name="몽환의 벨트", level = 200, main_option = ExMDF(stat_main = 50, stat_sub = 50, att = 6))#200 // 3
+Pendant = it.Item(name="고통의 근원", level = 160, main_option = ExMDF(stat_main = 10, stat_sub = 10, att = 5))#160 // 5
+Pocket = it.Item(name="저주받은 #의 마도서", level = 160, main_option = ExMDF(stat_main = 20, stat_sub = 10, att = 10))#160
 #Heart = it.Item(stat_main = 50, stat_sub = 50, att = 77, boss_pdamage = 30, armor_ignore = 30)
 #Badge = it.Item(stat_main = 15, stat_sub = 15, att = 10)
 #Ring = it.Item(stat_main = 5, stat_sub = 5, att = 4)

--- a/dpmModule/item/Default.py
+++ b/dpmModule/item/Default.py
@@ -1,22 +1,23 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
 #TODO : 이런 프로세스들을 좀 더 factorization 할 수는 없을까..
 
-EventRing = it.Item(name="이벤트 링", stat_main = 30, stat_sub = 30, att = 20, level = 120)
+EventRing = it.Item(name="이벤트 링", level = 120, main_option = ExMDF(stat_main = 30, stat_sub = 30, att = 20))
 def getEventRing(potential = it.ExMDF(), additional_potential = it.ExMDF()):
     item = EventRing.copy()
     item.set_potential(potential)
     item.set_additional_potential(additional_potential)
     return item
 
-Subweapon = it.Item(name="보조무기", stat_main = 10, stat_sub = 10, att = 3, level = 100)
+Subweapon = it.Item(name="보조무기", level = 100, main_option = ExMDF(stat_main = 10, stat_sub = 10, att = 3))
 def getSubweapon(potential = it.ExMDF(), additional_potential = it.ExMDF()):
     item = Subweapon.copy()
     item.set_potential(potential)
     item.set_additional_potential(additional_potential)
     return item
     
-Emblem = it.Item(name="엠블럼", stat_main = 10, stat_sub = 10, att = 2, level = 100)
+Emblem = it.Item(name="엠블럼", level = 100, main_option = ExMDF(stat_main = 10, stat_sub = 10, att = 2))
 def getEmblem(potential = it.ExMDF(), additional_potential = it.ExMDF()):
     item = Emblem.copy()
     item.set_potential(potential)

--- a/dpmModule/item/Else.py
+++ b/dpmModule/item/Else.py
@@ -1,38 +1,39 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
 #TODO: 리퀴드 하트
 
 #칭호들
 
 
-KingOfRootAbyss = it.Item(name="킹 오브 루타비스", att=3, stat_main = 8, stat_sub=8, potential = it.ExMDF(armor_ignore = 5, boss_pdamage = 5))
-PingkbinAndMe = it.Item(name="핑아일체", att = 5, stat_main = 10, stat_sub=10, potential = it.ExMDF( boss_pdamage = 10))
-MaplewellKnown = it.Item(name="메이플을 잘 아는", att = 5, stat_main = 10, stat_sub=10, potential = it.ExMDF( armor_ignore = 10))
+KingOfRootAbyss = it.Item(name="킹 오브 루타비스", level=0, main_option = ExMDF(att=3, stat_main = 8, stat_sub=8), potential = it.ExMDF(armor_ignore = 5, boss_pdamage = 5))
+PingkbinAndMe = it.Item(name="핑아일체", level=0, main_option = ExMDF(att = 5, stat_main = 10, stat_sub=10), potential = it.ExMDF(boss_pdamage = 10))
+MaplewellKnown = it.Item(name="메이플을 잘 아는", level=0, main_option = ExMDF(att = 5, stat_main = 10, stat_sub=10), potential = it.ExMDF(armor_ignore = 10))
 
 
 # 칠요셋
-WeeklyParkBadge = it.Item(name="칠요의 뱃지", stat_main = 7, stat_sub = 7, att = 7, armor_ignore = 19)  #뱃지가 따기 더 힘드므로 세트 옵션을 아예 임베딩
+WeeklyParkBadge = it.Item(name="칠요의 뱃지", level=100, main_option = ExMDF(stat_main = 7, stat_sub = 7, att = 7, armor_ignore = 19))  #뱃지가 따기 더 힘드므로 세트 옵션을 아예 임베딩
 # 뱃지 방무와 세트 효과 방무는 별개이므로 방무 10퍼씩 2번 적용. (19퍼랑 동일)
-WeeklyParkMedal = it.Item(name="칠요의 몬스터파커", stat_main = 7, stat_sub = 7, armor_ignore = 10)
+WeeklyParkMedal = it.Item(name="칠요의 몬스터파커", level=100, main_option = ExMDF(stat_main = 7, stat_sub = 7, armor_ignore = 10))
 
 def get_weekly_set():
     return {"badge" : WeeklyParkBadge.copy(),
                 "medal" : WeeklyParkMedal.copy() }
 
 def get_medal(value):
-    return it.Item(name="훈장", att = value, stat_main = value, stat_sub = value)
+    return it.Item(name="훈장", level=0, main_option = ExMDF(att = value, stat_main = value, stat_sub = value))
 
 def get_pet(att):   
-    return it.Item(name="펫장비", att = att)
+    return it.Item(name="펫장비", level=0, main_option = ExMDF(att = att))
 
 def get_heart(att, ptnl = it.ExMDF(), aptnl = it.ExMDF()):
-    return it.Item(name="하트", att = att, potential = ptnl, additional_potential = aptnl)
+    return it.Item(name="하트", level=100, main_option = ExMDF(att = att), potential = ptnl, additional_potential = aptnl)
 
 def ocean_glow(star, each_enhance = it.ExMDF(), potential = it.ExMDF(),
                         additional_potential = it.ExMDF(),
                         bonus = it.ExMDF()):
     
-    OceanGlowEaring = it.Item(name="오션 글로우 이어링", stat_main = 7, stat_sub = 5, att = 5)
+    OceanGlowEaring = it.Item(name="오션 글로우 이어링", level=150, main_option = ExMDF(stat_main = 7, stat_sub = 5, att = 5))
     OceanGlowEaring.add_main_option(bonus)
     OceanGlowEaring.set_potential(potential)
     OceanGlowEaring.set_additional_potential(additional_potential)

--- a/dpmModule/item/Empress.py
+++ b/dpmModule/item/Empress.py
@@ -1,10 +1,11 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
-Head = it.Item(name="여제 모자", stat_main = 25, stat_sub = 25, att = 1, armor_ignore = 10, level = 140)
-Glove = it.Item(name="여제 장갑", stat_main = 16, stat_sub = 16, att = 5, level = 140)
-Shoes = it.Item(name="여제 신발", stat_main = 15, stat_sub = 15, att = 1, level = 140)
-Cloak = it.Item(name="여제 망토", stat_main = 7, stat_sub = 7, att = 1, level = 140)
-Shoulder = it.Item(name="여제 견장", stat_main = 11, stat_sub = 11, att = 7, level = 140)
+Head = it.Item(name="여제 모자", level = 140, main_option = ExMDF(stat_main = 25, stat_sub = 25, att = 1, armor_ignore = 10))
+Glove = it.Item(name="여제 장갑", level = 140, main_option = ExMDF(stat_main = 16, stat_sub = 16, att = 5))
+Shoes = it.Item(name="여제 신발", level = 140, main_option = ExMDF(stat_main = 15, stat_sub = 15, att = 1))
+Cloak = it.Item(name="여제 망토", level = 140, main_option = ExMDF(stat_main = 7, stat_sub = 7, att = 1))
+Shoulder = it.Item(name="여제 견장", level = 140, main_option = ExMDF(stat_main = 11, stat_sub = 11, att = 7))
 
 _valueMap = [[69, [0,9,13,17,23,29]],
                 [100,[0,12,18,25,32,41]],

--- a/dpmModule/item/ItemKernel.py
+++ b/dpmModule/item/ItemKernel.py
@@ -8,60 +8,30 @@ class Item():
     - parameters
     
       .name : Item's name. Need not be unique.
-      .stat_main : Main stat
-      .stat_sub : Sub stat
-      .att : AD(or MA) valule
-      .patt : Ad(or MA) %
-      .pdamage : Damage increment %
-      .armor_ignore : Armor ignorant %
+      .level : Item's required level.
+      .main_option : Main Option.(ExtendedCharacterModifier)
       
       .potential : Potential Value.(ExtendedCharacterModifier)
       .add_potential : Additional Potential Value. (ExtendedCharacterModifier)
     '''
-    def __init__(self, name = 'DEFAULT', level = 150, stat_main = 0, stat_sub = 0, att = 0, patt = 0, pdamage = 0, armor_ignore = 0, pstat_main = 0, pstat_sub = 0, potential = ExMDF(), additional_potential = ExMDF()):
+    def __init__(self, name, level, main_option: ExMDF, potential = ExMDF(), additional_potential = ExMDF()):
         #Prototypical option
         self.name = name
         #Main options
-        self.stat_main = stat_main
-        self.stat_sub = stat_sub
-        self.att = att
-        self.patt = patt
-        self.pdamage = pdamage
-        self.armor_ignore = armor_ignore
-        
-        self.pstat_main = pstat_main
-        self.pstat_sub = pstat_sub
-        
+        self.main_option = main_option
         self.potential = potential
         self.additional_potential = additional_potential
         
         self.level = level
 
     def get_modifier(self):
-        myModifier = ExMDF(stat_main = self.stat_main, stat_sub = self.stat_sub, att = self.att, patt = self.patt, pdamage = self.pdamage, armor_ignore = self.armor_ignore)
-        return myModifier + self.potential + self.additional_potential
+        return self.main_option + self.potential + self.additional_potential
         
     def add_main_option(self, mf : ExMDF):
-        self.stat_main += mf.stat_main
-        self.stat_sub += mf.stat_sub
-        self.att += mf.att
-        self.patt += mf.patt
-        self.pdamage += mf.pdamage
-        self.armor_ignore += mf.armor_ignore
-        
-        self.pstat_main += mf.pstat_main
-        self.pstat_sub += mf.pstat_sub
+        self.main_option += mf
     
     def set_main_option(self, mf : ExMDF):
-        self.stat_main = mf.stat_main
-        self.stat_sub = mf.stat_sub
-        self.att = mf.att
-        self.patt = mf.patt
-        self.pdamage = mf.pdamage
-        self.armor_ignore = mf.armor_ignore
-        
-        self.pstat_main = mf.pstat_main
-        self.pstat_sub = mf.pstat_sub
+        self.main_option = mf.copy()
         
     def set_potential(self, mdf : ExMDF):
         self.potential = mdf.copy()
@@ -70,39 +40,23 @@ class Item():
         self.additional_potential = mdf.copy()
         
     def copy(self):
-        return Item(name = self.name, level = self.level, stat_main = self.stat_main, \
-        stat_sub = self.stat_sub, att = self.att, patt = self.patt, pdamage = self.pdamage,\
-        armor_ignore = self.armor_ignore, pstat_main = self.pstat_main, pstat_sub = self.pstat_sub, \
-        potential = self.potential, \
-        additional_potential = self.additional_potential)
+        return Item(name = self.name, level = self.level, main_option = self.main_option, potential = self.potential, additional_potential = self.additional_potential)
         
     def as_dict(self):
         potential_dict = self.potential.as_dict()
-        potential_dict["cooltime_reduce"] = self.potential.skill_modifier.cooltime_reduce
         additional_potential_dict = self.additional_potential.as_dict()
-        additional_potential_dict["cooltime_reduce"] = self.additional_potential.skill_modifier.cooltime_reduce
-        return {"main" : {"stat_main" : self.stat_main, "stat_sub" : self.stat_sub, "att" : self.att, "armor_ignore" : self.armor_ignore, "pstat_main" : self.pstat_main, "pstat_sub" : self.pstat_sub},
+        return {"main" : self.main_option.as_dict(),
                 "potential" : potential_dict,
                 "additional_potential" : additional_potential_dict}
         
     def log(self):
         txt = "name : %s, level : %d\n"%(self.name, self.level)
-        txt += "stat_main : %.1f, stat_sub %.1f\n"%(self.stat_main, self.stat_sub)
-        txt += "pstat_main : %.1f, pstat_sub %.1f\n"%(self.pstat_main, self.pstat_sub)
-        txt += "att : %.1f, patt %.1f\n"%(self.att, self.patt)
-        txt += "pdamage : %.1f, armor_ignore %.1f\n"%(self.pdamage, self.armor_ignore)
+        txt += "==main option==\n"
+        txt += self.main_option.log()
         txt += "==potential==\n"
-        txt += "pstat_main : %.1f, pstat_sub %.1f\n"%(self.potential.pstat_main, self.potential.pstat_sub)
-        txt += "att : %.1f, patt %.1f\n"%(self.potential.att, self.potential.patt)
-        txt += "pdamage : %.1f, armor_ignore %.1f\n"%(self.potential.pdamage, self.potential.armor_ignore)
-        txt += "crit : %.1f, crit_damage %.1f\n"%(self.potential.crit, self.potential.crit_damage)
-        txt += "cooltime_reduce : %.1f\n"%(self.potential.skill_modifier.cooltime_reduce)
+        txt += self.potential.log()
         txt += "==additional_potential==\n"
-        txt += "pstat_main : %.1f, pstat_sub %.1f\n"%(self.additional_potential.pstat_main, self.additional_potential.pstat_sub)
-        txt += "att : %.1f, patt %.1f\n"%(self.additional_potential.att, self.additional_potential.patt)
-        txt += "pdamage : %.1f, armor_ignore %.1f\n"%(self.additional_potential.pdamage, self.additional_potential.armor_ignore)
-        txt += "crit : %.1f, crit_damage %.1f\n"%(self.additional_potential.crit, self.additional_potential.crit_damage)
-        txt += "cooltime_reduce : %.1f\n"%(self.additional_potential.skill_modifier.cooltime_reduce)
+        txt += self.additional_potential.log()
         return txt
 
 class EnhancerFactory():
@@ -289,7 +243,7 @@ class EnhancerFactory():
         else:
             raise TypeError("Level Must be 130, 140, 150, 160, 200")
             
-        att = weapon.att
+        att = weapon.main_option.att
         att_init = att
         
         for i in range(1,star + 1):
@@ -354,8 +308,8 @@ class WeaponFactoryClass():
         if _type == '블레이드':
             _type = '단검'
         _att, _bonus = self.getMap(_type)
-        item = Item(name = _type, att = _att, level = self.level)
-        item.add_main_option(self.modifier)
+        item = Item(name = _type, main_option = self.modifier, level = self.level)
+        item.add_main_option(ExMDF(att = _att))
         item.add_main_option(EnhancerFactory.get_weapon_scroll_enhancement(self.level, elist))
         item.add_main_option(ExMDF(att = _bonus[-1*bonusAttIndex]))
         item.add_main_option(EnhancerFactory.get_weapon_starforce_enhancement(item, self.level, star))
@@ -376,8 +330,8 @@ class WeaponFactoryClass():
             raise TypeError("Invalid blade, (Arcane, Absolab, RootAbyss) is allowed.")
 
         _att, _bonus = self.getMap(_type)
-        item = Item(name = "블레이드", att = _att, level = self.level)
-        item.add_main_option(get_blade_modifier())
+        item = Item(name = "블레이드", main_option = get_blade_modifier(), level = self.level)
+        item.add_main_option(ExMDF(att = _att))
         item.add_main_option(EnhancerFactory.get_weapon_scroll_enhancement(self.level, elist))
         item.add_main_option(EnhancerFactory.get_weapon_starforce_enhancement(item, self.level, star))
         item.add_main_option(bonusElse)

--- a/dpmModule/item/ItemKernel.py
+++ b/dpmModule/item/ItemKernel.py
@@ -18,9 +18,9 @@ class Item():
         #Prototypical option
         self.name = name
         #Main options
-        self.main_option = main_option
-        self.potential = potential
-        self.additional_potential = additional_potential
+        self.main_option = main_option.copy()
+        self.potential = potential.copy()
+        self.additional_potential = additional_potential.copy()
         
         self.level = level
 

--- a/dpmModule/item/Meister.py
+++ b/dpmModule/item/Meister.py
@@ -1,8 +1,9 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
-Ring = it.Item(name="마이스터링", stat_main = 5, stat_sub = 5, att = 1, level = 140)
-Ear = it.Item(name="마이스터 이어링", stat_main = 5, stat_sub = 5, att = 4, level = 140)
-Soulder = it.Item(name="마이스터 숄더", stat_main = 13, stat_sub = 13, att = 9, level = 140)
+Ring = it.Item(name="마이스터링", level = 140, main_option = ExMDF(stat_main = 5, stat_sub = 5, att = 1))
+Ear = it.Item(name="마이스터 이어링", level = 140, main_option = ExMDF(stat_main = 5, stat_sub = 5, att = 4))
+Soulder = it.Item(name="마이스터 숄더", level = 140, main_option = ExMDF(stat_main = 13, stat_sub = 13, att = 9))
 
 
 class Factory():

--- a/dpmModule/item/RootAbyss.py
+++ b/dpmModule/item/RootAbyss.py
@@ -1,10 +1,11 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
 ## Armors ##
 #No upgrade
-Top = it.Item(name="이글아이 아머", stat_main = 30, stat_sub = 30, att = 2, armor_ignore = 5, level = 150)
-Bottom = it.Item(name="트릭스터 팬츠", stat_main = 30, stat_sub = 30, att = 2, armor_ignore = 5, level = 150)
-Head = it.Item(name="하이네스 햇", stat_main = 40, stat_sub = 40, att = 2, armor_ignore = 10, level = 150)
+Top = it.Item(name="이글아이 아머", level = 150, main_option = ExMDF(stat_main = 30, stat_sub = 30, att = 2, armor_ignore = 5))
+Bottom = it.Item(name="트릭스터 팬츠", level = 150, main_option = ExMDF(stat_main = 30, stat_sub = 30, att = 2, armor_ignore = 5))
+Head = it.Item(name="하이네스 햇", level = 150, main_option = ExMDF(stat_main = 40, stat_sub = 40, att = 2, armor_ignore = 10))
 
 _valueMap = [[86, [0,11,16,21,28,36]],
                 [125,[0,15,22,31,40,52]],
@@ -19,7 +20,7 @@ _valueMap = [[86, [0,11,16,21,28,36]],
                 [81,[0,13,18,25,33,42]],
                 [169,[0,9,20,32,47,64]]]#Need blade & Zero weapon
 
-WeaponFactory = it.WeaponFactoryClass(150, _valueMap, modifier = it.ExMDF(stat_main = 40, stat_sub = 40, pdamage = 30, armor_ignore = 10))
+WeaponFactory = it.WeaponFactoryClass(150, _valueMap, modifier = it.ExMDF(stat_main = 40, stat_sub = 40, boss_pdamage = 30, armor_ignore = 10))
 
 
 class Factory():

--- a/dpmModule/item/Tyrant.py
+++ b/dpmModule/item/Tyrant.py
@@ -1,12 +1,13 @@
 from . import ItemKernel as it
+ExMDF = it.ExMDF
 
 # 장갑은 아무도 안씀
 #Glove = it.Item(stat_main = 12, stat_sub = 12, att = 15)
 # 신발 업횟 2
-Shoes = it.Item(name="타일런트 슈즈", stat_main = 50, stat_sub = 50, att = 30, level = 150)
+Shoes = it.Item(name="타일런트 슈즈", level = 150, main_option = ExMDF(stat_main = 50, stat_sub = 50, att = 30))
 # 망토 업횟 2
-Cloak = it.Item(name="타일런트 클록", stat_main = 50, stat_sub = 50, att = 30, level = 150)
+Cloak = it.Item(name="타일런트 클록", level = 150, main_option = ExMDF(stat_main = 50, stat_sub = 50, att = 30))
 # 벨트 업횟 1
-Belt = it.Item(name="타일런트 벨트", stat_main = 50, stat_sub = 50, att = 25, level = 150)
+Belt = it.Item(name="타일런트 벨트", level = 150, main_option = ExMDF(stat_main = 50, stat_sub = 50, att = 25))
 
 # get_surprise_enhance_list_direct 사용 (150제)

--- a/dpmModule/jobs/jobutils.py
+++ b/dpmModule/jobs/jobutils.py
@@ -17,10 +17,10 @@ def create_auxilary_attack(skill_wrapper, ratio, nametag = '복사'):
 def get_weapon_att(WEAPON_NAME, spec = 6000):
     if spec < 5000:
         #파프
-        return RootAbyss.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).att
+        return RootAbyss.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).main_option.att
     elif spec < 7000:
         #앱솔
-        return Absolab.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).att
+        return Absolab.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).main_option.att
     else:
         #아케인
-        return Arcane.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).att
+        return Arcane.WeaponFactory.getWeapon(WEAPON_NAME, star = 0, elist = [0,0,0,0] ).main_option.att

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -334,9 +334,9 @@ class ExtendedCharacterModifier(CharacterModifier):
     def log(self):
         txt = super(ExtendedCharacterModifier, self).log()
         txt + "buff_rem : %.1f, summon_rem : %.1f\n" % (self.buff_rem, self.summon_rem)
-        txt += "cooltime_reduce : %.1f pcooltime_reduce : %.1f\n" % (self.cooltime_reduce, self.pcooltime_reduce)
-        txt += "reuse_chance : %.1f prop_ignore : %.1f\n" % (self.reuse_chance, self.prop_ignore)
-        txt += "additional_target : %d passive_level : %d\n" % (self.additional_target, self.passive_level)
+        txt += "cooltime_reduce : %.1f, pcooltime_reduce : %.1f\n" % (self.cooltime_reduce, self.pcooltime_reduce)
+        txt += "reuse_chance : %.1f, prop_ignore : %.1f\n" % (self.reuse_chance, self.prop_ignore)
+        txt += "additional_target : %d, passive_level : %d\n" % (self.additional_target, self.passive_level)
         return txt
     
     def copy(self):


### PR DESCRIPTION
* 무기류 잠재능력이 캐릭터에 반영되지 않는 버그 수정
* 무기류 잠재능력을 1개의 배열이 아닌 무기/보조/엠블 각각 반환하게 변경
* 무기 기본옵션의 보공이 뎀퍼로 되어있는것 수정
* Item 클래스의 레벨을 필수적으로 받게 함
* 아이템 기본 옵션의 주스탯%, 부스탯%가 적용되지 않는것 수정
* Item 클래스의 기본 옵션을 ExMDF로 변경
  * 스탯을 따로 들고있는게 버그의 원인이였음
  * 드용도, 딥다크 등 기본옵션에 크확/크뎀이 붙기도 함