### PR TITLE
fix: 바이퍼 스킬

### DIFF
--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -3,6 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import RuleSet, ConditionRule
 from . import globalSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
@@ -12,35 +13,36 @@ from math import ceil
 
 class EnergyChargeWrapper(core.StackSkillWrapper):
     def __init__(self, combat):
-        skill = core.BuffSkill("에너지차지 발동", 0, 999999*1000)
+        skill = core.BuffSkill("에너지 차지", 0, 999999*1000)
         super(EnergyChargeWrapper, self).__init__(skill, 10000)
         self.stack = 0
-        self._st = 0
+        self.charged = False
         self.combat = combat
-    def vary(self, val, force = False):
-        #print(" State : %d, %d \n vary %d" % (self.stack, self._st, val))
-        if (force or not self._st) and val > 0:
-            self.stack += val
+    
+    def vary(self, val):
+        if val >= 10000:
+            self.stack = 10000
+        if (not self.charged) and val > 0:
+            self.stack = min(self.stack + val, 10000)
         elif val < 0:
-            self.stack += val
-        if self._st and self.stack <= 0:
-            self.turnOff()
-        elif (not self._st) and self.stack >= 10000:
-            self.turnOn()
+            self.stack = max(self.stack + val, 0)
+        if self.charged and self.stack <= 0:
+            self.charged = False
+        elif (not self.charged) and self.stack >= 10000:
+            self.charged = True
         return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
-            
-    def turnOn(self):
-        self.stack = 10000
-        self.skill.att = 50 + 2 * self.combat
-        self._st = 1
 
-    def turnOff(self):
-        self.stack = 0
-        self.skill.att = 25
-        self._st = 0       
+    def get_modifier(self):
+        if self.charged == 1:
+            return core.CharacterModifier(att = 50 + 2 * self.combat)
+        else:
+            return core.CharacterModifier(att = 25 + 1 * self.combat)
 
     def isStateOn(self):
-        return self._st
+        return self.charged
+
+    def isStateOff(self):
+        return not self.charged
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -52,21 +54,23 @@ class JobGenerator(ck.JobGenerator):
         self.preEmptiveSkills = 1
         self._combat = 0
 
+    def get_ruleset(self):
+        ruleset = RuleSet()
+        # ruleset.add_rule(ConditionRule('에너지 오브(더미)', '에너지 차지', lambda sk: sk.isStateOff()), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule('트랜스 폼', '에너지 차지', lambda sk: sk.judge(5000, -1)), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule('스티뮬레이트', '에너지 차지', lambda sk: sk.judge(7500, -1)), RuleSet.BASE)
+        return ruleset
+
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         CriticalRoar = core.InformedCharacterModifier("크리티컬 로어",crit = 20, crit_damage = 5)
-        
         MentalClearity = core.InformedCharacterModifier("멘탈 클리어리티",att = 30)
         PhisicalTraining = core.InformedCharacterModifier("피지컬 트레이닝",stat_main = 30, stat_sub = 30)
-        
         CriticalRage = core.InformedCharacterModifier("크리티컬 레이지",crit = 15, crit_damage = 10)    #보스상대 추가+20% 크리율
-        
         StimulatePassive = core.InformedCharacterModifier("스티뮬레이트(패시브)",boss_pdamage = 20)
-        
-        EchoOfHero = core.InformedCharacterModifier("영웅의 메아리", patt = 4) #타임리프
 
         LoadedDicePassive = pirates.LoadedDicePassiveWrapper(vEhc, 2, 3)
         
-        return [CriticalRoar, MentalClearity, PhisicalTraining, CriticalRage, StimulatePassive, EchoOfHero, LoadedDicePassive]
+        return [CriticalRoar, MentalClearity, PhisicalTraining, CriticalRage, StimulatePassive, LoadedDicePassive]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self._combat
@@ -74,35 +78,55 @@ class JobGenerator(ck.JobGenerator):
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 70)
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5 + 0.5*ceil(self._combat/2))
 
