### PR TITLE
전직업 메용 적용 및 스킬명 변경

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -110,7 +110,7 @@ class JobGenerator():
     
     from . import globalSkill
     self.preEmptiveSkills = 2
-    globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster()
+    globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster()
     globalSkill.soul_contract()
     
     미하일까지..

--- a/dpmModule/character/readme.md
+++ b/dpmModule/character/readme.md
@@ -150,7 +150,7 @@ JobGenerator
         ```python
         return (Paralyze, 
                 [Infinity, Meditation, EpicAdventure, OverloadMana.ensure(vEhc,1,5),
-                globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                 SoulContract] +\
                 [DotPunisher.ensure(vEhc,0,0), Meteor, MegidoFlame, FlameHeize, PoisonNova.ensure(vEhc,2,1)] +\
                 [Ifritt, FireAura, FuryOfIfritt.ensure(vEhc,3,2),

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -243,7 +243,7 @@ class JobGenerator(ck.JobGenerator):
         Shard.protect_from_running()
 
         return(Divide,
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), ResonanceStack, GraveDebuff, WraithOfGod, Restore,
+                [globalSkill.maple_heros(chtr.level, name = "레프의 용사", combat_level=self._combat), ResonanceStack, GraveDebuff, WraithOfGod, Restore,
                     AuraWeaponBuff, AuraWeapon, MagicCircuitFullDrive, 
                     globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()] +\
                 [Resonance, Grave, Blossom, Marker, Ruin] +\

--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -243,7 +243,7 @@ class JobGenerator(ck.JobGenerator):
         Shard.protect_from_running()
 
         return(Divide,
-                [globalSkill.maple_heros(chtr.level), ResonanceStack, GraveDebuff, WraithOfGod, Restore,
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), ResonanceStack, GraveDebuff, WraithOfGod, Restore,
                     AuraWeaponBuff, AuraWeapon, MagicCircuitFullDrive, 
                     globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()] +\
                 [Resonance, Grave, Blossom, Marker, Ruin] +\

--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -137,7 +137,7 @@ class JobGenerator(ck.JobGenerator):
                 [Booster, SoulGaze, LuckyDice, FinalContract,
                     SoulExult, SoulContract,Overdrive, OverdrivePenalty,
                     FinaturaFettucciaBuff, SpotLightBuff, MascortFamilier,
-                    globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster()] +\
+                    globalSkill.maple_heros(chtr.level, name = "노바의 용사", combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster()] +\
                 [FinaturaFettuccia, EnergyBurst] +\
                 [SuperNova, MascortFamilierAttack, ShinyBubbleBreath, SpotLight] +\
                 [] +\

--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -137,7 +137,7 @@ class JobGenerator(ck.JobGenerator):
                 [Booster, SoulGaze, LuckyDice, FinalContract,
                     SoulExult, SoulContract,Overdrive, OverdrivePenalty,
                     FinaturaFettucciaBuff, SpotLightBuff, MascortFamilier,
-                    globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster()] +\
+                    globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster()] +\
                 [FinaturaFettuccia, EnergyBurst] +\
                 [SuperNova, MascortFamilierAttack, ShinyBubbleBreath, SpotLight] +\
                 [] +\

--- a/dpmModule/jobs/aran.py
+++ b/dpmModule/jobs/aran.py
@@ -233,7 +233,7 @@ class JobGenerator(ck.JobGenerator):
         AdrenalineGenerator.onConstraint(core.ConstraintElement('아드레날린부스트가 불가능할때', AdrenalineBoost, AdrenalineBoost.is_not_active))
         AdrenalineGenerator.onAfter(AdrenalineBoost)
         return(BasicAttack, 
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), HerosOath,
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), HerosOath,
                     Booster, SmashSwingIncr, SnowCharge, AdvancedComboAbility, ComboAbility,
                     BlessingMaha, AdrenalineBoost, AdrenalineBoostEndDummy,
                     AdrenalineGenerator, 

--- a/dpmModule/jobs/archmageFb.py
+++ b/dpmModule/jobs/archmageFb.py
@@ -141,7 +141,7 @@ class JobGenerator(ck.JobGenerator):
 
         return (Paralyze, 
                 [Infinity, Meditation, EpicAdventure, OverloadMana.ensure(vEhc,1,5),
-                globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                 SoulContract] +\
                 [DotPunisher.ensure(vEhc,0,0), Meteor, MegidoFlame, FlameHeize, MistEruption, PoisonNova.ensure(vEhc,2,1)] +\
                 [Ifritt, FireAura, FuryOfIfritt.ensure(vEhc,3,2),

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -190,7 +190,7 @@ class JobGenerator(ck.JobGenerator):
 
         return(ChainLightening,
                 [Infinity, Meditation, EpicAdventure, OverloadMana, FrostEffect,
-                globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                 SoulContract] +\
                 [IceAgeInit, Blizzard, LighteningSpear, ThunderBrake] +\
                 [ThunderStorm, Elquiness, IceAura, IceAgeSummon, FrozenOrbEjac, SpiritOfSnow] +\

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -432,7 +432,7 @@ class JobGenerator(ck.JobGenerator):
                     LuckyDice, Overdrive, OverdrivePenalty,
                     MagicCircuitFullDrive, MemoryOfSourceBuff, EndlessPainBuff,
                     InfinitySpell,
-                    globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()
+                    globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()
                     ] +\
                 [EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, 
                     CrawlingFear_Link, MemoryOfSource, EndlessPain, RaptRestriction, ReturningHate, Impulse_Connected,

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -432,7 +432,7 @@ class JobGenerator(ck.JobGenerator):
                     LuckyDice, Overdrive, OverdrivePenalty,
                     MagicCircuitFullDrive, MemoryOfSourceBuff, EndlessPainBuff,
                     InfinitySpell,
-                    globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()
+                    globalSkill.maple_heros(chtr.level, name = "레프의 용사", combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()
                     ] +\
                 [EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, 
                     CrawlingFear_Link, MemoryOfSource, EndlessPain, RaptRestriction, ReturningHate, Impulse_Connected,

--- a/dpmModule/jobs/battlemage.py
+++ b/dpmModule/jobs/battlemage.py
@@ -138,7 +138,7 @@ class JobGenerator(ck.JobGenerator):
         # 쓸윈 제거 ([너브 스티뮬레이션] : 공격 속도가 1단계 증가하는 기능이 추가됩니다.)
         return(FinishBlowEndpoint,
                 [Booster, WillOfLiberty, MasterOfDeath, UnionAura,
-                globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), #globalSkill.useful_wind_booster(),
+                globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), #globalSkill.useful_wind_booster(),
                 globalSkill.soul_contract()] +\
                 [DarkGenesis, BattlekingBar] +\
                 [RegistanceLineInfantry, Death, DeathAfterMOD, BlackMagicAlter, GrimReaper] +\

--- a/dpmModule/jobs/blaster.py
+++ b/dpmModule/jobs/blaster.py
@@ -219,7 +219,7 @@ class JobGenerator(ck.JobGenerator):
         SoulContract.protect_from_running()
         
         return(Mag_Pang,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
                     Booster, MaximizeCannon, WillOfLiberty, AuraWeaponBuff, AuraWeapon, BunkerBuster, Cylinder, Overheat, HammerSmashDebuff,
                     SoulContract] +\
                 [ReleaseHammer, BurningBreaker, BalkanPunch] +\

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -200,7 +200,7 @@ class JobGenerator(ck.JobGenerator):
 
         ### Exports ###
         return(ArrowOfStorm,
-                [globalSkill.maple_heros(chtr.level),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat),
                     SoulArrow, AdvancedQuibber, SharpEyes, ElusionStep, Preparation, EpicAdventure, ArmorPiercing,
                     ArrowRainBuff, CriticalReinforce, QuibberFullBurstBuff, QuibberFullBurstDOT, ImageArrowPassive,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/cadena.py
+++ b/dpmModule/jobs/cadena.py
@@ -334,7 +334,7 @@ class JobGenerator(ck.JobGenerator):
         VenomBurst.set_disabled_and_time_left(1)
 
         return(NormalAttack,
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, name = "노바의 용사", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     WeaponVariety, Booster, SpecialPotion, ProfessionalAgent,
                     ReadyToDie, ChainArts_Fury, 
                     SummonSlachingKnife_Horror, SummonBeatingNeedlebat_Honmy, VenomBurst_Poison, ChainArts_Maelstorm_Slow,

--- a/dpmModule/jobs/cadena.py
+++ b/dpmModule/jobs/cadena.py
@@ -334,7 +334,7 @@ class JobGenerator(ck.JobGenerator):
         VenomBurst.set_disabled_and_time_left(1)
 
         return(NormalAttack,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     WeaponVariety, Booster, SpecialPotion, ProfessionalAgent,
                     ReadyToDie, ChainArts_Fury, 
                     SummonSlachingKnife_Horror, SummonBeatingNeedlebat_Honmy, VenomBurst_Poison, ChainArts_Maelstorm_Slow,

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -115,7 +115,7 @@ class JobGenerator(ck.JobGenerator):
         SpecialMonkeyEscort_Canon.onAfter(SpecialMonkeyEscort_Boom)
     
         return(CanonBuster,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Booster, MonkeyWaveBuff, MonkeyFuriousBuff, MonkeyFuriousDot, OakRulet, Buckshot, MonkeyMagic,
                     EpicAdventure, LuckyDice, Overdrive, OverdrivePenalty, PirateFlag,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/captain.py
+++ b/dpmModule/jobs/captain.py
@@ -163,7 +163,7 @@ class JobGenerator(ck.JobGenerator):
     
         QuickDraw.set_disabled_and_time_left(-1)
         return (RapidFire,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     SummonCrewBuff, PirateStyle, Booster, InfiniteBullet, LuckyDice, UnwierdingNectar, EpicAdventure, PirateFlag, Overdrive, OverdrivePenalty,
                     BattleshipBomber_1_ON, BattleshipBomber_2_ON, QuickDraw,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/darknight.py
+++ b/dpmModule/jobs/darknight.py
@@ -128,7 +128,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
         
         return(BasicAttackWrapped, 
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     Booster, CrossoverChain, Sacrifice, Reincarnation,EpicAdventure, DarkThurst, AuraWeaponBuff, AuraWeapon,
                     globalSkill.soul_contract()] +\
                 [BiholderShock, GoungnilDescent, DarkSpear, PierceCyclone] +\

--- a/dpmModule/jobs/demonavenger.py
+++ b/dpmModule/jobs/demonavenger.py
@@ -155,7 +155,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
         
         return(BasicAttackWrapper,
-               [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+               [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     Booster, DevilCryBuff, InfinityForce, Metamorphosis, BlueBlood, DemonFortitude, AuraWeaponBuff, AuraWeapon, DemonAwakning,
                     globalSkill.soul_contract()] +\
                 [Execution, Cerberus, DevilCry, SpiritOfRageEnd] +\

--- a/dpmModule/jobs/demonavenger.py
+++ b/dpmModule/jobs/demonavenger.py
@@ -155,7 +155,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
         
         return(BasicAttackWrapper,
-               [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+               [globalSkill.useful_sharp_eyes(),
                     Booster, DevilCryBuff, InfinityForce, Metamorphosis, BlueBlood, DemonFortitude, AuraWeaponBuff, AuraWeapon, DemonAwakning,
                     globalSkill.soul_contract()] +\
                 [Execution, Cerberus, DevilCry, SpiritOfRageEnd] +\

--- a/dpmModule/jobs/demonslayer.py
+++ b/dpmModule/jobs/demonslayer.py
@@ -143,7 +143,7 @@ class JobGenerator(ck.JobGenerator):
             jobutils.create_auxilary_attack(sk, 0.9, "(블루 블러드)")
 
         return(BasicAttackWrapper,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     Booster, DemonSlashRemainTime, DemonSlashTrigger, DevilCryBuff, InfinityForce, Metamorphosis, BlueBlood, DemonFortitude, AuraWeaponBuff, AuraWeapon, DemonAwakning,
                     globalSkill.soul_contract()] +\
                 [Cerberus, DevilCry, SpiritOfRageEnd] +\

--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -133,7 +133,7 @@ class JobGenerator(ck.JobGenerator):
             jobutils.create_auxilary_attack(sk, 0.7, nametag = '(미러이미징)')
         
         return(PhantomBlow,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     Booster, DarkSight, FinalCutBuff, EpicAdventure, FlashBangDebuff, HiddenBladeBuff, UltimateDarksight, ReadyToDie,
                     globalSkill.soul_contract()] +\
                 [FinalCut, FlashBang, BladeTornado, SuddenRaid, KarmaFury, BladeStorm, Asura] +\

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -194,7 +194,7 @@ class JobGenerator(ck.JobGenerator):
         SpiritFrenzy.onConstraint(SpiritFrenzyConstraint)
 
         return(BasicAttackWrapper, 
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     EnhanceSpiritLink, LuckyDice, HerosOath, Frid, 
                     Overdrive, OverdrivePenalty, SoulConcentrate, DoubleBody, SoulTrapStack,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/evan.py
+++ b/dpmModule/jobs/evan.py
@@ -216,7 +216,7 @@ class JobGenerator(ck.JobGenerator):
             i.onAfter(DragonSparking)
             
         return(CircleOfMana,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     OverloadMana, Booster, OnixBless, Frid, HerosOath, SwiftBack, ElementalBlastBuff,
                     globalSkill.soul_contract()] +\
                 [ZodiakRayInit, DragonBreak, MagicParticle] +\

--- a/dpmModule/jobs/flamewizard.py
+++ b/dpmModule/jobs/flamewizard.py
@@ -118,7 +118,7 @@ class JobGenerator(ck.JobGenerator):
         SavageFlame.onAfter(SavageFlameStack.stackController(-15))
         
         return (OrbitalFlame,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     WordOfFire, FiresOfCreation, BurningRegion, GloryOfGuardians, OverloadMana, Flame,
                     globalSkill.soul_contract()] +\
                 [CygnusPalanks, BlazingOrbital, DragonSlaveInit, SavageFlame, InfinityFlameCircleInit, 

--- a/dpmModule/jobs/flamewizard.py
+++ b/dpmModule/jobs/flamewizard.py
@@ -118,7 +118,7 @@ class JobGenerator(ck.JobGenerator):
         SavageFlame.onAfter(SavageFlameStack.stackController(-15))
         
         return (OrbitalFlame,
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     WordOfFire, FiresOfCreation, BurningRegion, GloryOfGuardians, OverloadMana, Flame,
                     globalSkill.soul_contract()] +\
                 [CygnusPalanks, BlazingOrbital, DragonSlaveInit, SavageFlame, InfinityFlameCircleInit, 

--- a/dpmModule/jobs/hero.py
+++ b/dpmModule/jobs/hero.py
@@ -174,7 +174,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
 
         return(RaisingBlowInrage,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(), globalSkill.useful_combat_orders(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(), globalSkill.useful_combat_orders(),
                     ComboAttack, Fury, EpicAdventure, Valhalla, 
                     InsizingBuff, InsizingDot, AuraWeaponBuff, AuraWeapon, ComboDesfortBuff, 
                     ComboInstinct, ComboInstinctOff, PanicBuff,

--- a/dpmModule/jobs/hoyoung.py
+++ b/dpmModule/jobs/hoyoung.py
@@ -152,4 +152,4 @@ class JobGenerator(ck.JobGenerator):
         Sage_Elemental_Clone_Attack_Opt = core.OptionalElement(Sage_Elemental_Clone_Attack.is_active(), Sage_Elemental_Clone_Attack_Active_Opt, Sage_Elemental_Clone_Attack_Passive_Opt)
 
 
-        return()
+        return(globalSkill.maple_heros(chtr.level, combat_level=self._combat))

--- a/dpmModule/jobs/hoyoung.py
+++ b/dpmModule/jobs/hoyoung.py
@@ -152,4 +152,4 @@ class JobGenerator(ck.JobGenerator):
         Sage_Elemental_Clone_Attack_Opt = core.OptionalElement(Sage_Elemental_Clone_Attack.is_active(), Sage_Elemental_Clone_Attack_Active_Opt, Sage_Elemental_Clone_Attack_Passive_Opt)
 
 
-        return(globalSkill.maple_heros(chtr.level, combat_level=self._combat))
+        return(globalSkill.maple_heros(chtr.level, name = "아니마의 용사", combat_level=self._combat))

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -304,7 +304,7 @@ class JobGenerator(ck.JobGenerator):
         Reaction_Spectrum.protect_from_running()
 
         return(BasicAttackWrapper,
-                [SoulOfCrystalPassive, globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+                [SoulOfCrystalPassive, globalSkill.maple_heros(chtr.level, name = "레프의 용사", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     Booster, FastCharge, WraithOfGod, MagicCircuitFullDrive, SoulOfCrystal,
                     Craft_Javelin_EnhanceBuff, CrystalCharge, GloryWingUse,
                     OverloadMana, BlessMark, CurseMark,

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -304,7 +304,7 @@ class JobGenerator(ck.JobGenerator):
         Reaction_Spectrum.protect_from_running()
 
         return(BasicAttackWrapper,
-                [SoulOfCrystalPassive, globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [SoulOfCrystalPassive, globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     Booster, FastCharge, WraithOfGod, MagicCircuitFullDrive, SoulOfCrystal,
                     Craft_Javelin_EnhanceBuff, CrystalCharge, GloryWingUse,
                     OverloadMana, BlessMark, CurseMark,

--- a/dpmModule/jobs/kaiser.py
+++ b/dpmModule/jobs/kaiser.py
@@ -216,7 +216,7 @@ class JobGenerator(ck.JobGenerator):
             sk.protect_from_running()
     
         return(BasicAttack,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     RegainStrenth, BlazeUp, FinalFiguration, MajestyOfKaiser, FinalTrance, AuraWeaponBuff, AuraWeapon, MorphGauge,
                     SoulContract] +\
                 [AdvancedWillOfSword_Dummy] +\

--- a/dpmModule/jobs/kaiser.py
+++ b/dpmModule/jobs/kaiser.py
@@ -216,7 +216,7 @@ class JobGenerator(ck.JobGenerator):
             sk.protect_from_running()
     
         return(BasicAttack,
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, name = "노바의 용사", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     RegainStrenth, BlazeUp, FinalFiguration, MajestyOfKaiser, FinalTrance, AuraWeaponBuff, AuraWeapon, MorphGauge,
                     SoulContract] +\
                 [AdvancedWillOfSword_Dummy] +\

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -217,7 +217,7 @@ class JobGenerator(ck.JobGenerator):
         UltimateTrain.onBefore(PsychicPoint.stackController(-15))
         
         return(PsychicGrab2,
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, name = "이계의 용사", combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Booster, PsychicShield, PsychicGround, 
                     PsycoBreak, UltimatePsychicBuff, PsychicCharging, 
                     PsychicOver, OverloadMana, PsychicPoint,

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -217,7 +217,7 @@ class JobGenerator(ck.JobGenerator):
         UltimateTrain.onBefore(PsychicPoint.stackController(-15))
         
         return(PsychicGrab2,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Booster, PsychicShield, PsychicGround, 
                     PsycoBreak, UltimatePsychicBuff, PsychicCharging, 
                     PsychicOver, OverloadMana, PsychicPoint,

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -215,7 +215,7 @@ class JobGenerator(ck.JobGenerator):
         SoulContract = globalSkill.soul_contract()
 
         return(Attack, 
-                [LuminousState, globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [LuminousState, globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Booster, PodicMeditaion, DarknessSocery, DarkCrescendo, HerosOath, Memorize, Frid, OverloadMana,
                     SoulContract] +\
                 [LightAndDarkness] +\

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -175,7 +175,7 @@ class JobGenerator(ck.JobGenerator):
         RoboFactory.onAfter(RoboFactoryBuff.controller(1))
         
         return(MassiveFire,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     Booster, WillOfLiberty, LuckyDice, SupportWaverBuff, RobolauncherBuff, RoboFactoryBuff, MultipleOptionBuff, BomberTime, Overdrive, OverdrivePenalty,
                     globalSkill.soul_contract()] +\
                 [MicroMissle, BusterCallInit] +\

--- a/dpmModule/jobs/mercedes.py
+++ b/dpmModule/jobs/mercedes.py
@@ -160,7 +160,7 @@ class JobGenerator(ck.JobGenerator):
             wrp.modifier = ElementalGhostFast
     
         return(IshtarRing,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(), 
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), 
                     Booster, ElvishBlessing, AncientSpirit, HerosOath, Frid, Sylphidia.ignore(), CriticalReinforce, UnicornSpikeBuff, RegendrySpearBuff, ElementalGhost,
                     SoulContract] +\
                 [UnicornSpike, RegendrySpear, WrathOfEllil, IrkilaBreathInit] +\

--- a/dpmModule/jobs/michael.py
+++ b/dpmModule/jobs/michael.py
@@ -133,7 +133,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
         
         return(BasicAttackWrapper, 
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     GuardOfLight, LoyalGuardBuff, SoulAttack, Booster, Invigorate, SacredCube, 
                     DeadlyChargeBuff, QueenOfTomorrow, AuraWeaponBuff, AuraWeapon, RoIias, SwordOfSoullight,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/michael.py
+++ b/dpmModule/jobs/michael.py
@@ -133,7 +133,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
         
         return(BasicAttackWrapper, 
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     GuardOfLight, LoyalGuardBuff, SoulAttack, Booster, Invigorate, SacredCube, 
                     DeadlyChargeBuff, QueenOfTomorrow, AuraWeaponBuff, AuraWeapon, RoIias, SwordOfSoullight,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/nightlord.py
+++ b/dpmModule/jobs/nightlord.py
@@ -111,7 +111,7 @@ class JobGenerator(ck.JobGenerator):
             sk.onAfter(FatalVenom)
 
         return (QuarupleThrow, 
-            [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+            [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     ShadowPartner, SpiritJavelin, PurgeArea, BleedingToxin, EpicAdventure, 
                     UltimateDarksight, ReadyToDie, SpreadThrowInit,
                     globalSkill.soul_contract()] + \

--- a/dpmModule/jobs/nightwalker.py
+++ b/dpmModule/jobs/nightwalker.py
@@ -195,7 +195,7 @@ class JobGenerator(ck.JobGenerator):
         ShadowBite.onAfter(ShadowBiteBuff.controller(2000))
                 
         return( QuintupleThrow,
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     ElementalDarkness, Heist, Booster, ShadowServent, SpiritThrowing, ShadowBatStack,
                     ShadowElusion, ReadyToDie, Dominion, GloryOfGuardians, ShadowSpear, ShadowServentExtend, ShadowBite, ShadowBiteBuff,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/nightwalker.py
+++ b/dpmModule/jobs/nightwalker.py
@@ -195,7 +195,7 @@ class JobGenerator(ck.JobGenerator):
         ShadowBite.onAfter(ShadowBiteBuff.controller(2000))
                 
         return( QuintupleThrow,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     ElementalDarkness, Heist, Booster, ShadowServent, SpiritThrowing, ShadowBatStack,
                     ShadowElusion, ReadyToDie, Dominion, GloryOfGuardians, ShadowSpear, ShadowServentExtend, ShadowBite, ShadowBiteBuff,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -307,7 +307,7 @@ class JobGenerator(ck.JobGenerator):
         
         ### Exports ###
         return(CardinalBlastBasic,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_wind_booster(),
                     AncientBowBooster, CurseTolerance, CurseTransition, SharpEyes,
                     RelicEvolution, EpicAdventure,
                     AncientGuidanceBuff, AdditionalTransition, CriticalReinforce,

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -152,7 +152,7 @@ class JobGenerator(ck.JobGenerator):
         #이들 정보교환 부분을 굳이 Task exchange로 표현할 필요가 있을까?
         
         return(BasicAttackWrapper,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     TalentOfPhantomII, TalentOfPhantomIII, FinalCutBuff, BoolsEye,
                     JudgementBuff, Booster, PrieredAria, HerosOath, ReadyToDie, JokerBuff, Frid,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -170,7 +170,7 @@ class JobGenerator(ck.JobGenerator):
             jobutils.create_auxilary_attack(sk, 0.7, nametag = '(쉐도우파트너)')
         
         return(BasicAttackWrapper, 
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     Booster, FlipTheCoin, ShadowerInstinct, ShadowPartner, Smoke, AdvancedDarkSight, EpicAdventure, UltimateDarksight, MesoStack,
                         ReadyToDie, globalSkill.soul_contract()] +\
                 [Eviscerate, SonicBlow, BailOfShadow, DarkFlare]+\

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -125,7 +125,7 @@ class JobGenerator(ck.JobGenerator):
         ChargedArrowHold.set_disabled_and_time_left(5000) # 최초 차징 시간
         
         return(Snipping,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_wind_booster(),
                     SoulArrow, ElusionStep, SharpEyes, BoolsEye, EpicAdventure, CriticalReinforce, SplitArrowBuff,
                         globalSkill.soul_contract()] +\
                 [TrueSnipping, ChargedArrowHold, ChargedArrow] +\

--- a/dpmModule/jobs/soulmaster.py
+++ b/dpmModule/jobs/soulmaster.py
@@ -115,7 +115,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
 
         return(BasicAttackWrapper,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     NimbleFinger, TrueSight, SolunaTime, SoulForge, 
                     GloryOfGuardians, AuraWeaponBuff, AuraWeapon, globalSkill.soul_contract(), Elision, ElisionBreak, SelestialDanceInit, 
                     ] +\

--- a/dpmModule/jobs/soulmaster.py
+++ b/dpmModule/jobs/soulmaster.py
@@ -115,7 +115,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
 
         return(BasicAttackWrapper,
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     NimbleFinger, TrueSight, SolunaTime, SoulForge, 
                     GloryOfGuardians, AuraWeaponBuff, AuraWeapon, globalSkill.soul_contract(), Elision, ElisionBreak, SelestialDanceInit, 
                     ] +\

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -154,7 +154,7 @@ class JobGenerator(ck.JobGenerator):
         NoiShinChanGeuk.onAfter(NoiShinChanGeukAttack)
 
         return(BasicAttackWrapper,
-                [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     LightningStack, Booster, ChookRoi, WindBooster, LuckyDice,
                     HuricaneBuff, GloryOfGuardians, SkyOpen, Overdrive, OverdrivePenalty, ShinNoiHapL,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -154,7 +154,7 @@ class JobGenerator(ck.JobGenerator):
         NoiShinChanGeuk.onAfter(NoiShinChanGeukAttack)
 
         return(BasicAttackWrapper,
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
+                [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     LightningStack, Booster, ChookRoi, WindBooster, LuckyDice,
                     HuricaneBuff, GloryOfGuardians, SkyOpen, Overdrive, OverdrivePenalty, ShinNoiHapL,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -178,7 +178,7 @@ class JobGenerator(ck.JobGenerator):
         SerpentScrew.onConstraint(EnergyConstraint)
     
         return (BasicAttackWrapper,
-            [globalSkill.maple_heros(chtr.level), globalSkill.useful_sharp_eyes(),
+            [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
             LuckyDice, Viposition, Stimulate, EpicAdventure, PirateFlag, Overdrive, Transform, NautilusBuff,
             UnityOfPowerBuff, OverdrivePenalty, DragonStrikeBuff, EnergyCharge,
             SerpentScrewTrackingBuff, globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -157,7 +157,7 @@ class JobGenerator(ck.JobGenerator):
         AnotherBite.protect_from_running()
 
         return(WildBalkan,
-                [globalSkill.maple_heros(chtr.level),
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat),
                     CriticalReinforce, SoulArrow, Booster, Hauling, BeastForm, SharpEyes, SilentRampage, JaguerStorm,
                     globalSkill.soul_contract()] +\
                 [Normal, ClawCut, Crossroad, SonicBoom, JaguarSoul, RampageAsOne] +\

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -96,7 +96,7 @@ class JobGenerator(ck.JobGenerator):
         Mercilesswind.onAfter(MercilesswindDOT)
 
         return(SongOfHeaven, 
-                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), 
+                [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self._combat), 
                     Storm, SylphsAid, Albatross, SharpEyes, GloryOfGuardians, StormBringerDummy, CriticalReinforce,
                     PinPointPierceDebuff,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -96,7 +96,7 @@ class JobGenerator(ck.JobGenerator):
         Mercilesswind.onAfter(MercilesswindDOT)
 
         return(SongOfHeaven, 
-                [globalSkill.maple_heros(chtr.level), 
+                [globalSkill.maple_heros(chtr.level, combat_level=self._combat), 
                     Storm, SylphsAid, Albatross, SharpEyes, GloryOfGuardians, StormBringerDummy, CriticalReinforce,
                     PinPointPierceDebuff,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -360,7 +360,7 @@ class JobGenerator(ck.JobGenerator):
         '''
 
         return(ComboHolder,
-                [globalSkill.maple_heros(chtr.level, combat_level = 0), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
+                [globalSkill.maple_heros(chtr.level, name = "륀느의 가호", combat_level = 0), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     AlphaState, BetaState, DivineLeer, AuraWeaponBuff, AuraWeapon, DoubleTime, TimeDistortion, TimeHolding, IntensiveTime, LimitBreak,
                     SoulContract]+\
                 [ShadowRain, TwinBladeOfTime, ShadowFlashAlpha, ShadowFlashBeta]+\


### PR DESCRIPTION
구현된 모든 직업의 메용에 컴뱃 오더스를 적용시켰습니다.

데몬어벤져는 메용 액티브를 사용하지 않으므로 `generate()`의 리턴값에서 뺐습니다.

자기 직업에 맞는 이름이 출력되도록 변경했습니다.