### PR TITLE
컴뱃 오더스 적용 (2)

### DIFF
--- a/dpmModule/jobs/michael.py
+++ b/dpmModule/jobs/michael.py
@@ -6,7 +6,7 @@ from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobclass import cygnus
 from .jobbranch import warriors
-
+from math import ceil
 # 미하일 영메 적용여부에 대해 고민해볼 필요 있음
 
 
@@ -18,11 +18,14 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "미하일"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'mess')
         self.preEmptiveSkills = 1
+        self._combat = 0
 
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(crit = 20)
 
-    def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):        
+    def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         ElementalExpert = core.InformedCharacterModifier("엘리멘탈 엑스퍼트",patt = 10)
         
         PhisicalTraiging = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
@@ -30,21 +33,22 @@ class JobGenerator(ck.JobGenerator):
         InvigoratePassive = core.InformedCharacterModifier("격려(패시브)",att = 20)
         Intension = core.InformedCharacterModifier("인텐션",stat_main = 60, crit = 20, pdamage_indep = 10)
         ShiningCharge = core.InformedCharacterModifier("샤이닝 차지(패시브)",pdamage = 60)
-        CombatMastery = core.InformedCharacterModifier("컴뱃 마스터리",armor_ignore = 40)
-        AdvancedSowrdMastery = core.InformedCharacterModifier("어드밴스드 소드 마스터리",att = 30, crit = 15, crit_damage = 10)
-        AdvancedFinalAttackPassive = core.InformedCharacterModifier("어드밴스드 파이널 어택(패시브)",att = 30)
+        CombatMastery = core.InformedCharacterModifier("컴뱃 마스터리",armor_ignore = 40+2*passive_level)
+        AdvancedSowrdMastery = core.InformedCharacterModifier("어드밴스드 소드 마스터리",att = 30+passive_level, crit = 15+passive_level//3, crit_damage = 10)
+        AdvancedFinalAttackPassive = core.InformedCharacterModifier("어드밴스드 파이널 어택(패시브)",att = 30+passive_level)
 
         return [ElementalExpert, PhisicalTraiging, SwordMastery,
                             InvigoratePassive, Intension, ShiningCharge, CombatMastery, AdvancedSowrdMastery,
                             AdvancedFinalAttackPassive]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         PARTYPEOPLE = 1        
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 20)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5 + 0.5*ceil(passive_level/2))
         
         SoulLink = core.InformedCharacterModifier("소울 링크",pdamage = 5*PARTYPEOPLE)
-        SoulRage = core.InformedCharacterModifier("소울 레이지", pdamage_indep = 30, crit_damage = 8)
+        SoulRage = core.InformedCharacterModifier("소울 레이지", pdamage_indep = 30+self._combat, crit_damage = 8)
         
         return [WeaponConstant, Mastery, SoulLink, SoulRage]
 
@@ -61,7 +65,8 @@ class JobGenerator(ck.JobGenerator):
         
         로얄 가드는 6초마다 사용하며 다른 스킬로 인해 약간 나중에 사용할 수도 있음. 로얄 가드 5중첩 버프를 상시 유지하도록 가정.
         '''
-        
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         GuardOfLight = core.BuffSkill("빛의 수호", 900, 30000, rem = True, red = True, cooltime = 180000, pdamage = 20).wrap(core.BuffSkillWrapper)
         
         LoyalGuardBuff = core.BuffSkill("로얄 가드", 0, 12000, att = 45).wrap(core.BuffSkillWrapper)  #10->15->20->30->45
@@ -74,13 +79,13 @@ class JobGenerator(ck.JobGenerator):
         
         SoulAttack = core.BuffSkill("소울 어택", 0, 10000, cooltime = -1, pdamage_indep = 25, crit = 20).wrap(core.BuffSkillWrapper)
         
-        FinalAttack = core.DamageSkill("파이널 어택", 0, 95*4, 0.75).setV(vEhc, 3, 4, False).wrap(core.DamageSkillWrapper)
+        FinalAttack = core.DamageSkill("파이널 어택", 0, (95+passive_level)*4, 0.01*(75+passive_level)).setV(vEhc, 3, 4, False).wrap(core.DamageSkillWrapper)
         Booster = core.BuffSkill("부스터", 0, 180000, rem = True).wrap(core.BuffSkillWrapper)
         Invigorate = core.BuffSkill("격려", 0, 180000, rem = True, att = 30).wrap(core.BuffSkillWrapper)
         
-        SoulAssult = core.DamageSkill("소울 어썰트", 600, 210, 11+1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)   #암흑 20%
+        SoulAssult = core.DamageSkill("소울 어썰트", 600, 210+3*self._combat, 11+1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)   #암흑 20%
         
-        ShiningCross = core.DamageSkill("샤이닝 크로스", 600, 440, 4 + 1, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #암흑 30% 10초
+        ShiningCross = core.DamageSkill("샤이닝 크로스", 600, 440+3*self._combat, 4 + 1, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #암흑 30% 10초
         ShiningCrossInstall = core.SummonSkill("샤이닝 크로스(인스톨)", 0, 1200, 75, 4+1, 12000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)    #100% 암흑 5초
         
         #하이퍼

--- a/dpmModule/jobs/nightlord.py
+++ b/dpmModule/jobs/nightlord.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule
 from . import globalSkill
 from .jobbranch import thieves
+from math import ceil
 #TODO : 5차 신스킬 적용
 
 ######   Passive Skill   ######
@@ -20,6 +21,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "나이트로드"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+        self._combat = 0
 
     def get_ruleset(self):
         ruleset = RuleSet()
@@ -27,24 +29,28 @@ class JobGenerator(ck.JobGenerator):
         return ruleset
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         NimbleBody = core.InformedCharacterModifier("님블 바디",stat_main = 20)
         CriticalThrow = core.InformedCharacterModifier("크리티컬 스로우", crit=50, crit_damage = 5)
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
         
         Adrenalin = core.InformedCharacterModifier("아드레날린",crit_damage=10)
         JavelinMastery = core.InformedCharacterModifier("자벨린 마스터리",pdamage_indep = 25)    #20%확률로 100%크리. 현재 비활성,
-        PurgeAreaPassive = core.InformedCharacterModifier("퍼지 에어리어(패시브)",boss_pdamage = 10)
-        DarkSerenity = core.InformedCharacterModifier("다크 세레니티",att = 40, armor_ignore = 30)
+        PurgeAreaPassive = core.InformedCharacterModifier("퍼지 에어리어(패시브)",boss_pdamage = 10 + ceil(self._combat / 3))
+        DarkSerenity = core.InformedCharacterModifier("다크 세레니티",att = 40+passive_level, armor_ignore = 30+passive_level)
         
-        JavelineExpert = core.InformedCharacterModifier("자벨린 엑스퍼트",att = 30, crit_damage = 15)
+        JavelineExpert = core.InformedCharacterModifier("자벨린 엑스퍼트",att = 30 + passive_level, crit_damage = 15 + passive_level//3)
         ReadyToDiePassive = thieves.ReadyToDiePassiveWrapper(vEhc, 1, 1)
         
         return [NimbleBody, CriticalThrow, PhisicalTraining, 
                 Adrenalin, JavelinMastery, PurgeAreaPassive, DarkSerenity, JavelineExpert, ReadyToDiePassive]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         WeaponConstant = core.InformedCharacterModifier("무기상수", pdamage_indep = 75)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5)    #오더스 기본적용!        
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5+0.5*(passive_level / 2))    #오더스 기본적용!        
         
         return [WeaponConstant, Mastery]
 
@@ -57,21 +63,24 @@ class JobGenerator(ck.JobGenerator):
         얼닼사는 스프 사용중에만 사용
         
         '''
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         #Buff skills
         ShadowPartner = core.BuffSkill("쉐도우 파트너", 0, 200 * 1000, rem = True).wrap(core.BuffSkillWrapper) # 펫버프
         SpiritJavelin = core.BuffSkill("스피릿 자벨린", 0, 200 * 1000, rem = True).wrap(core.BuffSkillWrapper) # 펫버프