-        CriticalRage = core.InformedCharacterModifier("크리티컬 레이지(준액티브)",crit = 20)    #보스상대 추가+20% 크리율
+        CriticalRage = core.InformedCharacterModifier("크리티컬 레이지(보스)",crit = 20)    #보스상대 추가+20% 크리율
         GuardCrush = core.InformedCharacterModifier("가드 크러시",armor_ignore = 40 + 2*passive_level) #40% 확률로 방무 100% 무시.
-        CounterAttack = core.InformedCharacterModifier("카운터 어택",pdamage = 25 + 2*passive_level)  #피격시 25%로발동.
+        # CounterAttack = core.InformedCharacterModifier("카운터 어택",pdamage = 25 + 2*passive_level) # TODO: 적용 여부 결정해야함
         
-        return [WeaponConstant, Mastery, CriticalRage, GuardCrush, CounterAttack]
+        return [WeaponConstant, Mastery, CriticalRage, GuardCrush]
         
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
         울트라 차지 : 공격시 350충전, 최대 차지시 공50, 보스공격시 2배 충전. 최대스택 10000.
+
+        트랜스 폼은 게이지 5000 이하일때 사용
+        스티뮬레이트는 게이지 7500 이하일때 사용
+
+        더블 럭키 다이스-인핸스
+        피스트 인레이지-리인포스, 보스킬러, 보너스 어택
+        에너지 블라스트-보너스 어택
 
         인레이지-노틸-드스-유니티
         '''
         ######   Skill   ######
         passive_level = chtr.get_base_modifier().passive_level + self._combat
         serverlag = 3
+        TRANSFORM_HIT = 12
 
-        LuckyDice = core.BuffSkill("로디드 다이스", 600, 180 * 1000, pdamage = 20+10/6+10/6*(5/6+1/11)*(10*(5+passive_level)*0.01)).isV(vEhc, 2, 2).wrap(core.BuffSkillWrapper)#딜레이 모름
-        #1중첩 럭다 재사용 50초 감소 / 방어력30% / 체엠 20% / 크리율15% / 뎀증20 / 경치30
-        #2중첩 럭다 재사용 50초 감소 / 방어력40% / 체엠 30% / 크리율25% / 뎀증30 / 경치40
-        #7 발동시 방무 20 -> 30
+        # Buff Skill
+        DICE_WEIGHT = 22
+        DICE_POOL = 115
+        DICE_PROC = DICE_WEIGHT / DICE_POOL # 더블 럭키 다이스 - 인핸스
+        LuckyDice = core.BuffSkill("로디드 다이스", 990, 180 * 1000, pdamage = 20+10*DICE_PROC+10*DICE_PROC*((1-DICE_PROC)+DICE_WEIGHT/(DICE_POOL*2-DICE_WEIGHT))*(10*(5+passive_level)*0.01)).isV(vEhc, 2, 2).wrap(core.BuffSkillWrapper)
         Viposition = core.BuffSkill("바이퍼지션", 0, (180+4*self._combat) * 1000, patt = 30+self._combat).wrap(core.BuffSkillWrapper)
+
+        # Damage Skill    
+        FistInrage = core.DamageSkill("피스트 인레이지", 690, 320 + 4*self._combat, 8 + 1, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        FistInrage_T = core.DamageSkill("피스트 인레이지(변신)", 690, 320+4*self._combat, 8 + 1 + 2, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        
+        DragonStrike = core.DamageSkill("드래곤 스트라이크", 690, 300 + 4*self._combat, 12, cooltime = 15 * 1000, red=True).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        DragonStrikeBuff = core.BuffSkill("드래곤 스트라이크(디버프)", 0, 15 * 1000, cooltime = -1, pdamage_indep = 20 + self._combat//2).wrap(core.BuffSkillWrapper)
+        
+        Nautilus = core.DamageSkill("노틸러스", 690, 440+4*self._combat, 7, cooltime = 60 * 1000, red=True).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        NautilusFinalAttack = core.DamageSkill("노틸러스(파이널 어택)", 0, 165+2*self._combat, 2).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+
+        # Hyper
         Stimulate = core.BuffSkill("스티뮬레이트", 930, 120 * 1000, cooltime = 240 * 1000, pdamage = 20).wrap(core.BuffSkillWrapper)# 에너지 주기적으로 800씩 증가, 미완충시 풀완충.
         StimulateSummon = core.SummonSkill("스티뮬레이트(게이지 증가 더미)", 0, (5 + serverlag) * 1000, 0, 0, 120 * 1000).wrap(core.SummonSkillWrapper)
-        
         UnityOfPower = core.DamageSkill("유니티 오브 파워", 1080, 650, 5, cooltime = 90000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)   #완충시에만 사용 가능, 에너지 1500 소모.
         UnityOfPowerBuff = core.BuffSkill("유니티 오브 파워(디버프)", 0, 90 * 1000, cooltime = -1, crit_damage = 40).wrap(core.BuffSkillWrapper)   #4스택 가정.
-        #크리티컬 리인포스 - >재정의 필요함..
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
 
+        # 5th
         PirateFlag = PirateFlag = adventurer.PirateFlagWrapper(vEhc, 3, 2, chtr.level)
         
         #오버드라이브 (앱솔 가정)
@@ -110,79 +134,73 @@ class JobGenerator(ck.JobGenerator):
         WEAPON_ATT = jobutils.get_weapon_att("너클")
         Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
         
-        Transform = core.BuffSkill("트랜스 폼", 450, (50+vEhc.getV(1,1))*1000, cooltime = 180 * 1000, pdamage_indep = (20 + 0.2*vEhc.getV(1,1))).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)#에너지 완충
-        TransformEnergyOrb = core.DamageSkill("에너지 오브", 1140, 450 +vEhc.getV(1,1)*18, (2+(vEhc.getV(1,1) == 25)*1) * 8, modifier = core.CharacterModifier(crit = 50, armor_ignore = 50)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        Transform = core.BuffSkill("트랜스 폼", 450, (50+vEhc.getV(1,1))*1000, cooltime = 180 * 1000, red=True, pdamage_indep = 20 + vEhc.getV(1,1) // 5).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)
+        TransformEnergyOrbDummy = core.DamageSkill("에너지 오브(더미)", 0, 0, 0, cooltime = -1).wrap(core.DamageSkillWrapper)
+        TransformEnergyOrb = core.DamageSkill("에너지 오브", 750, 450 +vEhc.getV(1,1)*18, 3 * TRANSFORM_HIT, modifier = core.CharacterModifier(crit = 50, armor_ignore = 50)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+
+        SerpentScrew = core.SummonSkill("서펜트 스크류", 600, 260, 360 + vEhc.getV(0,0)*14, 3, 99999 * 10000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        SerpentScrewDummy = core.SummonSkill("서펜트 스크류(지속)", 0, 1000, 0, 0, 99999 * 10000, cooltime = -1).wrap(core.SummonSkillWrapper)
     
-        FistInrage = core.DamageSkill("피스트 인레이지", 690, 320 + 4*self._combat, 8 + 1, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-        FistInrage_T = core.DamageSkill("피스트 인레이지(변신)", 690, 320+4*self._combat, 8 + 1 + 2, modifier = core.CharacterModifier(boss_pdamage = 20, pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)#완충시 10번 공격
-        
-        DragonStrike = core.DamageSkill("드래곤 스트라이크", 690, 300 + 4*self._combat, 12, cooltime = 15 * 1000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        DragonStrikeBuff = core.BuffSkill("드래곤 스트라이크(디버프)", 0, 15 * 1000, cooltime = -1, pdamage_indep = 20 + self._combat//2).wrap(core.BuffSkillWrapper)
-        
-        Nautilus = core.DamageSkill("노틸러스", 690, 440+4*self._combat, 7, cooltime = 60 * 1000).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
-        NautilusBuff = core.BuffSkill("노틸러스(버프)", 0, 60 * 1000, cooltime = -1).wrap(core.BuffSkillWrapper)
-        NautilusFinalAttack = core.DamageSkill("노틸러스(파이널 어택)", 0, 165+2*self._combat, 2).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
-        
-        SerpentScrew = core.SummonSkill("서펜트 스크류", 600, 285, 360 + vEhc.getV(0,0)*14, 3, 99999 * 10000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)    #보스 공격시 에너지 소모량 70% 감소, 틱당 에너지 85 소모.
-        SerpentScrewDummy = core.SummonSkill("서펜트 스크류(지속)", 0, 1000, 0, 0, 99999 * 10000, cooltime = -1).wrap(core.SummonSkillWrapper)   #초당 에너지 60 소모 #보스 공격시 에너지 소모량 70% 감소, 틱당 에너지 85 소모.
-        SerpentScrewTrackingBuff = core.BuffSkill("서펜트 스크류(On)", 0, 999999999, cooltime = -1).wrap(core.BuffSkillWrapper)
-    
-        FuriousCharge = core.DamageSkill("퓨리어스 차지", 540, 600+vEhc.getV(4,4)*24, 10, cooltime = 10 * 1000, modifier = core.CharacterModifier(boss_pdamage = 30)).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
+        FuriousCharge = core.DamageSkill("퓨리어스 차지", 420, 600+vEhc.getV(4,4)*24, 10, cooltime = 10 * 1000, modifier = core.CharacterModifier(boss_pdamage = 30)).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
+
         ######   Skill Wrapper   ######
+        # Energy Charge
         EnergyCharge = EnergyChargeWrapper(passive_level)
-        EnergyCharge.set_name_style("게이지 %d만큼 변화")
-        #1중첩 럭다 재사용 50초 감소 / 방어력30% / 체엠 20% / 크리율15% / 뎀증20 / 경치30
-        #2중첩 럭다 재사용 50초 감소 / 방어력40% / 체엠 30% / 크리율25% / 뎀증30 / 경치40
-        #7 발동시 방무 20 -> 30
-        
-        Stimulate.onAfter(EnergyCharge.stackController(10000, name = "스티뮬레이트"))
-        Stimulate.onAfter(StimulateSummon)
-    
-        UnityOfPower.onAfter(EnergyCharge.stackController(-1500))
-        UnityOfPower.onAfter(UnityOfPowerBuff)
-        
-        Transform.onAfter(EnergyCharge.stackController(10000, name = "트랜스 폼"))
-        Transform.onAfter(core.RepeatElement(TransformEnergyOrb, 3))
-    
-        Nautilus.onAfter(NautilusBuff)
-    
-        FinalAttack = core.OptionalElement(NautilusBuff.is_active, NautilusFinalAttack)
-    
-        FistInrage.onAfter(NautilusFinalAttack)
+        EnergyCharge.set_name_style("게이지 %d")
+        EnergyConstraint = core.ConstraintElement("에너지 차지 상태에서만 사용 가능", EnergyCharge, EnergyCharge.isStateOn)
+
+        Stimulate.onAfter(EnergyCharge.stackController(10000))
+        Transform.onAfter(EnergyCharge.stackController(10000))
+        TransformEnergyOrb.onAfter(EnergyCharge.stackController(700 * TRANSFORM_HIT))
+        StimulateSummon.onTick(EnergyCharge.stackController(800))
         FistInrage.onAfter(EnergyCharge.stackController(700))
-        FistInrage_T.onAfter(NautilusFinalAttack)
+        Nautilus.onAfter(EnergyCharge.stackController(700))
+        NautilusFinalAttack.onAfter(EnergyCharge.stackController(700))
+        SerpentScrewDummy.onTick(EnergyCharge.stackController(-85))
+        SerpentScrew.onTick(EnergyCharge.stackController(-85*0.3))
         FistInrage_T.onAfter(EnergyCharge.stackController(-150))
+        DragonStrike.onAfter(EnergyCharge.stackController(-180))
+        UnityOfPower.onAfter(EnergyCharge.stackController(-1500))
         
+        # Basic Attack
         BasicAttack = core.OptionalElement(EnergyCharge.isStateOn, FistInrage_T, FistInrage)
         BasicAttackWrapper = core.DamageSkill('기본 공격',0,0,0).wrap(core.DamageSkillWrapper)
         BasicAttackWrapper.onAfter(BasicAttack)
-        DragonStrike.onAfter(EnergyCharge.stackController(-180))
+
+        # Dragon Strike
+        DragonStrike.onConstraint(EnergyConstraint)
         DragonStrike.onAfter(DragonStrikeBuff)
+    
+        # Final Attack
+        FinalAttack = core.OptionalElement(lambda: not Nautilus.is_available(), NautilusFinalAttack)
+        FistInrage.onAfter(FinalAttack)
+        FistInrage_T.onAfter(FinalAttack)
+        FuriousCharge.onAfter(FinalAttack)
+
+        # Stimulate
+        Stimulate.onAfter(StimulateSummon)
+    
+        # Unity Of Power
+        UnityOfPower.onConstraint(EnergyConstraint)
+        UnityOfPower.onAfter(UnityOfPowerBuff)
         
-        SerpentScrewDummy.onTick(EnergyCharge.stackController(-60*0.3))
-        SerpentScrew.onTick(EnergyCharge.stackController(-85*0.3))
-        SerpentScrew.onAfter(SerpentScrewDummy)
-        SerpentScrew.onAfter(SerpentScrewTrackingBuff)  #디버깅용
+        # Transform
+        Transform.onAfter(TransformEnergyOrbDummy.controller(1))
+        TransformEnergyOrbDummy.onAfter(core.RepeatElement(TransformEnergyOrb, 2 + vEhc.getV(1, 1) // 30))
         
+        # Serpent Screw
+        SerpentScrew.onConstraint(core.ConstraintElement("에너지 100 이상", EnergyCharge, partial(EnergyCharge.judge, 100, 1)))
         SerpentScrewOff = SerpentScrew.controller(150, name = "서펜트 스크류 사용 종료")
         SerpentScrewOff.onAfter(SerpentScrewDummy.controller(-1))
-        SerpentScrewOff.onAfter(SerpentScrewTrackingBuff.controller(-1))    #디버깅용
         
-        SerpentScrewDummy.onTick(core.OptionalElement(partial(EnergyCharge.judge, 100, -1), SerpentScrewOff, name = "서펜트 스크류 사용 종료(100 미만 게이지일 경우)"))
-        
-        ### 에너지 차지 옵션 적용 ###
-        EnergyConstraint = core.ConstraintElement("에너지 차지 상태에서만 사용 가능", EnergyCharge, EnergyCharge.isStateOn)
-        
-        UnityOfPower.onConstraint(EnergyConstraint)
-        DragonStrike.onConstraint(EnergyConstraint)
-        SerpentScrew.onConstraint(EnergyConstraint)
-    
+        SerpentScrew.onTick(core.OptionalElement(partial(EnergyCharge.judge, 100, -1), SerpentScrewOff, name = "서펜트 스크류 사용 종료(100 미만 게이지일 경우)"))
+            
         return (BasicAttackWrapper,
             [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
-            LuckyDice, Viposition, Stimulate, EpicAdventure, PirateFlag, Overdrive, Transform, NautilusBuff,
-            UnityOfPowerBuff, OverdrivePenalty, DragonStrikeBuff, EnergyCharge,
-            SerpentScrewTrackingBuff, globalSkill.soul_contract()] +\
-            [UnityOfPower, Nautilus, DragonStrike, FuriousCharge] +\
+                LuckyDice, Viposition, Stimulate, EpicAdventure, PirateFlag, Overdrive, Transform,
+                UnityOfPowerBuff, OverdrivePenalty, DragonStrikeBuff, EnergyCharge,
+                globalSkill.soul_contract()] +\
+            [UnityOfPower, Nautilus, DragonStrike, FuriousCharge, TransformEnergyOrbDummy] +\
             [SerpentScrew, SerpentScrewDummy, StimulateSummon] +\
             [] +\
             [BasicAttackWrapper])


### PR DESCRIPTION
* 트랜스폼, 스티뮬레이트 완충 적용 안되던것 수정
* 더블 럭키 다이스-인핸스 기댓값 적용
* 게이지 변동되는 스킬 목록 수정
* 파이널 어택 적용되는 스킬 목록 수정
* 5차 스킬 딜레이 수정
* 완충시에도 에너지 충전되는 스킬 명시적으로 표현
* 유니티 오브 파워 실제 쿨타임과 맞추고 Rule로 제어
* 에너지 오브 딜레이 수정
* 에너지 오브 트랜스폼 켜져있을때만 사용가능
* 서펜트 정확히 종료되게 함
* 딜사이클
  * 스티뮬레이트 게이지 1000 이하에서 사용
  * 트랜스폼은 쿨마다 사용하는게 최종뎀 때문에 더 좋음