### PR TITLE
fix: 썬콜 빙결 중첩

### DIFF
--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -95,8 +95,8 @@ class JobGenerator(ck.JobGenerator):
         FrozenOrbEjac = core.SummonSkill("프로즌 오브", 690, 210, 220+4*combat, 1, 4000, cooltime = 5000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
     
         LighteningSpear = core.DamageSkill("라이트닝 스피어", 0, 0, 1, cooltime = 75 * 1000).wrap(core.DamageSkillWrapper)
-        LighteningSpearSingle = core.DamageSkill("라이트닝 스피어(단일)", 270, 200, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
-        LighteningSpearFinalizer = core.DamageSkill("라이트닝 스피어 막타", 1080, 1500, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        LighteningSpearSingle = core.DamageSkill("라이트닝 스피어(키다운)", 270, 200, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        LighteningSpearFinalizer = core.DamageSkill("라이트닝 스피어(막타)", 1080, 1500, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         IceAgeInit = core.DamageSkill("아이스 에이지(개시)", 660, 500 + vEhc.getV(2,3)*20, 10, cooltime = 60 * 1000, red = True).isV(vEhc,2,3).wrap(core.DamageSkillWrapper)
         IceAgeSummon = core.SummonSkill("아이스 에이지(장판)", 0, 810, 125 + vEhc.getV(2,3)*5, 3, 15 * 1000, cooltime = -1).isV(vEhc,2,3).wrap(core.SummonSkillWrapper)
@@ -141,12 +141,12 @@ class JobGenerator(ck.JobGenerator):
         FrozenOrbEjac.onTick(BlizzardPassive)
 
         #Lightening Spear
-        LighteningSpearSingle.onAfter(BlizzardPassive)
         LighteningSpearSingle.add_runtime_modifier(FrostEffect, applyFrostEffect)
         LighteningSpearSingle.onAfter(FrostDecrement)
-        LighteningSpearFinalizer.onAfter(BlizzardPassive)
+        LighteningSpearSingle.onAfter(BlizzardPassive)
         LighteningSpearFinalizer.add_runtime_modifier(FrostEffect, applyFrostEffect)
         LighteningSpearFinalizer.onAfter(FrostDecrement)
+        LighteningSpearFinalizer.onAfter(BlizzardPassive)
         
         LighteningRepeator = core.RepeatElement(LighteningSpearSingle, 30)
         LighteningRepeator.onAfter(LighteningSpearFinalizer)
@@ -154,20 +154,21 @@ class JobGenerator(ck.JobGenerator):
         LighteningSpear.onAfter(LighteningRepeator)
         
         #damage skills
-        ChainLightening.onAfter(BlizzardPassive)
+        ChainLightening.add_runtime_modifier(FrostEffect, applyFrostEffect)
         ChainLightening.onAfter(FrostDecrement)
+        ChainLightening.onAfter(BlizzardPassive)
 
         ThunderStorm.add_runtime_modifier(FrostEffect, applyFrostEffect)
         
         IceAgeSummon.onTicks([BlizzardPassive, FrostIncrement])
-        IceAgeInit.onBefore(FrostIncrement)
+        IceAgeInit.onAfter(FrostIncrement)
         IceAgeInit.onAfter(BlizzardPassive)
         IceAgeInit.onAfter(IceAgeSummon)
         
         Elquiness.onTick(FrostIncrement)
         
-        Blizzard.onBefore(FrostIncrement)
-        BlizzardPassive.onBefore(FrostEffect.stackController(0.6))
+        Blizzard.onAfter(FrostIncrement)
+        BlizzardPassive.onAfter(FrostEffect.stackController(0.6))
         
         SpiritOfSnow.onTick(FrostEffect.stackController(3))
         

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -95,7 +95,7 @@ class JobGenerator(ck.JobGenerator):
         FrozenOrbEjac = core.SummonSkill("프로즌 오브", 690, 210, 220+4*combat, 1, 4000, cooltime = 5000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
     
         LighteningSpear = core.DamageSkill("라이트닝 스피어", 0, 0, 1, cooltime = 75 * 1000).wrap(core.DamageSkillWrapper)
-        LighteningSpearSingle = core.DamageSkill("라이트닝 스피어(키다운)", 270, 200, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        LighteningSpearSingle = core.DamageSkill("라이트닝 스피어(키다운)", 267, 200, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper) # 총 8010ms
         LighteningSpearFinalizer = core.DamageSkill("라이트닝 스피어(막타)", 1080, 1500, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         IceAgeInit = core.DamageSkill("아이스 에이지(개시)", 660, 500 + vEhc.getV(2,3)*20, 10, cooltime = 60 * 1000, red = True).isV(vEhc,2,3).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -86,7 +86,7 @@ class JobGenerator(ck.JobGenerator):
         ######   Skill   ######
         #Buff skills
         Meditation = core.BuffSkill("메디테이션", 0, 240*1000, att = 30, rem = True, red = True).wrap(core.BuffSkillWrapper)
-        EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10, red = True).wrap(core.BuffSkillWrapper)
+        EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         OverloadMana = magicians.OverloadManaWrapper(vEhc, 1, 2)
         
         #Damage Skills
@@ -142,10 +142,10 @@ class JobGenerator(ck.JobGenerator):
 
         #Lightening Spear
         LighteningSpearSingle.add_runtime_modifier(FrostEffect, applyFrostEffect)
-        LighteningSpearSingle.onAfter(FrostDecrement)
+        LighteningSpearSingle.onJustAfter(FrostDecrement)
         LighteningSpearSingle.onAfter(BlizzardPassive)
         LighteningSpearFinalizer.add_runtime_modifier(FrostEffect, applyFrostEffect)
-        LighteningSpearFinalizer.onAfter(FrostDecrement)
+        LighteningSpearFinalizer.onJustAfter(FrostDecrement)
         LighteningSpearFinalizer.onAfter(BlizzardPassive)
         
         LighteningRepeator = core.RepeatElement(LighteningSpearSingle, 30)
@@ -155,20 +155,20 @@ class JobGenerator(ck.JobGenerator):
         
         #damage skills
         ChainLightening.add_runtime_modifier(FrostEffect, applyFrostEffect)
-        ChainLightening.onAfter(FrostDecrement)
+        ChainLightening.onJustAfter(FrostDecrement)
         ChainLightening.onAfter(BlizzardPassive)
 
         ThunderStorm.add_runtime_modifier(FrostEffect, applyFrostEffect)
         
         IceAgeSummon.onTicks([BlizzardPassive, FrostIncrement])
-        IceAgeInit.onAfter(FrostIncrement)
+        IceAgeInit.onJustAfter(FrostIncrement)
         IceAgeInit.onAfter(BlizzardPassive)
         IceAgeInit.onAfter(IceAgeSummon)
         
         Elquiness.onTick(FrostIncrement)
         
-        Blizzard.onAfter(FrostIncrement)
-        BlizzardPassive.onAfter(FrostEffect.stackController(0.6))
+        Blizzard.onJustAfter(FrostIncrement)
+        BlizzardPassive.onJustAfter(FrostEffect.stackController(0.6))
         
         SpiritOfSnow.onTick(FrostEffect.stackController(3))
         
@@ -176,7 +176,7 @@ class JobGenerator(ck.JobGenerator):
         
         for node in [ThunderBrake1, ThunderBrake2, ThunderBrake3, ThunderBrake4, ThunderBrake5, ThunderBrake6, ThunderBrake7, ThunderBrake8]:
             node.add_runtime_modifier(FrostEffect, applyFrostEffect)
-            node.onAfter(FrostDecrement)
+            node.onJustAfter(FrostDecrement)
             node.onAfter(BlizzardPassive)
             node_before.onAfter(node)
         


### PR DESCRIPTION
* 체인 라이트닝에 프로스트 이펙트 적용되지 않은것 수정
* 공격-중첩감소-블리자드 순으로 항상 연결되도록 함
* 스택 증감을 onJustAfter 타이밍으로 일괄 변경
  * onAfter으로 하면 데미지 계산 직전에 스택이 줄어들어 스택이 낮게 적용되는 문제가 있었음
* 에픽 어드벤처에 쿨감 적용 안되게 수정
* 라이트닝 스피어 키다운 총 시간 8010ms가 되도록 변경