-        PurgeArea = core.BuffSkill("퍼지 에어리어", 600, 40 * 1000, armor_ignore=30).wrap(core.BuffSkillWrapper) #딜레이 모름
+        PurgeArea = core.BuffSkill("퍼지 에어리어", 600, (40+self._combat) * 1000, armor_ignore=30+self._combat).wrap(core.BuffSkillWrapper) #딜레이 모름
         BleedingToxin = core.BuffSkill("블리딩 톡신", 780, 90*1000, cooltime = 200 * 1000, att = 60).wrap(core.BuffSkillWrapper)
         BleedingToxinDot = core.DotSkill("블리딩 톡신(도트)", 1000, 90*1000).wrap(core.SummonSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
 
         
-        QuarupleThrow =core.DamageSkill("쿼드러플 스로우", 600, 378, 5 * 1.7, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)    #쉐도우 파트너 적용
+        QuarupleThrow =core.DamageSkill("쿼드러플 스로우", 600, 378 + 4*self._combat, 5 * 1.7, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)    #쉐도우 파트너 적용
         
-        MarkOfNightlord = core.DamageSkill("마크 오브 나이트로드", 0, (60 + chtr.level), 0.375*3).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
-        MarkOfNightlordPungma = core.DamageSkill("마크 오브 나이트로드(풍마)", 0, (60 + chtr.level), 0.375*3).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper) # 툴팁대로면 19.355%가 맞으나, 쿼드러플과 동일한 37.5%로 적용되는 중
-    
-        FatalVenom = core.DotSkill("페이탈 베놈", 480, 8000).wrap(core.SummonSkillWrapper)
+        MARK_PROP = (60+2*passive_level)/(160+2*passive_level)
+        MarkOfNightlord = core.DamageSkill("마크 오브 나이트로드", 0, (60+3*passive_level+chtr.level), MARK_PROP*3).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        MarkOfNightlordPungma = core.DamageSkill("마크 오브 나이트로드(풍마)", 0, (60+3*passive_level+chtr.level), MARK_PROP*3).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper) # 툴팁대로면 19.355%가 맞으나, 쿼드러플과 동일한 37.5%로 적용되는 중
+
+        # TODO: 타수 분리    
+        FatalVenom = core.DotSkill("페이탈 베놈", (160+5*passive_level)*(2+(10+passive_level)//6), 8000).wrap(core.SummonSkillWrapper)
     
         #_VenomBurst = core.DamageSkill("베놈 버스트", ??) ## 패시브 50%확률로 10초간 160+6*vlevel dot. 사용시 도트뎀 모두 피해 + (500+20*vlevel) * 5. 어차피 안쓰는 스킬이므로 작성X
         

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule
 from . import globalSkill
 from .jobbranch import warriors
+from math import ceil
 
 #TODO : 5차 신스킬 적용
 # 4차 스킬은 컴뱃오더스 적용 기준으로 작성해야 함.
@@ -21,6 +22,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "팔라딘"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 2
+        self._combat = 2
 
     def get_ruleset(self):
         ruleset = RuleSet()
@@ -28,16 +30,18 @@ class JobGenerator(ck.JobGenerator):
         return ruleset
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
         ShieldMastery = core.InformedCharacterModifier("실드 마스터리",att = 10)
         
-        PaladinExpert = core.InformedCharacterModifier("팔라딘 엑스퍼트(두손둔기)",crit_damage = 15+5, pdamage_indep = 42, crit = 42, armor_ignore = 37.9)
+        PaladinExpert = core.InformedCharacterModifier("팔라딘 엑스퍼트(두손둔기)",crit_damage = 15+passive_level//3+5, pdamage_indep = 42+passive_level, crit = 42+passive_level, armor_ignore = 37.9)
         
         return [PhisicalTraining, ShieldMastery, PaladinExpert]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 34)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -4.5)    #오더스 기본적용!
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -4.5+ 0.5*ceil(passive_level/2))    #오더스 기본적용!
         
         ElementalCharge = core.InformedCharacterModifier("엘리멘탈 차지",pdamage = 25, att = 60)  #조건부 적용 여부는 추후검토.
         ParashockGuard = core.InformedCharacterModifier("파라쇼크 가드",att = 20)

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -22,7 +22,6 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "팔라딘"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 2
-        self._combat = 2
 
     def get_ruleset(self):
         ruleset = RuleSet()
@@ -34,7 +33,7 @@ class JobGenerator(ck.JobGenerator):
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
         ShieldMastery = core.InformedCharacterModifier("실드 마스터리",att = 10)
         
