### PR TITLE
fix: 오버드라이브 페널티

### DIFF
--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -135,7 +135,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("소울슈터")
-        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 3, 3, WEAPON_ATT)
+        Overdrive = pirates.OverdriveWrapper(vEhc, 3, 3, WEAPON_ATT)
     
         EnergyBurst = core.DamageSkill("에너지 버스트", 900, (600+20*vEhc.getV(4,4)) * 3, 12, red = True, cooltime = 120 * 1000).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
         
@@ -180,7 +180,7 @@ class JobGenerator(ck.JobGenerator):
     
         return (Trinity_1,
                 [Booster, SoulGaze, LuckyDice, FinalContract,
-                    SoulExult, SoulContract,Overdrive, OverdrivePenalty,
+                    SoulExult, SoulContract, Overdrive,
                     FinaturaFettucciaBuff, SpotLightBuff, Trinity_Buff, MascortFamilier,
                     globalSkill.maple_heros(chtr.level, name = "노바의 용사", combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster()] +\
                 [FinaturaFettuccia, EnergyBurst] +\

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -276,7 +276,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("너클")
-        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
+        Overdrive = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         MagicCircuitFullDrive = core.BuffSkill("매직 서킷 풀드라이브", 720, (30+vEhc.getV(4,3))*1000, pdamage = (20 + vEhc.getV(4,3)), cooltime = 200*1000, red=True).isV(vEhc,4,3).wrap(core.BuffSkillWrapper)
         MagicCircuitFullDriveStorm = core.DamageSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 500+20*vEhc.getV(4,3), 3, cooltime=4000).wrap(core.DamageSkillWrapper)
@@ -429,7 +429,7 @@ class JobGenerator(ck.JobGenerator):
         return(PlainAttack, 
                 [ContactCaravan, ScarletBuff, AbyssBuff, SpectorState, Booster,
                     ChargeSpellAmplification, WraithOfGod,
-                    LuckyDice, Overdrive, OverdrivePenalty,
+                    LuckyDice, Overdrive,
                     MagicCircuitFullDrive, MemoryOfSourceBuff, EndlessPainBuff,
                     InfinitySpell,
                     globalSkill.maple_heros(chtr.level, name = "레프의 용사", combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.soul_contract()

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -86,7 +86,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("핸드캐논")
-        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
+        Overdrive = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
     
         PirateFlag = adventurer.PirateFlagWrapper(vEhc, 4, 3, chtr.level)
 
@@ -117,7 +117,7 @@ class JobGenerator(ck.JobGenerator):
         return(CanonBuster,
                 [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Booster, MonkeyWaveBuff, MonkeyFuriousBuff, MonkeyFuriousDot, OakRulet, Buckshot, MonkeyMagic,
-                    EpicAdventure, LuckyDice, Overdrive, OverdrivePenalty, PirateFlag,
+                    EpicAdventure, LuckyDice, Overdrive, PirateFlag,
                     globalSkill.soul_contract()] +\
                 [MonkeyWave, MonkeyFurious, ICBM] +\
                 [OakRuletDOT, SupportMonkeyTwins, RollingCanonRainbow, BFGCannonball, ICBMDOT, SpecialMonkeyEscort_Boom, SpecialMonkeyEscort_Canon] +\

--- a/dpmModule/jobs/captain.py
+++ b/dpmModule/jobs/captain.py
@@ -121,7 +121,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("건")
-        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 4, 4, WEAPON_ATT)
+        Overdrive = pirates.OverdriveWrapper(vEhc, 4, 4, WEAPON_ATT)
         
         BulletParty = core.DamageSkill("불릿 파티", 0, 0, 0, cooltime = 75000, red = True).wrap(core.DamageSkillWrapper)
         BulletPartyTick = core.DamageSkill("불릿 파티(틱)", BULLET_PARTY_TICK, 230+9*vEhc.getV(5,5), 5, modifier = CONTINUAL_AIMING).isV(vEhc,5,5).wrap(core.DamageSkillWrapper) #12초간 지속 -> 50회 시전
@@ -167,7 +167,7 @@ class JobGenerator(ck.JobGenerator):
 
         return (RapidFire,
                 [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
-                    SummonCrewBuff, PirateStyle, Booster, InfiniteBullet, LuckyDice, UnwierdingNectar, EpicAdventure, PirateFlag, Overdrive, OverdrivePenalty,
+                    SummonCrewBuff, PirateStyle, Booster, InfiniteBullet, LuckyDice, UnwierdingNectar, EpicAdventure, PirateFlag, Overdrive,
                     QuickDraw, globalSkill.soul_contract()] +\
                 [BattleshipBomber, Headshot, Nautilus, DeadEye, StrangeBomb] +\
                 [OctaQuaterdeck, BattleshipBomber_1, BattleshipBomber_2, NautilusAssult, NautilusAssult_2, SummonCrew] +\

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -128,7 +128,7 @@ class JobGenerator(ck.JobGenerator):
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
 
         WEAPON_ATT = jobutils.get_weapon_att("너클")
-        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
+        Overdrive = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
         
         SoulConcentrate = core.BuffSkill("정령 집속", 900, (30+vEhc.getV(2,1))*1000, cooltime = 120*1000, red=True, pdamage_indep = (5+vEhc.getV(2,1)//2)).isV(vEhc,2,1).wrap(core.BuffSkillWrapper)
         SoulConcentrateSummon = core.SummonSkill("정령 집속(무작위)", 0, 2000, 1742, 1, (30+vEhc.getV(2,1))*1000, cooltime = -1).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
@@ -192,7 +192,7 @@ class JobGenerator(ck.JobGenerator):
         return(BasicAttackWrapper, 
                 [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     EnhanceSpiritLink, LuckyDice, HerosOath,
-                    Overdrive, OverdrivePenalty, SoulConcentrate, DoubleBody, SoulTrapStack,
+                    Overdrive, SoulConcentrate, DoubleBody, SoulTrapStack,
                     globalSkill.soul_contract()] +\
                 [BladeImp, BladeImpBuff, SoulTrap] +\
                 [EnhanceSpiritLinkSummon_S, EnhanceSpiritLinkSummon_J_Init, EnhanceSpiritLinkSummon_J, SoulConcentrateSummon] +\

--- a/dpmModule/jobs/jobbranch/pirates.py
+++ b/dpmModule/jobs/jobbranch/pirates.py
@@ -4,14 +4,19 @@ from ...kernel.core import CharacterModifier as MDF
 from ...character import characterKernel as ck
 from functools import partial
 
-# 오버드라이브 함수 버전
-# 직업 소스에서 chtr.itemlist["weapon"].att 으로 무기 공격력 접근이 가능하나 강화 후 공격력이 나옴
-def OverdriveWrapper(vEhc, num1, num2, WEAPON_ATT):
-    Overdrive = core.BuffSkill("오버 드라이브", 420, 30*1000, cooltime = (70 - 0.2*vEhc.getV(num1, num2))*1000, red=True, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
-    OverdrivePenalty = core.BuffSkill("오버 드라이브(페널티)", 0, (40 - 0.2*vEhc.getV(num1, num2))*1000, cooltime = -1, att = -0.15 * WEAPON_ATT).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
-    Overdrive.onAfter(OverdrivePenalty.controller(30*1000))
-    OverdrivePenalty.set_disabled_and_time_left(-1)
-    return Overdrive, OverdrivePenalty
+class OverdriveWrapper(core.BuffSkillWrapper):
+    def __init__(self, vEhc, num1, num2, WEAPON_ATT):
+        skill = core.BuffSkill("오버 드라이브", 420, 30*1000, cooltime = (70 - vEhc.getV(num1, num2) // 5)*1000, red=True, att = WEAPON_ATT*0.01*(20 + 2* vEhc.getV(num1, num2))).isV(vEhc, num1, num2)
+        self.penaltyModifier = core.CharacterModifier(att = -0.15 * WEAPON_ATT)
+        super(OverdriveWrapper, self).__init__(skill)
+
+    def get_modifier(self) -> core.CharacterModifier:
+        if self.onoff:
+            return self.skill.get_modifier()
+        elif not self.available:
+            return self.penaltyModifier
+        else:
+            return self.disabledModifier
 
 def LoadedDicePassiveWrapper(vEhc, num1, num2):
     LoadedDicePassive = core.InformedCharacterModifier("로디드 다이스(패시브)", att = vEhc.getV(num1, num2) + 10)

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -127,7 +127,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("건")
-        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
+        Overdrive = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
 
         RegistanceLineInfantry = resistance.ResistanceLineInfantryWrapper(vEhc, 3, 3, ROBOT_MASTERY) # 메카닉은 인팬트리에 로봇 마스터리 최종뎀이 적용됨
         
@@ -176,7 +176,7 @@ class JobGenerator(ck.JobGenerator):
         
         return(MassiveFire,
                 [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
-                    Booster, WillOfLiberty, LuckyDice, SupportWaverBuff, RobolauncherBuff, RoboFactoryBuff, MultipleOptionBuff, BomberTime, Overdrive, OverdrivePenalty,
+                    Booster, WillOfLiberty, LuckyDice, SupportWaverBuff, RobolauncherBuff, RoboFactoryBuff, MultipleOptionBuff, BomberTime, Overdrive,
                     globalSkill.soul_contract()] +\
                 [MicroMissle, BusterCallInit] +\
                 [HommingMissleHolder, RegistanceLineInfantry, SupportWaver, Robolauncher, RoboFactory, DistortionField, MultipleOption] +\

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -116,7 +116,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("너클")
-        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
+        Overdrive = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
 
         ShinNoiHapL = core.BuffSkill("신뇌합일", 540, (30+vEhc.getV(3,2)//2) * 1000, red = True, cooltime = (121-vEhc.getV(3,2)//2)*1000, pdamage_indep=4+vEhc.getV(3,2)//5).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
         ShinNoiHapLAttack = core.SummonSkill("신뇌합일(공격)", 0, 3000, 16*vEhc.getV(3,2) + 400, 7, (30+vEhc.getV(3,2)//2) * 1000, cooltime = -1).isV(vEhc,3,2).wrap(core.SummonSkillWrapper)
@@ -156,7 +156,7 @@ class JobGenerator(ck.JobGenerator):
         return(BasicAttackWrapper,
                 [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                     LightningStack, Booster, ChookRoi, WindBooster, LuckyDice,
-                    HuricaneBuff, GloryOfGuardians, SkyOpen, Overdrive, OverdrivePenalty, ShinNoiHapL,
+                    HuricaneBuff, GloryOfGuardians, SkyOpen, Overdrive, ShinNoiHapL,
                     globalSkill.soul_contract()] +\
                 [GioaTan, CygnusPalanks, NoiShinChanGeuk] +\
                 [ShinNoiHapLAttack, NoiShinChanGeukAttack] +\

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -138,7 +138,7 @@ class JobGenerator(ck.JobGenerator):
         #오버드라이브 (앱솔 가정)
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("너클")
-        Overdrive, OverdrivePenalty = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
+        Overdrive = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
         
         Transform = core.BuffSkill("트랜스 폼", 450, (50+vEhc.getV(1,1))*1000, cooltime = 180 * 1000, red=True, pdamage_indep = 20 + vEhc.getV(1,1) // 5).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)
         TransformEnergyOrbDummy = core.DamageSkill("에너지 오브(더미)", 0, 0, 0, cooltime = -1).wrap(core.DamageSkillWrapper)
@@ -201,7 +201,7 @@ class JobGenerator(ck.JobGenerator):
         return (BasicAttackWrapper,
             [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(),
                 LuckyDice, Viposition, Stimulate, EpicAdventure, PirateFlag, Overdrive, Transform,
-                UnityOfPowerBuff, OverdrivePenalty, DragonStrikeBuff, EnergyCharge,
+                UnityOfPowerBuff, DragonStrikeBuff, EnergyCharge,
                 globalSkill.soul_contract()] +\
             [UnityOfPower, Nautilus, DragonStrike, FuriousCharge, TransformEnergyOrbDummy] +\
             [SerpentScrew, SerpentScrewDummy, StimulateSummon] +\


### PR DESCRIPTION
* 오버드라이브에 쿨감이 적용되면서 페널티 지속시간을 단순 쿨타임 뺄셈으로 적용이 불가능해짐
* OverdriveWrapper의 get_modifier에서 판단하는 방식으로 변경