-        PaladinExpert = core.InformedCharacterModifier("팔라딘 엑스퍼트(두손둔기)",crit_damage = 15+passive_level//3+5, pdamage_indep = 42+passive_level, crit = 42+passive_level, armor_ignore = 37.9)
+        PaladinExpert = core.InformedCharacterModifier("팔라딘 엑스퍼트(두손둔기)",crit_damage = 5 + (32+passive_level) // 3, pdamage_indep = 42+passive_level, crit = 42+passive_level, armor_ignore = 15+ceil((32+passive_level)/2)) + core.ExtendedCharacterModifier(crit_damage= 5, armor_ignore = 10)
         
         return [PhisicalTraining, ShieldMastery, PaladinExpert]
 

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -67,13 +67,13 @@ class JobGenerator(ck.JobGenerator):
         템페스트 오브 카드 사용하지 않음
         '''
         passive_level = chtr.get_base_modifier().passive_level + self._combat
-        STEALSKILL_CONSTANT = 1.2
+        STEALSKILL = core.CharacterModifier(pdamage_indep = 100*((1.2 / 1.3)-1))
         #Buff skills
         TalentOfPhantomII = core.BuffSkill("분노(탤팬2)", 0, 180000, rem = True, att = 30).wrap(core.BuffSkillWrapper)
         # 힐+마오팬보다 분노가 허수아비딜은 잘나옴
         # TalentOfPhantomII = core.BuffSkill("힐(탤팬2)", 450, 2*1000, cooltime=10*1000, pdamage_indep=10).wrap(core.BuffSkillWrapper)
         TalentOfPhantomIII = core.BuffSkill("크로스 오버 체인(탤팬3)", 0, 180000, rem = True, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
-        FinalCut = core.DamageSkill("탤런트 오브 팬텀시프 IV(파이널 컷)", 450, 2000 + 20 * self._combat, 1, modifier = core.CharacterModifier(pdamage_indep = 100*((STEALSKILL_CONSTANT / 1.3)-1)),cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        FinalCut = core.DamageSkill("탤런트 오브 팬텀시프 IV(파이널 컷)", 450, 2000 + 20 * self._combat, 1, modifier = STEALSKILL, cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
         FinalCutBuff = core.BuffSkill("파이널 컷(버프, 탤팬4)", 0, 60000, cooltime = -1, rem = True, pdamage_indep = 40 + self._combat).wrap(core.BuffSkillWrapper)
         BoolsEye = core.BuffSkill("불스아이(탤팬5)", 960, 30 * 1000, cooltime = 180 * 1000, crit = 20, crit_damage = 10, armor_ignore = 20, pdamage = 20).wrap(core.BuffSkillWrapper)
     

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -7,6 +7,7 @@ from ..execution.rules import RuleSet, ConcurrentRunRule, ReservationRule
 from . import globalSkill
 from .jobclass import heroes
 from .jobbranch import thieves
+from math import ceil
 
 # TODO : [마크 오브 팬텀] : 괴도의 증표를 1개 모으는데 필요한 얼티밋 드라이브 적중 수가 5회에서 7회로 증가됩니다. 템페스트 오브 카드로도 괴도의 증표를 모을 수 있게 됩니다. 얼티밋 드라이브와 같은 횟수를 공격해야 괴도의 증표를 획득 할 수 있습니다.
 ######   Passive Skill   ######
@@ -21,14 +22,16 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "팬텀"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+        self._combat = 0
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         HighDexterity = core.InformedCharacterModifier("하이 덱스터리티",stat_sub = 40)
         LuckMonopoly = core.InformedCharacterModifier("럭 모노폴리",stat_main = 60)
         LuckOfPhantomtheif = core.InformedCharacterModifier("럭오브팬텀시프",stat_main = 60)
         MoonLight = core.InformedCharacterModifier("문 라이트",att = 40)
         AcuteSence = core.InformedCharacterModifier("어큐트 센스",crit = 35, pdamage_indep = 30)
-        CainExpert = core.InformedCharacterModifier("케인 엑스퍼트", att = 40+self.combat, crit_damage = 15, pdamage_indep = 25 + int(self.combat * 0.5))
+        CainExpert = core.InformedCharacterModifier("케인 엑스퍼트", att = 40+passive_level, crit_damage = 15+passive_level//3, pdamage_indep = 25 + passive_level//2)
     
         ReadyToDiePassive = thieves.ReadyToDiePassiveWrapper(vEhc, 3, 3)
 
@@ -37,8 +40,9 @@ class JobGenerator(ck.JobGenerator):
                                 ReadyToDiePassive]
                                 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 30)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5 +0.5*ceil(passive_level / 2))
         
         return [WeaponConstant, Mastery]
 
@@ -62,14 +66,14 @@ class JobGenerator(ck.JobGenerator):
         펫버프 : 프레이 오브 아리아, 메용, 크오체
         템페스트 오브 카드 사용하지 않음
         '''
-        
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         #Buff skills
         TalentOfPhantomII = core.BuffSkill("분노(탤팬2)", 0, 180000, rem = True, att = 30).wrap(core.BuffSkillWrapper)
         # 힐+마오팬보다 분노가 허수아비딜은 잘나옴
         # TalentOfPhantomII = core.BuffSkill("힐(탤팬2)", 450, 2*1000, cooltime=10*1000, pdamage_indep=10).wrap(core.BuffSkillWrapper)
         TalentOfPhantomIII = core.BuffSkill("크로스 오버 체인(탤팬3)", 0, 180000, rem = True, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
-        FinalCut = core.DamageSkill("탤런트 오브 팬텀시프 IV(파이널 컷)", 450, 2000, 1, cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
-        FinalCutBuff = core.BuffSkill("파이널 컷(버프, 탤팬4)", 0, 60000, cooltime = -1, rem = True, pdamage_indep = 40).wrap(core.BuffSkillWrapper)
+        FinalCut = core.DamageSkill("탤런트 오브 팬텀시프 IV(파이널 컷)", 450, 2000 + 20 * self._combat, 1, cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        FinalCutBuff = core.BuffSkill("파이널 컷(버프, 탤팬4)", 0, 60000, cooltime = -1, rem = True, pdamage_indep = 40 + self._combat).wrap(core.BuffSkillWrapper)
         BoolsEye = core.BuffSkill("불스아이(탤팬5)", 960, 30 * 1000, cooltime = 180 * 1000, crit = 20, crit_damage = 10, armor_ignore = 20, pdamage = 20).wrap(core.BuffSkillWrapper)
     
         JudgementBuff = core.BuffSkill("저지먼트(버프)", 0, 999999999, crit = 0).wrap(core.BuffSkillWrapper)    #확률성 크리티컬
@@ -77,24 +81,24 @@ class JobGenerator(ck.JobGenerator):
         Booster = core.BuffSkill("부스터", 0, 240 * 1000, rem = True).wrap(core.BuffSkillWrapper)    #딜레이 모름
         
         MileAiguillesInit = core.BuffSkill("얼티밋 드라이브(개시)", 240, 240).wrap(core.BuffSkillWrapper)
-        MileAiguilles = core.DamageSkill("얼티밋 드라이브", 150, 125 + 2*combat, 3, modifier = core.CharacterModifier(pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        MileAiguilles = core.DamageSkill("얼티밋 드라이브", 150, 125 + self._combat, 3, modifier = core.CharacterModifier(pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
 
-        CarteNoir = core.DamageSkill("느와르 카르트", 0, 270, min(chtr.get_modifier().crit/100 + 0.1, 1)).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        CarteNoir = core.DamageSkill("느와르 카르트", 0, 270 + 2*passive_level, min(chtr.get_modifier().crit/100 + 0.1, 1)).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         CarteNoir_ = core.DamageSkill("느와르 카르트(저지먼트)", 0, 270, 10).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
-        PrieredAria = core.BuffSkill("프레이 오브 아리아", 0, (240+7*combat)*1000, pdamage = 30+combat, armor_ignore = 30+combat).wrap(core.BuffSkillWrapper)
+        PrieredAria = core.BuffSkill("프레이 오브 아리아", 0, (240+7*self._combat)*1000, pdamage = 30+self._combat, armor_ignore = 30+self._combat).wrap(core.BuffSkillWrapper)
 
         # 템오카 안쓰는게 더 높게 나옴
         # TempestOfCardInit = core.DamageSkill("템페스트 오브 카드(시전)", 0, 0, 0, cooltime = 18000*0.8 + 180*56, red = True).wrap(core.DamageSkillWrapper, name = "템오카 시전")
-        # TempestOfCard = core.DamageSkill("템페스트 오브 카드", 180, 200+2*combat, 3, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        # TempestOfCard = core.DamageSkill("템페스트 오브 카드", 180, 200+2*self._combat, 3, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
     
         HerosOath = core.BuffSkill("히어로즈 오쓰", 0, 60000, cooltime = 120000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 3, 3)
         
         # 트와일라이트 미적용 상태
-        # Twilight = core.BuffSkill("트와일라이트", 120, 15000, cooltime = 15000, armor_ignore = 20).wrap(core.BuffSkillWrapper)
-        # TwilightHit = core.DamageSkill("트와일라이트(공격)", 540, 450, 3, cooltime = -1).wrap(core.DamageSkillWrapper)
+        # Twilight = core.BuffSkill("트와일라이트", 120, 15000, cooltime = 15000, armor_ignore = 20 + self._combat//2).wrap(core.BuffSkillWrapper)
+        # TwilightHit = core.DamageSkill("트와일라이트(공격)", 540, 450+3*self._combat, 3, cooltime = -1).wrap(core.DamageSkillWrapper)
 
         JokerInit = core.DamageSkill("조커(시전)", 540, 0, 0, cooltime = 150000, red = True).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
         JokerDamage = core.DamageSkill("조커", 460, 240+9*vEhc.getV(4,4), 30).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)  #14회 반복, 총 420타이므로 30타로 적용

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -67,12 +67,13 @@ class JobGenerator(ck.JobGenerator):
         템페스트 오브 카드 사용하지 않음
         '''
         passive_level = chtr.get_base_modifier().passive_level + self._combat
+        STEALSKILL_CONSTANT = 1.2
         #Buff skills
         TalentOfPhantomII = core.BuffSkill("분노(탤팬2)", 0, 180000, rem = True, att = 30).wrap(core.BuffSkillWrapper)
         # 힐+마오팬보다 분노가 허수아비딜은 잘나옴
         # TalentOfPhantomII = core.BuffSkill("힐(탤팬2)", 450, 2*1000, cooltime=10*1000, pdamage_indep=10).wrap(core.BuffSkillWrapper)
         TalentOfPhantomIII = core.BuffSkill("크로스 오버 체인(탤팬3)", 0, 180000, rem = True, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
-        FinalCut = core.DamageSkill("탤런트 오브 팬텀시프 IV(파이널 컷)", 450, 2000 + 20 * self._combat, 1, cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        FinalCut = core.DamageSkill("탤런트 오브 팬텀시프 IV(파이널 컷)", 450, 2000 + 20 * self._combat, 1, modifier = core.CharacterModifier(pdamage_indep = 100*((STEALSKILL_CONSTANT / 1.3)-1)),cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
         FinalCutBuff = core.BuffSkill("파이널 컷(버프, 탤팬4)", 0, 60000, cooltime = -1, rem = True, pdamage_indep = 40 + self._combat).wrap(core.BuffSkillWrapper)
         BoolsEye = core.BuffSkill("불스아이(탤팬5)", 960, 30 * 1000, cooltime = 180 * 1000, crit = 20, crit_damage = 10, armor_ignore = 20, pdamage = 20).wrap(core.BuffSkillWrapper)
     

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, MutualRule, ConcurrentRunRule, ReservationRule
 from . import globalSkill
 from .jobbranch import bowmen
+from math import ceil
 #TODO : 5차 신스킬 적용    
 
 
@@ -17,6 +18,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "신궁"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+        self._combat = 0
 
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(armor_ignore = 50)
@@ -33,19 +35,21 @@ class JobGenerator(ck.JobGenerator):
         return ruleset
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         CriticalShot = core.InformedCharacterModifier("크리티컬 샷",crit = 40)
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
         
         MarkmanShip = core.InformedCharacterModifier("마크맨쉽",armor_ignore = 25, pdamage = 15)
 
-        CrossBowExpert = core.InformedCharacterModifier("크로스보우 엑스퍼트",att= 30+self.combat*1, crit_damage = 8)
+        CrossBowExpert = core.InformedCharacterModifier("크로스보우 엑스퍼트",att= 30+passive_level, crit_damage = 8)
         
         return [CriticalShot, PhisicalTraining, MarkmanShip, 
                 CrossBowExpert]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 35)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5 + 0.5 * self.combat)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5 + 0.5*ceil(passive_level/2))
 
         MortalBlow = core.InformedCharacterModifier("모탈 블로우",pdamage = 2)        
         ExtremeArchery = core.InformedCharacterModifier("익스트림 아처리:석궁",crit_damage = 20)
@@ -60,16 +64,17 @@ class JobGenerator(ck.JobGenerator):
         스나, 피어싱, 롱레트, 프리저
         '''
         distance = 400
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
 
-        WEAKNESS_FINDING = core.CharacterModifier(armor_ignore = 50 + self.combat * 1)
-        DISTANCING_SENSE = core.CharacterModifier(pdamage_indep = 40 + self.combat * 2)
-        LASTMAN_STANDING = core.CharacterModifier(pdamage_indep = 20 + self.combat * 2)
+        WEAKNESS_FINDING = core.CharacterModifier(armor_ignore = 50 + passive_level)
+        DISTANCING_SENSE = core.CharacterModifier(pdamage_indep = 40 + passive_level)
+        LASTMAN_STANDING = core.CharacterModifier(pdamage_indep = 20 + 2*passive_level)
         PASSIVE_MODIFIER = WEAKNESS_FINDING + DISTANCING_SENSE + LASTMAN_STANDING
         
         #Buff skills
         SoulArrow = core.BuffSkill("소울 애로우", 0, 300 * 1000, att = 30, rem = True).wrap(core.BuffSkillWrapper)
-        ElusionStep = core.BuffSkill("일루젼 스탭", 0, (300+combat*16) * 1000, stat_main = 40 + combat*1, rem = True).wrap(core.BuffSkillWrapper)
-        SharpEyes = core.BuffSkill("샤프 아이즈", 660, 300 * 1000, crit = 20 + combat*1, crit_damage = 15 + combat*1, rem = True).wrap(core.BuffSkillWrapper)
+        ElusionStep = core.BuffSkill("일루젼 스탭", 0, (300+self._combat*8) * 1000, stat_main = 40 + self._combat, rem = True).wrap(core.BuffSkillWrapper)
+        SharpEyes = core.BuffSkill("샤프 아이즈", 660, (300+10*self._combat) * 1000, crit = 20 + ceil(self._combat/2), crit_damage = 15 + ceil(self._combat/2), rem = True).wrap(core.BuffSkillWrapper)
         #크리티컬 리인포스 - >재정의 필요함..
         
         BoolsEye = core.BuffSkill("불스아이", 960, 30 * 1000, cooltime = 90 * 1000, crit = 20, crit_damage = 10, armor_ignore = 20, pdamage = 20).wrap(core.BuffSkillWrapper)
@@ -78,7 +83,7 @@ class JobGenerator(ck.JobGenerator):
         #Damage Skills
         # 롱레인지 트루샷: 나무위키피셜 DPM 떨어지므로 보류
 
-        Snipping = core.DamageSkill("스나이핑", 630, 465+combat*5, 9 + 1, modifier = core.CharacterModifier(crit = 100, armor_ignore = 20 + combat * 1, pdamage = 20, boss_pdamage = 10) + PASSIVE_MODIFIER).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        Snipping = core.DamageSkill("스나이핑", 630, 465+self._combat*5, 9 + 1, modifier = core.CharacterModifier(crit = 100, armor_ignore = 20 + combat * 1, pdamage = 20, boss_pdamage = 10) + PASSIVE_MODIFIER).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         TrueSnippingTick = core.DamageSkill("트루 스나이핑(타격)", 690, 950+vEhc.getV(2,2)*30, 14+1, modifier = core.CharacterModifier(pdamage = 100, armor_ignore = 100) + PASSIVE_MODIFIER).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         TrueSnipping = core.DamageSkill("트루 스나이핑", 120, 0, 0, cooltime = 180 * 1000, red=True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         

--- a/dpmModule/jobs/soulmaster.py
+++ b/dpmModule/jobs/soulmaster.py
@@ -7,6 +7,7 @@ from ..execution.rules import RuleSet, InactiveRule
 from . import globalSkill
 from .jobclass import cygnus
 from .jobbranch import warriors
+from math import ceil
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -16,6 +17,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "소울마스터"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+        self._combat = 0
 
     def get_ruleset(self):
         ruleset = RuleSet()
@@ -27,6 +29,8 @@ class JobGenerator(ck.JobGenerator):
         return core.CharacterModifier(pdamage = 20)
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         ElementalExpert = core.InformedCharacterModifier("엘리멘탈 엑스퍼트", patt = 10)
         ElementalHarmony = core.InformedCharacterModifier("엘리멘탈 하모니", stat_main = chtr.level // 2)
         
@@ -36,16 +40,18 @@ class JobGenerator(ck.JobGenerator):
         BodyAndSoul = core.InformedCharacterModifier("바디 앤 소울",stat_main = 40, stat_sub = 20)
         InnerShout = core.InformedCharacterModifier("이너 샤우트",att = 30, stat_main = 40)
         
-        SoulPledge = core.InformedCharacterModifier("소울 플레지",stat_main = 30, stat_sub = 30, crit = 10) #오더스?
-        SwordExpert = core.InformedCharacterModifier("소드 엑스퍼트",att = 50, crit_damage = 15) #오더스?
-        Unforseeable = core.InformedCharacterModifier("언포시어블",armor_ignore = 30, boss_pdamage = 15) #오더스?
+        SoulPledge = core.InformedCharacterModifier("소울 플레지",stat_main = 30+passive_level, stat_sub = 30+passive_level, crit = 10)
+        SwordExpert = core.InformedCharacterModifier("소드 엑스퍼트",att = 50+passive_level, crit_damage = 15+passive_level//3)
+        Unforseeable = core.InformedCharacterModifier("언포시어블",armor_ignore = 30+2*passive_level, boss_pdamage = 15+passive_level)
         
         return [ElementalHarmony, ElementalExpert, SwordOfLight, Soul, InnerTrust,
                             BodyAndSoul, InnerShout, SoulPledge, SwordExpert, Unforseeable]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 34)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5+0.5*ceil(passive_level/2))
         TrueSightHyper = core.InformedCharacterModifier("트루 사이트(하이퍼)", prop_ignore = 10)
         
         return [WeaponConstant, Mastery, TrueSightHyper]
@@ -56,23 +62,24 @@ class JobGenerator(ck.JobGenerator):
         트루사이트 : 내성무시 / 방무
         보스전 딜스킬 : 리인포스 / 이그노어 가드 / 보스킬러
         '''
-        FallingMoon = core.CharacterModifier(pdamage_indep = -10)
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+        FallingMoon = core.CharacterModifier(pdamage_indep = -10+passive_level//3)
 
         #Buff skills
         NimbleFinger = core.BuffSkill("님블 핑거", 0, 180 * 1000, rem = True).wrap(core.BuffSkillWrapper) # 펫버프
         TrueSight = core.BuffSkill("트루 사이트", 990, 30 * 1000, armor_ignore = 10+10, pdamage_indep = 5).wrap(core.BuffSkillWrapper) # 내성무시는 not_implied_skill_list에 있음
-        SolunaTime = core.BuffSkill("솔루나 타임", 0, 200 * 1000, rem = True, crit = 35, pdamage_indep = 25, att = 45).wrap(core.BuffSkillWrapper)  # 딜레이 없음
+        SolunaTime = core.BuffSkill("솔루나 타임", 0, (200+6*self._combat) * 1000, rem = True, crit = 35 + passive_level // 2, pdamage_indep = 25, att = 45+passive_level+passive_level//2).wrap(core.BuffSkillWrapper)  # 딜레이 없음
         SoulForge = core.BuffSkill("소울 포지", 0, 180 * 1000, att = 50, rem = True).wrap(core.BuffSkillWrapper) # 펫버프
         GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
         #Damage Skills
-        SpeedingDance = core.DamageSkill("댄스오브 문/스피딩 선셋", (360+270)/2, 400, 4 * 2, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20) + FallingMoon).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        SpeedingDance = core.DamageSkill("댄스오브 문/스피딩 선셋", (360+270)/2, 400+4*self._combat, 4 * 2, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20) + FallingMoon).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
         CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 4, 4)
         
         SelestialDanceInit = core.BuffSkill("셀레스티얼 댄스", 570, (40+vEhc.getV(0,0))*1000, cooltime = 150 * 1000, red = True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         SelestialDanceSummon = core.SummonSkill("셀레스티얼 댄스(추가타)", 0, 5000, (1200 + 40 * vEhc.getV(0,0)), 3, (40 + vEhc.getV(0,0)) * 1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
-        SelestialDanceAttack = core.DamageSkill("댄스오브 문/스피딩 선셋(셀레스티얼)", 0, 400*0.01*(30+vEhc.getV(0,0)), 4 * 2, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20) + FallingMoon).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)    #직접사용 X
+        SelestialDanceAttack = core.DamageSkill("댄스오브 문/스피딩 선셋(셀레스티얼)", 0, (400+4*self._combat)*0.01*(30+vEhc.getV(0,0)), 4 * 2, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20) + FallingMoon).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)    #직접사용 X
         
         #엘리시온 38타 / 3타
         Elision = core.BuffSkill("엘리시온", 750, 30 * 1000, cooltime = 180 * 1000, red=True).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)    #시전딜레이 750ms

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -8,6 +8,7 @@ from . import jobutils
 from .jobbranch import pirates
 from .jobclass import cygnus
 from . import jobutils
+from math import ceil
 
 #TODO : 5차 신스킬 적용
 #TODO : 천지개벽 발동 중에는 태풍을 노쿨로 사용하도록
@@ -31,11 +32,14 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "스트라이커"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+        self._combat = 0
 
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(armor_ignore = 40) # 뇌전 스택으로 평균 35~40%의 방무 적용
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         ElementalExpert = core.InformedCharacterModifier("엘리멘탈 엑스퍼트",stat_main = chtr.level // 2)
         ElementalHarmony = core.InformedCharacterModifier("엘리멘탈 하모니",patt = 10)
 
@@ -44,7 +48,7 @@ class JobGenerator(ck.JobGenerator):
         
         Gekgap = core.InformedCharacterModifier("극갑",pdamage = 5)
         NoiGe = core.InformedCharacterModifier("뇌제",att = 30)
-        NuckleExpert = core.InformedCharacterModifier("너클 숙련",att = 30, crit_damage = 20)
+        NuckleExpert = core.InformedCharacterModifier("너클 엑스퍼트",att = 30 + passive_level, crit_damage = 30 + passive_level)
         NoiShin = core.InformedCharacterModifier("뇌신",crit = 30, crit_damage = 25)
         
         SkyOpenPassive = core.InformedCharacterModifier("천지개벽(패시브)",pdamage_indep = 20)
@@ -57,8 +61,10 @@ class JobGenerator(ck.JobGenerator):
             SkyOpenPassive, LoadedDicePassive]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 70)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5 + 0.5*ceil(passive_level/2))
         
         return [WeaponConstant, Mastery]
         
@@ -80,22 +86,23 @@ class JobGenerator(ck.JobGenerator):
         
         모든 스킬은 쿨타임마다 사용
         '''
-        CHOOKROI = 0.7
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+        CHOOKROI = 0.7 + 0.01*passive_level
         #Buff skills
 
         Booster = core.BuffSkill("부스터", 0, 180000, rem = True).wrap(core.BuffSkillWrapper)
-        ChookRoi = core.BuffSkill("축뢰", 1620, 180000, rem = True).wrap(core.BuffSkillWrapper) # 타수증가 적용으로 계싼할지는 염두에 두어야 함
-        WindBooster = core.BuffSkill("윈드 부스터", 0, 300000, rem = True).wrap(core.BuffSkillWrapper)
-        HuricaneBuff = core.BuffSkill("태풍(버프)", 0, 90000, rem = True, pdamage = 35).wrap(core.BuffSkillWrapper)
+        ChookRoi = core.BuffSkill("축뢰", 1620, (180+5*self._combat)*1000, rem = True).wrap(core.BuffSkillWrapper) # 타수증가 적용으로 계싼할지는 염두에 두어야 함
+        WindBooster = core.BuffSkill("윈드 부스터", 0, (300+5*passive_level)*1000, rem = True).wrap(core.BuffSkillWrapper)
+        HuricaneBuff = core.BuffSkill("태풍(버프)", 0, (90+passive_level)*1000, rem = True, pdamage = 35).wrap(core.BuffSkillWrapper)
     
         LightningStack = LightningWrapper(core.BuffSkill("엘리멘탈 : 라이트닝", 0, 99999999))
 
-        HuricaneConcat = core.DamageSkill("태풍(연계)", 420, 390, 5+1, modifier = core.CharacterModifier(pdamage_indep = 20)).setV(vEhc, 0, 2).wrap(core.DamageSkillWrapper)
+        HuricaneConcat = core.DamageSkill("태풍(연계)", 420, 390+3*passive_level, 5+1, modifier = core.CharacterModifier(pdamage_indep = 20)).setV(vEhc, 0, 2).wrap(core.DamageSkillWrapper)
         
-        Destroy = core.DamageSkill("섬멸", 480, 350, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        Thunder = core.DamageSkill("벽력", 540, 320, 5 + 1).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        DestroyConcat = core.DamageSkill("섬멸(연계)", 480, 350, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20, pdamage_indep = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        ThunderConcat = core.DamageSkill("벽력(연계)", 540, 320, 5 + 1, modifier = core.CharacterModifier(pdamage_indep = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #연계최종뎀 20%
+        Destroy = core.DamageSkill("섬멸", 480, 350 + 4*self._combat, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        Thunder = core.DamageSkill("벽력", 540, 320 + 4*self._combat, 5 + 1).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        DestroyConcat = core.DamageSkill("섬멸(연계)", 480, 350 + 4*self._combat, 7, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20, pdamage_indep = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        ThunderConcat = core.DamageSkill("벽력(연계)", 540, 320 + 4*self._combat, 5 + 1, modifier = core.CharacterModifier(pdamage_indep = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)   #연계최종뎀 20%
 
         # 하이퍼
         # 딜레이 추가 필요

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -48,7 +48,7 @@ class JobGenerator(ck.JobGenerator):
         
         Gekgap = core.InformedCharacterModifier("극갑",pdamage = 5)
         NoiGe = core.InformedCharacterModifier("뇌제",att = 30)
-        NuckleExpert = core.InformedCharacterModifier("너클 엑스퍼트",att = 30 + passive_level, crit_damage = 30 + passive_level)
+        NuckleExpert = core.InformedCharacterModifier("너클 엑스퍼트",att = 30 + passive_level, crit_damage = 20 + passive_level // 2)
         NoiShin = core.InformedCharacterModifier("뇌신",crit = 30, crit_damage = 25)
         
         SkyOpenPassive = core.InformedCharacterModifier("천지개벽(패시브)",pdamage_indep = 20)

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -7,22 +7,22 @@ from . import globalSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
 from . import jobutils
+from math import ceil
 #TODO : 5차 신스킬 적용
 
 class EnergyChargeWrapper(core.StackSkillWrapper):
-    def __init__(self):
+    def __init__(self, combat):
         skill = core.BuffSkill("에너지차지 발동", 0, 999999*1000)
         super(EnergyChargeWrapper, self).__init__(skill, 10000)
         self.stack = 0
         self._st = 0
-
+        self.combat = combat
     def vary(self, val, force = False):
-#        print(" State : %d, %d \n vary %d" % (self.stack, self._st, val))
+        #print(" State : %d, %d \n vary %d" % (self.stack, self._st, val))
         if (force or not self._st) and val > 0:
             self.stack += val
         elif val < 0:
             self.stack += val
-            
         if self._st and self.stack <= 0:
             self.turnOff()
         elif (not self._st) and self.stack >= 10000:
@@ -31,7 +31,7 @@ class EnergyChargeWrapper(core.StackSkillWrapper):
             
     def turnOn(self):
         self.stack = 10000
-        self.skill.att = 50
+        self.skill.att = 50 + 2 * self.combat
         self._st = 1
 
     def turnOff(self):
@@ -42,7 +42,6 @@ class EnergyChargeWrapper(core.StackSkillWrapper):
     def isStateOn(self):
         return self._st
 
-
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
@@ -51,6 +50,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "바이퍼"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 1
+        self._combat = 0
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         CriticalRoar = core.InformedCharacterModifier("크리티컬 로어",crit = 20, crit_damage = 5)
@@ -69,13 +69,14 @@ class JobGenerator(ck.JobGenerator):
         return [CriticalRoar, MentalClearity, PhisicalTraining, CriticalRage, StimulatePassive, EchoOfHero, LoadedDicePassive]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 70)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5 + 0.5*ceil(self._combat/2))
 
         CriticalRage = core.InformedCharacterModifier("크리티컬 레이지(준액티브)",crit = 20)    #보스상대 추가+20% 크리율
-        GuardCrush = core.InformedCharacterModifier("가드 크러시",armor_ignore = 40) #40% 확률로 방무 100% 무시.
-        CounterAttack = core.InformedCharacterModifier("카운터 어택",pdamage = 25)  #피격시 25%로발동.
-        
+        GuardCrush = core.InformedCharacterModifier("가드 크러시",armor_ignore = 40 + 2*passive_level) #40% 확률로 방무 100% 무시.
+        CounterAttack = core.InformedCharacterModifier("카운터 어택",pdamage = 25 + 2*passive_level)  #피격시 25%로발동.
         
         return [WeaponConstant, Mastery, CriticalRage, GuardCrush, CounterAttack]
         
@@ -86,13 +87,14 @@ class JobGenerator(ck.JobGenerator):
         인레이지-노틸-드스-유니티
         '''
         ######   Skill   ######
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         serverlag = 3
 
         LuckyDice = core.BuffSkill("로디드 다이스", 600, 180 * 1000, pdamage = 20 *4/3).isV(vEhc, 2, 2).wrap(core.BuffSkillWrapper)#딜레이 모름
         #1중첩 럭다 재사용 50초 감소 / 방어력30% / 체엠 20% / 크리율15% / 뎀증20 / 경치30
         #2중첩 럭다 재사용 50초 감소 / 방어력40% / 체엠 30% / 크리율25% / 뎀증30 / 경치40
         #7 발동시 방무 20 -> 30
-        Viposition = core.BuffSkill("바이퍼지션", 0, 180 * 1000, patt = 30).wrap(core.BuffSkillWrapper)
+        Viposition = core.BuffSkill("바이퍼지션", 0, (180+4*self._combat) * 1000, patt = 30+self._combat).wrap(core.BuffSkillWrapper)
         Stimulate = core.BuffSkill("스티뮬레이트", 930, 120 * 1000, cooltime = 240 * 1000, pdamage = 20).wrap(core.BuffSkillWrapper)# 에너지 주기적으로 800씩 증가, 미완충시 풀완충.
         StimulateSummon = core.SummonSkill("스티뮬레이트(게이지 증가 더미)", 0, (5 + serverlag) * 1000, 0, 0, 120 * 1000).wrap(core.SummonSkillWrapper)
         
@@ -111,15 +113,15 @@ class JobGenerator(ck.JobGenerator):
         Transform = core.BuffSkill("트랜스 폼", 450, (50+vEhc.getV(1,1))*1000, cooltime = 180 * 1000, pdamage_indep = (20 + 0.2*vEhc.getV(1,1))).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)#에너지 완충
         TransformEnergyOrb = core.DamageSkill("에너지 오브", 1140, 450 +vEhc.getV(1,1)*18, (2+(vEhc.getV(1,1) == 25)*1) * 8, modifier = core.CharacterModifier(crit = 50, armor_ignore = 50)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
     
-        FistInrage = core.DamageSkill("피스트 인레이지", 690, 320, 8 + 1, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-        FistInrage_T = core.DamageSkill("피스트 인레이지(변신)", 690, 320, 8 + 1 + 2, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)#완충시 10번 공격
+        FistInrage = core.DamageSkill("피스트 인레이지", 690, 320 + 4*self._combat, 8 + 1, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        FistInrage_T = core.DamageSkill("피스트 인레이지(변신)", 690, 320+4*self._combat, 8 + 1 + 2, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)#완충시 10번 공격
         
-        DragonStrike = core.DamageSkill("드래곤 스트라이크", 690, 300, 12, cooltime = 15 * 1000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        DragonStrikeBuff = core.BuffSkill("드래곤 스트라이크(디버프)", 0, 15 * 1000, cooltime = -1, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
+        DragonStrike = core.DamageSkill("드래곤 스트라이크", 690, 300 + 4*self._combat, 12, cooltime = 15 * 1000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        DragonStrikeBuff = core.BuffSkill("드래곤 스트라이크(디버프)", 0, 15 * 1000, cooltime = -1, pdamage_indep = 20 + self._combat//2).wrap(core.BuffSkillWrapper)
         
-        Nautilus = core.DamageSkill("노틸러스", 690, 440, 7, cooltime = 60 * 1000).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        Nautilus = core.DamageSkill("노틸러스", 690, 440+4*self._combat, 7, cooltime = 60 * 1000).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         NautilusBuff = core.BuffSkill("노틸러스(버프)", 0, 60 * 1000, cooltime = -1).wrap(core.BuffSkillWrapper)
-        NautilusFinalAttack = core.DamageSkill("노틸러스(파이널 어택)", 0, 165, 2).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        NautilusFinalAttack = core.DamageSkill("노틸러스(파이널 어택)", 0, 165+2*self._combat, 2).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         SerpentScrew = core.SummonSkill("서펜트 스크류", 600, 285, 360 + vEhc.getV(0,0)*14, 3, 99999 * 10000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)    #보스 공격시 에너지 소모량 70% 감소, 틱당 에너지 85 소모.
         SerpentScrewDummy = core.SummonSkill("서펜트 스크류(지속)", 0, 1000, 0, 0, 99999 * 10000, cooltime = -1).wrap(core.SummonSkillWrapper)   #초당 에너지 60 소모 #보스 공격시 에너지 소모량 70% 감소, 틱당 에너지 85 소모.
@@ -127,7 +129,7 @@ class JobGenerator(ck.JobGenerator):
     
         FuriousCharge = core.DamageSkill("퓨리어스 차지", 540, 600+vEhc.getV(4,4)*24, 10, cooltime = 10 * 1000, modifier = core.CharacterModifier(boss_pdamage = 30)).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
         ######   Skill Wrapper   ######
-        EnergyCharge = EnergyChargeWrapper()
+        EnergyCharge = EnergyChargeWrapper(passive_level)
         EnergyCharge.set_name_style("게이지 %d만큼 변화")
         #1중첩 럭다 재사용 50초 감소 / 방어력30% / 체엠 20% / 크리율15% / 뎀증20 / 경치30
         #2중첩 럭다 재사용 50초 감소 / 방어력40% / 체엠 30% / 크리율25% / 뎀증30 / 경치40

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobbranch import bowmen
 from .jobclass import cygnus
+from math import ceil
 #TODO : 5차 신스킬 적용
 
 class JobGenerator(ck.JobGenerator):
@@ -16,21 +17,26 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "윈드브레이커"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self._use_critical_reinforce = True
+        self._combat = 0
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         ElementalExpert = core.InformedCharacterModifier("엘리멘탈 엑스퍼트", patt = 10)
         ElementalHarmony = core.InformedCharacterModifier("엘리멘탈 하모니", stat_main = chtr.level // 2)
         
         WhisperOfWind = core.InformedCharacterModifier("위스퍼 오브 윈드", att = 20)
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝", stat_main = 30, stat_sub = 30)
         
-        WindBlessingPassive = core.InformedCharacterModifier("윈드 블레싱(패시브)", pstat_main = 15, patt = 10 + self.combat*1)
-        BowExpert = core.InformedCharacterModifier("보우 엑스퍼트", att = 30 + self.combat*1, crit_damage = 20, pdamage_indep = 25 + self.combat*1, boss_pdamage = 40 + self.combat*1)
+        WindBlessingPassive = core.InformedCharacterModifier("윈드 블레싱(패시브)", pstat_main = 15+passive_level//3, patt = 10 + ceil(passive_level/3))
+        BowExpert = core.InformedCharacterModifier("보우 엑스퍼트", att = 30 + passive_level, crit_damage = 20+passive_level//2, pdamage_indep = 25 + passive_level//3, boss_pdamage = 40 + passive_level)
         return [ElementalExpert, ElementalHarmony, WhisperOfWind, PhisicalTraining, BowExpert, WindBlessingPassive]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
+
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 30)
-        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5 + self.combat*0.5)
+        Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5 + 0.5*ceil(passive_level / 2))
         
         return [WeaponConstant, Mastery]
 
@@ -45,16 +51,17 @@ class JobGenerator(ck.JobGenerator):
         트라이플링 윔 평균치로 계산
         
         '''
+        passive_level = chtr.get_base_modifier().passive_level + self._combat
         #Buff skills
         Storm = core.BuffSkill("엘리멘트(스톰)", 0, 200 * 1000, pdamage = 10, rem = True).wrap(core.BuffSkillWrapper) #딜레이 모름
         SylphsAid = core.BuffSkill("실프스 에이드", 0, 200 * 1000, att = 20, crit = 10, rem = True).wrap(core.BuffSkillWrapper) #딜레이 모름
-        Albatross = core.BuffSkill("알바트로스 맥시멈", 0, 200 * 1000, att = 50 + combat*1, pdamage = 25, armor_ignore = 15, crit = 25, rem = True).wrap(core.BuffSkillWrapper)  #900 -> 690
-        SharpEyes = core.BuffSkill("샤프 아이즈", 660, 300 * 1000, crit = 20 + combat*1, crit_damage = 15 + combat*1, rem = True).wrap(core.BuffSkillWrapper)
+        Albatross = core.BuffSkill("알바트로스 맥시멈", 0, 200 * 1000, att = 50 + passive_level, pdamage = 25+2*(passive_level//3), armor_ignore = 15+passive_level//3, crit = 25+passive_level//2, rem = True).wrap(core.BuffSkillWrapper)  #900 -> 690
+        SharpEyes = core.BuffSkill("샤프 아이즈", 660, (300+10*self._combat) * 1000, crit = 20 + ceil(self._combat/2), crit_damage = 15 + ceil(self._combat/2), rem = True).wrap(core.BuffSkillWrapper)
         GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60 * 1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
         StormBringerDummy = core.BuffSkill("스톰 브링어(버프)", 0, 200 * 1000).wrap(core.BuffSkillWrapper)  #딜레이 계산 필요
         # 하이퍼: 데미지 증가, 확률 10% 증가, 타수 증가
-        TriflingWhim = core.DamageSkill("트라이플링 윔", 0, (290 + combat*3) * 0.8 + (390 + combat*3) * 0.2, 2 * (0.5 + 0.1), modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        TriflingWhim = core.DamageSkill("트라이플링 윔", 0, (290 + passive_level*3) * 0.8 + (390 + passive_level*3) * 0.2, 2 * (0.5 + 0.1), modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         StormBringer = core.DamageSkill("스톰 브링어", 0, 500, 0.3).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
     
         # 핀포인트 피어스
@@ -63,7 +70,7 @@ class JobGenerator(ck.JobGenerator):
 
         #Damage Skills
         # 하이퍼: 데미지 증가, 보스 데미지 증가
-        SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + combat*3, 1, modifier = core.CharacterModifier(pdamage = ((1.2 + combat*0.01)**4 - 1) * 100 + 20, boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #코강렙 20이상 가정.
+        SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + self._combat*3, 1, modifier = core.CharacterModifier(pdamage = ((1.2 + self._combat*0.01)**4 - 1) * 100 + 20, boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #코강렙 20이상 가정.
         
         CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 600, 120 * 5, 450 + 18*vEhc.getV(0,0), 5, 120 * (40 + vEhc.getV(0,0)), cooltime = 30 * 1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         
@@ -89,7 +96,7 @@ class JobGenerator(ck.JobGenerator):
         Mercilesswind.onAfter(MercilesswindDOT)
 
         return(SongOfHeaven, 
-                [globalSkill.maple_heros(chtr.level, combat_level=combat), 
+                [globalSkill.maple_heros(chtr.level), 
                     Storm, SylphsAid, Albatross, SharpEyes, GloryOfGuardians, StormBringerDummy, CriticalReinforce,
                     PinPointPierceDebuff,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -39,20 +39,6 @@ class LimitBreakNew():
 # LimitBreak = LimitBreakSet.get_buff()
 '''
 
-'''
-beta_enrage
-
-대검 마스터리: 스킬 사용 시 공격 받은 적이 스킬의 최대 공격 가능한 몬스터 수보다 적을 때 1명 당 8%의 데미지 증가
-
-각각 베타 스킬에 꼭 적용해주세요. 툴팁에 나와있는 몬스터 수를 그대로 작성해주시면 됩니다.
-
-vlevel = 코어 20레벨 효과인 타겟 수 증가를 적용하기 위한 변수입니다. 5차 스킬은 레벨에 따른 타겟 수 증가가 없으니 -1으로 써주세요.
-'''
-def beta_enrage(target, vlevel):
-    if vlevel >= 20:
-        target += 1
-    return core.CharacterModifier(pdamage = 8 * (target - 1))
-
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
@@ -175,38 +161,42 @@ class JobGenerator(ck.JobGenerator):
         DivineLeer = core.DotSkill("디바인 리어", 200, 99999999).wrap(core.SummonSkillWrapper)
 
         #### 베타 ####
-        
 
-        UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        #대검 마스터리: 스킬 사용 시 공격 받은 적이 스킬의 최대 공격 가능한 몬스터 수보다 적을 때 1명 당 8%의 데미지 증가
+        #각각 베타 스킬에 꼭 적용해주세요. 툴팁에 나와있는 몬스터 수를 그대로 작성해주시면 됩니다.
+        #일반 스킬은 True, 5차 스킬은 False
+        beta_enrage = lambda x, y: core.CharacterModifier(pdamage = 8 * (x + int(y) - 1))
+
+        UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 210, 6, modifier = beta_enrage(6, True)).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6, modifier = beta_enrage(6, True)).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
-        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330 + 5*self._combat, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330 + 5*self._combat, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330 + 5*self._combat, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330 + 5*self._combat, 9, modifier = beta_enrage(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330 + 5*self._combat, 9, modifier = beta_enrage(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330 + 5*self._combat, 9, modifier = beta_enrage(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
         THROWINGHIT = 5
-        FlashCut = core.DamageSkill("프론트 슬래시", 630, 205, 6, modifier = beta_enrage(6, vEhc.getV(6, 2))).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 360, 300, 550 + 5*self._combat, 2, THROWINGHIT*300, cooltime=-1, modifier = beta_enrage(6, vEhc.getV(1, 2))).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
-        #ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550 + 5*self._combat, 2 * 5, modifier = beta_enrage(6, vEhc.getV(1 , 2))).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
+        FlashCut = core.DamageSkill("프론트 슬래시", 630, 205, 6, modifier = beta_enrage(6, True)).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 360, 300, 550 + 5*self._combat, 2, THROWINGHIT*300, cooltime=-1, modifier = beta_enrage(6, True)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
+        #ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550 + 5*self._combat, 2 * 5, modifier = beta_enrage(6, True)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
         
-        SpinDriver = core.DamageSkill("터닝 드라이브", 540, 260, 6, modifier = beta_enrage(6, vEhc.getV(2 , 2))).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 200+2*self._combat, 2*7, modifier = beta_enrage(6, vEhc.getV(3 , 2))).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
+        SpinDriver = core.DamageSkill("터닝 드라이브", 540, 260, 6, modifier = beta_enrage(6, True)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 200+2*self._combat, 2*7, modifier = beta_enrage(6, True)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
         
-        GigaCrash = core.DamageSkill("기가 크래시", 630, 250, 6, modifier = beta_enrage(6, vEhc.getV(7 , 2))).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        GigaCrashTAG = core.DamageSkill("기가 크래시(태그)", 0, 250, 6, modifier = beta_enrage(6, vEhc.getV(7 , 2))).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        GigaCrash = core.DamageSkill("기가 크래시", 630, 250, 6, modifier = beta_enrage(6, True)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        GigaCrashTAG = core.DamageSkill("기가 크래시(태그)", 0, 250, 6, modifier = beta_enrage(6, True)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
-        FallingStar = core.DamageSkill("점핑 크래시", 660, 225, 6, modifier = beta_enrage(6, vEhc.getV(8 , 2))).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        FallingStar = core.DamageSkill("점핑 크래시", 660, 225, 6, modifier = beta_enrage(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
         # 충격파 값 포함
-        FallingStarTAG = core.DamageSkill("점핑 크래시(태그)", 0, 225, 6, modifier = beta_enrage(6, vEhc.getV(8 , 2))).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
-        FallingStarWave = core.DamageSkill("점핑 크래시(충격파)", 0, 225, 3, modifier = beta_enrage(6, vEhc.getV(8 , 2))).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        FallingStarTAG = core.DamageSkill("점핑 크래시(태그)", 0, 225, 6, modifier = beta_enrage(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        FallingStarWave = core.DamageSkill("점핑 크래시(충격파)", 0, 225, 3, modifier = beta_enrage(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 380+3*self._combat, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 380+3*self._combat, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
+        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 380+3*self._combat, 10, modifier = beta_enrage(6, True)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 380+3*self._combat, 10, modifier = beta_enrage(6, True)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
         
-        AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(파동)", 0, 285+3*self._combat, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(파동)", 0, 285+3*self._combat, 10, modifier = beta_enrage(6, True)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
         #AdvancedEarthBreakElectric = core.DotSkill("어드밴스드 어스 브레이크(전기)", 340+3*self._combat, 5).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340+3*self._combat, 5, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340+3*self._combat, 5, modifier = beta_enrage(6, True)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
 
         DoubleTime = core.BuffSkill("래피드 타임", 0, 9999*10000, crit = 20, pdamage = 10).wrap(core.BuffSkillWrapper)
         TimeDistortion = core.BuffSkill("타임 디스토션", 540, 30000, cooltime = 240 * 1000, pdamage = 25).wrap(core.BuffSkillWrapper)
@@ -221,26 +211,26 @@ class JobGenerator(ck.JobGenerator):
         #### 5차 스킬 ####
         #5차스킬들 마스터리 알파/베타 구분해서 적용할것.
         
-        LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*vEhc.getV(0,0), 5, modifier = beta_enrage(15, -1)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*vEhc.getV(0,0), 5, modifier = beta_enrage(15, False)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         # 리미트 브레이크 중에는 디바인 포스 사용 (공격력 20 증가)
         LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+vEhc.getV(0,0)//2)*1000, pdamage_indep = (30+vEhc.getV(0,0)//5) *1.2 + 20, att = 20, cooltime = 240*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         
         #LimitBreakFinal = core.DamageSkill("리미트 브레이크 (막타)", 0, '''지속시간 동안 가한 데미지의 20% / 15''', 15)
         # 베타로 사용함.
-        TwinBladeOfTime = core.DamageSkill("조인트 어택", 0, 0, 0, cooltime = 120*1000, modifier = beta_enrage(12, -1)).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_1 = core.DamageSkill("조인트 어택(1)", 3480, 875+35*vEhc.getV(1,1), 8, modifier = beta_enrage(12, -1)).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_2 = core.DamageSkill("조인트 어택(2)", 0, 835+33*vEhc.getV(1,1), 8, modifier = beta_enrage(12, -1)).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_3 = core.DamageSkill("조인트 어택(3)", 0, 1000+40*vEhc.getV(1,1), 13, modifier = beta_enrage(12, -1)).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime = core.DamageSkill("조인트 어택", 0, 0, 0, cooltime = 120*1000, modifier = beta_enrage(12, False)).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_1 = core.DamageSkill("조인트 어택(1)", 3480, 875+35*vEhc.getV(1,1), 8, modifier = beta_enrage(12, False)).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_2 = core.DamageSkill("조인트 어택(2)", 0, 835+33*vEhc.getV(1,1), 8, modifier = beta_enrage(12, False)).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_3 = core.DamageSkill("조인트 어택(3)", 0, 1000+40*vEhc.getV(1,1), 13, modifier = beta_enrage(12, False)).wrap(core.DamageSkillWrapper)
         # 45타수가 시스템상으로 잘 반영되는지 확인필요.
-        TwinBladeOfTime_end = core.DamageSkill("조인트 어택(4)", 0, 900+36*vEhc.getV(1,1), 45, modifier = (beta_enrage(12, -1) + core.CharacterModifier(armor_ignore = 100))).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_end = core.DamageSkill("조인트 어택(4)", 0, 900+36*vEhc.getV(1,1), 45, modifier = (beta_enrage(12, False) + core.CharacterModifier(armor_ignore = 100))).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         
         #알파
         ShadowFlashAlpha = core.DamageSkill("쉐도우 플래시(알파)", 670, 500+20*vEhc.getV(2,2), 6, cooltime = 40*1000, red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         ShadowFlashAlphaEnd = core.DamageSkill("쉐도우 플래시(알파)(종료)", 0, 400+16*vEhc.getV(2,2), 15*3).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         #베타
-        ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 670, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, modifier = beta_enrage(8, -1), red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
-        ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 0, 750+30*vEhc.getV(2,2), 12 * 2, modifier = beta_enrage(8, -1)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 670, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, modifier = beta_enrage(8, False), red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 0, 750+30*vEhc.getV(2,2), 12 * 2, modifier = beta_enrage(8, False)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)
 

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -5,9 +5,10 @@ from functools import partial
 from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobbranch import warriors
+from math import ceil
 
 # TODO: 4카 5앱 적용, 리미트 막타 추가
-
+# 제로는 패시브 레벨 +1 어빌 미적용
 
 # 현재로는 계산 알고리즘 작성 구문에서 연산과정에 접근을 할 수 없도록 캡슐화되어 있으므로 사용 불가능
 '''
@@ -61,6 +62,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "제로"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 2
+        self._combat = 0
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
@@ -146,17 +148,17 @@ class JobGenerator(ck.JobGenerator):
         _StormBreak = core.DamageSkill("스톰 브레이크", 690, 335, 10 ).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         ### Dummy SKill End 
 
-        AdvancedSpinCutter = core.DamageSkill("어드밴스드 스핀 커터", 630, 260, 10 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedSpinCutterTAG = core.DamageSkill("어드밴스드 스핀 커터(태그)", 0, 260, 10 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedSpinCutterAura = core.DamageSkill("어드밴스드 스핀 커터(오라)", 0, 130, 4 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedSpinCutter = core.DamageSkill("어드밴스드 스핀 커터", 630, 260+3*self._combat, 10 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedSpinCutterTAG = core.DamageSkill("어드밴스드 스핀 커터(태그)", 0, 260+3*self._combat, 10 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedSpinCutterAura = core.DamageSkill("어드밴스드 스핀 커터(오라)", 0, 130+3*self._combat, 4 ).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedRollingCurve = core.DamageSkill("어드밴스드 롤링 커브", 960, 365, 12 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingCurveTAG = core.DamageSkill("어드밴스드 롤링 커브(태그)", 0, 365, 12 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingCurveAura = core.DamageSkill("어드밴스드 롤링 커브(오라)", 0, 350, 2 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingCurve = core.DamageSkill("어드밴스드 롤링 커브", 960, 365+3*self._combat, 12 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingCurveTAG = core.DamageSkill("어드밴스드 롤링 커브(태그)", 0, 365+3*self._combat, 12 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingCurveAura = core.DamageSkill("어드밴스드 롤링 커브(오라)", 0, 350+self._combat, 2 ).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedRollingAssulter = core.DamageSkill("어드밴스드 롤링 어썰터", 960, 375, 12 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingAssulterTAG = core.DamageSkill("어드밴스드 롤링 어썰터(태그)", 0, 375, 12 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingAssulterAura = core.DamageSkill("어드밴스드 롤링 어썰터(오라)", 0, 250, 3 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingAssulter = core.DamageSkill("어드밴스드 롤링 어썰터", 960, 375+2*self._combat, 12 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingAssulterTAG = core.DamageSkill("어드밴스드 롤링 어썰터(태그)", 0, 375+2*self._combat, 12 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingAssulterAura = core.DamageSkill("어드밴스드 롤링 어썰터(오라)", 0, 250+self._combat, 3 ).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
         WindCutter = core.DamageSkill("윈드 커터", 540, 165, 8 ).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         WindCutterSummon = core.SummonSkill("윈드 커터(소환)", 0, 500, 110, 3, 3000, cooltime=-1).setV(vEhc, 7, 2, False).wrap(core.SummonSkillWrapper)
@@ -164,11 +166,11 @@ class JobGenerator(ck.JobGenerator):
 
         WindStrike = core.DamageSkill("윈드 스트라이크",600, 250, 8).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
 
-        StormBreak = core.DamageSkill("어드밴스드 스톰 브레이크", 690, 335, 10 ).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        StormBreakSummon = core.SummonSkill("어드밴스드 스톰 브레이크(소환)", 0, 500, 335, 4, 3000, cooltime=-1).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        #StormBreakSummon = core.DamageSkill("어드밴스드 스톰 브레이크(소환)", 0, 335, 4).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) #2타 타격
-        #StormBreakElectric = core.DotSkill("어드밴스드 스톰 브레이크(전기)", 230, 3000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        StormBreakElectric = core.DamageSkill("어드밴스드 스톰 브레이크(전기)", 0, 230, 3 ).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        StormBreak = core.DamageSkill("어드밴스드 스톰 브레이크", 690, 335+2*self._combat, 10 ).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        StormBreakSummon = core.SummonSkill("어드밴스드 스톰 브레이크(소환)", 0, 500, 335+2*self._combat, 4, 3000, cooltime=-1).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        #StormBreakSummon = core.DamageSkill("어드밴스드 스톰 브레이크(소환)", 0, 335+2*self._combat, 4).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) #2타 타격
+        #StormBreakElectric = core.DotSkill("어드밴스드 스톰 브레이크(전기)", 230+2*self._combat, (3+ ceil(self._combat /10))*1000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        StormBreakElectric = core.DamageSkill("어드밴스드 스톰 브레이크(전기)", 0, 230+2*self._combat, 3+ceil(self._combat /10)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
 
         DivineLeer = core.DotSkill("디바인 리어", 200, 99999999).wrap(core.SummonSkillWrapper)
 
@@ -178,17 +180,17 @@ class JobGenerator(ck.JobGenerator):
         UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6, modifier = beta_enrage(6, vEhc.getV(5 , 3))).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
-        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330 + 5*self._combat, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330 + 5*self._combat, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330 + 5*self._combat, 9, modifier = beta_enrage(6, vEhc.getV(0 , 3))).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
         THROWINGHIT = 5
         FlashCut = core.DamageSkill("프론트 슬래시", 630, 205, 6, modifier = beta_enrage(6, vEhc.getV(6, 2))).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 360, 300, 550, 2, THROWINGHIT*300, cooltime=-1, modifier = beta_enrage(6, vEhc.getV(1, 2))).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
-        #ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550, 2 * 5, modifier = beta_enrage(6, vEhc.getV(1 , 2))).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
+        ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 360, 300, 550 + 5*self._combat, 2, THROWINGHIT*300, cooltime=-1, modifier = beta_enrage(6, vEhc.getV(1, 2))).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
+        #ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550 + 5*self._combat, 2 * 5, modifier = beta_enrage(6, vEhc.getV(1 , 2))).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
         
         SpinDriver = core.DamageSkill("터닝 드라이브", 540, 260, 6, modifier = beta_enrage(6, vEhc.getV(2 , 2))).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 200, 2*7, modifier = beta_enrage(6, vEhc.getV(3 , 2))).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
+        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 200+2*self._combat, 2*7, modifier = beta_enrage(6, vEhc.getV(3 , 2))).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
         
         GigaCrash = core.DamageSkill("기가 크래시", 630, 250, 6, modifier = beta_enrage(6, vEhc.getV(7 , 2))).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         GigaCrashTAG = core.DamageSkill("기가 크래시(태그)", 0, 250, 6, modifier = beta_enrage(6, vEhc.getV(7 , 2))).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
@@ -198,13 +200,13 @@ class JobGenerator(ck.JobGenerator):
         FallingStarTAG = core.DamageSkill("점핑 크래시(태그)", 0, 225, 6, modifier = beta_enrage(6, vEhc.getV(8 , 2))).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
         FallingStarWave = core.DamageSkill("점핑 크래시(충격파)", 0, 225, 3, modifier = beta_enrage(6, vEhc.getV(8 , 2))).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 380, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 380, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
+        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 380+3*self._combat, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 380+3*self._combat, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
         
-        AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(파동)", 0, 285, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(파동)", 0, 285+3*self._combat, 10, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
-        #AdvancedEarthBreakElectric = core.DotSkill("어드밴스드 어스 브레이크(전기)", 340, 5).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340, 5, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        #AdvancedEarthBreakElectric = core.DotSkill("어드밴스드 어스 브레이크(전기)", 340+3*self._combat, 5).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340+3*self._combat, 5, modifier = beta_enrage(6, vEhc.getV(4 , 2))).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
 
         DoubleTime = core.BuffSkill("래피드 타임", 0, 9999*10000, crit = 20, pdamage = 10).wrap(core.BuffSkillWrapper)
         TimeDistortion = core.BuffSkill("타임 디스토션", 540, 30000, cooltime = 240 * 1000, pdamage = 25).wrap(core.BuffSkillWrapper)


### PR DESCRIPTION
제로까지 끝마쳤습니다. 

미하일
* 영메 렙차 적용여부

나이트로드
* 써든레이드 미구현
* 베놈 타수 분리 필요

팔라딘
* ~어드밴스드 차지 미구현 (컴뱃 영향은 안받음)~
* ~생츄어리 미적용~

패스파인더
* 기능상 이상은 없으나 여러 패시브 스킬들이 혼합되어 있어 정리 필요

섀도어
* 써든레이드 미사용

바이퍼
* 파이널어택 미적용
* 럭키 다이스 미적용

와일드헌터
* `super(core.DamageSkillWrapper, self).__init__(skill, 3)` 오류로 인한 테스트 불가
* 드릴 컨테이너, 재규어 맥시멈 미구현
* 윌 오브 리버티 미사용

제로
* 어드밴스드 스톰 브레이크, 어드밴스드 어스 브레이크 전기지역 스킬 도트화해야함