### PR TITLE
fix: 와헌 스킬

### DIFF
--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -1,39 +1,58 @@
 from ..kernel import core
 from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
-from functools import partial
+from functools import partial, reduce
 from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobclass import resistance
 from .jobbranch import bowmen
 from math import ceil
-# TODO: 재규어 맥시멈, 드릴 컨테이너 추가
+# TODO: 드릴 컨테이너 추가
 
-class JaguerStack(core.DamageSkillWrapper, core.TimeStackSkillWrapper):
+class JaguerStack(core.DamageSkillWrapper):
     def __init__(self, level, vEhc):
-        self.level = level
-        self.modifier = core.CharacterModifier()
-        self._runtime_modifier_list = []
-        skill = core.DamageSkill("어나더 바이트", 0, 0, 0, cooltime=-1).setV(vEhc, 1, 2, False)
-        super(core.DamageSkillWrapper, self).__init__(skill, 3)
-        
-    def addStack(self, vary, left):
-        if self.getStack() < 0.5:
-            vary_ = 1
-        else: vary_ = vary
-        self.queue.append([vary_, left])
-        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self._id, spec = 'graph control')        
-        
-    def _use(self, skill_modifier):
-        mdf = self.get_modifier()
-        dmg = 60*self.getStack() + int(self.level/3)
-        return core.ResultObject(0, mdf, dmg, 1, sname = self._id, spec = 'damage')
+        self.debuffQueue = [] # (확률, 시간)
+        self.currentTime = 0
+        self.stack = 0
+        self.DEBUF_PERSISTENCE_TIME = 8000 # 8000ms
+        skill = core.DamageSkill("어나더 바이트", 0, 60 + level // 3, 0, cooltime=-1).setV(vEhc, 1, 2, False)
+        super(JaguerStack, self).__init__(skill)
 
-    def is_usable(self):
-        return False
+    def _add_debuff(self, value):
+        self.debuffQueue = [(self.currentTime, value)] + self.debuffQueue
+        return self._result_object_cache
 
-######   Passive Skill   ######
+    def add_debuff(self, value):
+        return core.TaskHolder(core.Task(self, partial(self._add_debuff, value)), name = f"{value*100}%")
 
+    def calculate_stack(self):
+        """
+        현재 시점부터 8초 이전까지의 재규어 공격이 전부 실패했을 확률을 바탕으로 스택 기댓값을 연산합니다.
+        """
+        fail_prob = reduce(lambda x, y: x * y, [max(1 - x[1], 0) for x in self.debuffQueue], 1)
+        return 3 * (1 - fail_prob)
+
+    def spend_time(self, time):
+        self.currentTime += time
+        # 8초 이상 지난 기록 제거
+        self.debuffQueue = [x for x in self.debuffQueue if x[0] + self.DEBUF_PERSISTENCE_TIME > self.currentTime]
+        self.stack = self.calculate_stack()
+        super(JaguerStack, self).spend_time(time)
+    
+    def get_hit(self):
+        return self.stack
+
+class JaguarWrapper(core.SummonSkillWrapper):
+    def __init__(self):
+        skill = core.SummonSkill("재규어", 0, 0, 0, 0, 99999999)
+        super(JaguarWrapper, self).__init__(skill)
+
+    def _set_delay(self, value):
+        self.tick = value
+        return self._result_object_cache
+
+    def set_delay(self, value):
+        return core.TaskHolder(core.Task(self, partial(self._set_delay, value)), name = f"재규어 딜레이 {value}")
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -48,7 +67,7 @@ class JobGenerator(ck.JobGenerator):
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self._combat
 
-        Jaguer = core.InformedCharacterModifier("재규어",crit=5)
+        Jaguer = core.InformedCharacterModifier("재규어",crit=5, buff_rem=10)
         NaturesWrath = core.InformedCharacterModifier("네이처스 래쓰",crit=25)
         AutomaticShootingDevice = core.InformedCharacterModifier("오토매팅 슈팅 디바이스",att=20)
         CrossbowMastery = core.InformedCharacterModifier("크로스보우 마스터리",pdamage = 10)
@@ -59,10 +78,11 @@ class JobGenerator(ck.JobGenerator):
         WildInstinct = core.InformedCharacterModifier("와일드 인스팅트",armor_ignore = 30 + 3*passive_level)
         ExtentMagazine = core.InformedCharacterModifier("익스텐드 매거진", pdamage_indep=20 + passive_level // 3, stat_main=60 + 2*passive_level, stat_sub=60 + 2*passive_level)
         AdvancedFinalAttackPassive = core.InformedCharacterModifier("어드밴스드 파이널 어택(패시브)", att = 20 + ceil(passive_level/2))
+        JaugerStormPassive = core.InformedCharacterModifier("재규어 스톰(패시브)", att = 5+2*vEhc.getV(0,0))
     
         return [Jaguer, NaturesWrath, AutomaticShootingDevice,
                             CrossbowMastery, PhisicalTraining, Flurry, JaugerLink, CrossbowExpert, 
-                            WildInstinct, ExtentMagazine, AdvancedFinalAttackPassive]
+                            WildInstinct, ExtentMagazine, AdvancedFinalAttackPassive, JaugerStormPassive]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self._combat
@@ -76,91 +96,105 @@ class JobGenerator(ck.JobGenerator):
         
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
-        재규어 7마리(25레벨시 8마리) 소환, 재규어당 데미지 62+vlevel, 3히트 가정.
+        재규어 스톰 3히트
+
+        하이퍼:
+        비스트 폼-리인포스
+        서먼 재규어-리인포스, 쿨타임 리듀스
+        와일드 발칸-리인포스, 보스 킬러
         
         코강 순서:
-        발칸 - (서먼/어나더) - 파택 - 클로우컷 - 헌팅유닛- 램피지애즈원/플래시레인 - 소닉붐 - 재규어소울 - 크로스 로드
+        발칸 - (서먼/어나더) - 파택 - 클로우컷 - 헌팅유닛- 램피지애즈원/플래시레인 - 소닉붐 - 재규어소울 - 크로스 로드 - 드릴 컨테이너
         '''
-
         passive_level = chtr.get_base_modifier().passive_level + self._combat
-        #재규어 스킬들
-        JAGUERNUMBER = 3
+
+        # Jaguar Skills
+        JAGUAR_STORM_HIT = 3
         
-        Normal = core.DamageSkill("서먼 재규어(재규어 공격)", 0, 140+chtr.level, 1, cooltime = 60000/37, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        ClawCut = core.DamageSkill("클로우 컷", 0, 200+chtr.level, 4, cooltime = 5000*0.9, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        Crossroad = core.DamageSkill("크로스 로드", 0, 450+2*chtr.level, 1, cooltime = 6000*0.9, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 8, 3, False).wrap(core.DamageSkillWrapper)
-        SonicBoom = core.DamageSkill("소닉 붐", 0, 220+chtr.level, 6, cooltime = 6000*0.9, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        JaguarSoul = core.DamageSkill("재규어 소울", 0, 1000+20*chtr.level, 1, cooltime = 210000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        RampageAsOne = core.DamageSkill("램피지 애즈 원", 0, 500+1*chtr.level, 9, cooltime=12000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        Jaguar = JaguarWrapper()
+        Normal = core.DamageSkill("재규어 평타", 0, 140+chtr.level, 1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        ClawCut = core.DamageSkill("클로우 컷", 0, 200+chtr.level, 4, cooltime = 5000*0.9, red=True, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        Crossroad = core.DamageSkill("크로스 로드", 0, 450+2*chtr.level, 1, cooltime = 6000*0.9, red=True, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 8, 3, False).wrap(core.DamageSkillWrapper)
+        SonicBoom = core.DamageSkill("소닉 붐", 0, 220+chtr.level, 6, cooltime = 6000*0.9, red=True, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        JaguarSoul = core.DamageSkill("재규어 소울", 0, 1000+20*chtr.level, 1, cooltime = 210000, red=True, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        RampageAsOne = core.DamageSkill("램피지 애즈 원", 0, 500+1*chtr.level, 9, cooltime = 12000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
     
-        Normal_JG = core.DamageSkill("재규어 공격(여럿)",          0, (140+chtr.level)*(62+vEhc.getV(0,0))*0.01, 1 * JAGUERNUMBER, cooltime = 60000/37, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        ClawCut_JG = core.DamageSkill("클로우 컷(여럿)",           0, (200+chtr.level)*(62+vEhc.getV(0,0))*0.01, 4 * JAGUERNUMBER, cooltime = 5000*0.9, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        Crossroad_JG = core.DamageSkill("크로스 로드(여럿)",       0, (450+2*chtr.level)*(62+vEhc.getV(0,0))*0.01, 1 * JAGUERNUMBER, cooltime = 6000*0.9, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 8, 3, False).wrap(core.DamageSkillWrapper)
-        SonicBoom_JG = core.DamageSkill("소닉 붐(여럿)",           0, (220+chtr.level)*(62+vEhc.getV(0,0))*0.01, 6 * JAGUERNUMBER, cooltime = 6000*0.9, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        JaguarSoul_JG = core.DamageSkill("재규어 소울(여럿)",      0, (1000+20*chtr.level)*(62+vEhc.getV(0,0))*0.01, 1 * JAGUERNUMBER, cooltime = 210000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        RampageAsOne_JG = core.DamageSkill("램피지 애즈 원(여럿)", 0, (500+1*chtr.level)*(62+vEhc.getV(0,0))*0.01, 9 * JAGUERNUMBER, cooltime=12000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        Normal_JG = core.DamageSkill("재규어 평타(재규어 스톰)", 0, (140+chtr.level)*(62+vEhc.getV(0,0))*0.01, 1 * JAGUAR_STORM_HIT, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        ClawCut_JG = core.DamageSkill("클로우 컷(재규어 스톰)", 0, (200+chtr.level)*(62+vEhc.getV(0,0))*0.01, 4 * JAGUAR_STORM_HIT, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        Crossroad_JG = core.DamageSkill("크로스 로드(재규어 스톰)", 0, (450+2*chtr.level)*(62+vEhc.getV(0,0))*0.01, 1 * JAGUAR_STORM_HIT, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 8, 3, False).wrap(core.DamageSkillWrapper)
+        SonicBoom_JG = core.DamageSkill("소닉 붐(재규어 스톰)", 0, (220+chtr.level)*(62+vEhc.getV(0,0))*0.01, 6 * JAGUAR_STORM_HIT, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        JaguarSoul_JG = core.DamageSkill("재규어 소울(재규어 스톰)", 0, (1000+20*chtr.level)*(62+vEhc.getV(0,0))*0.01, 1 * JAGUAR_STORM_HIT, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        RampageAsOne_JG = core.DamageSkill("램피지 애즈 원(재규어 스톰)", 0, (500+1*chtr.level)*(62+vEhc.getV(0,0))*0.01, 9 * JAGUAR_STORM_HIT, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
     
-    
+
         ######   Skill   ######
         #Buff skills
         SoulArrow = core.BuffSkill("소울 애로우", 0, 300*1000, rem = True, att = 20).wrap(core.BuffSkillWrapper)
-        Booster = core.BuffSkill("부스터", 0, 180 * 1000, rem = True).wrap(core.BuffSkillWrapper)    #딜레이 모름
+        Booster = core.BuffSkill("부스터", 0, 180 * 1000, rem = True).wrap(core.BuffSkillWrapper)
         Hauling = core.BuffSkill("하울링", 0, 300*1000, rem = True, patt = 10).wrap(core.BuffSkillWrapper)
         BeastForm = core.BuffSkill("비스트 폼", 0, 300*1000, rem = True, patt=20+5).wrap(core.BuffSkillWrapper)
         SharpEyes = core.BuffSkill("샤프 아이즈", 1080, (300+3*self._combat) * 1000, crit = 20 + ceil(self._combat/2), crit_damage = 15 + ceil(self._combat/2), rem = True).wrap(core.BuffSkillWrapper)
-        SilentRampage = core.BuffSkill("사일런트 램피지", 1020, 40*1000, pdamage=40, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
+
+        #Summon skills
+        HuntingUnit = core.SummonSkill("어시스턴트 헌팅 유닛", 660, 31000/90, 150, 1.5, 31000, rem=True).setV(vEhc, 4, 3, False).wrap(core.SummonSkillWrapper)
+        DrillContainer = core.SummonSkill("드릴 컨테이너", 660, 270, 430+4*self._combat, 1, 15000, cooltime = 30000, red=True, rem=True).setV(vEhc, 9, 2, False).wrap(core.SummonSkillWrapper)
         
-        WillOfLiberty = core.BuffSkill("윌 오브 리버티", 0, 60*1000, cooltime = 120*1000, pdamage = 10).wrap(core.BuffSkillWrapper)
-        
+        #Damage skills
+        WildBalkan = core.DamageSkill("와일드 발칸", 120, 370 + 2*self._combat, 1, modifier = core.CharacterModifier(boss_pdamage=10+20, pdamage=20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+
         FinalAttack70 = core.DamageSkill("파이널 어택(70)", 0, 210 + 2*passive_level, 0.01*(70+passive_level)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         FinalAttack100 = core.DamageSkill("파이널 어택(100)", 0, 210 + 2*passive_level, 1).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AnotherBite = JaguerStack(chtr.level, vEhc)
+
+        #Hyper
+        WillOfLiberty = core.BuffSkill("윌 오브 리버티", 0, 60*1000, cooltime = 120*1000, pdamage = 10).wrap(core.BuffSkillWrapper)
+        SilentRampage = core.BuffSkill("사일런트 램피지", 1020, 40*1000, pdamage=40, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
         
-        HuntingUnit = core.SummonSkill("어시스턴트 헌팅 유닛", 660, 31000/90, 150, 1.5, 31000).setV(vEhc, 4, 3, False).wrap(core.SummonSkillWrapper)
-    
-        WildBalkan = core.DamageSkill("와일드 발칸", 120, 370 + 2*self._combat, 1, modifier = core.CharacterModifier(boss_pdamage=10+20, pdamage=20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-    
+        #5th
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)
         RegistanceLineInfantry = resistance.ResistanceLineInfantryWrapper(vEhc, 3, 3)
-    
         CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 1, 1, 20)
     
-        JaguerStorm = core.BuffSkill("재규어 스톰", 840, 40*1000, cooltime = (150-vEhc.getV(0,0))*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        JaguerStorm = core.BuffSkill("재규어 스톰", 840, 40*1000, cooltime = (150-vEhc.getV(0,0))*1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         
-        AnotherBite = JaguerStack(chtr.level, vEhc)
-        #JaguerMaximum = core. 안씀..
-        #TODO : 재규어맥시멈 사용여부
-# MP 1000 소비, 12초[10초+10레벨당 1초] 동안 무적이 되어 최대 15명의 적을 2000%의 데미지로 연속해서 12번 공격하는 공격을 3회 시전 후 3600%의 데미지로 15번 마무리 공격[기본 공격: (스킬 레벨*40+1000)%의 데미지, 마무리 공격: (스킬 레벨*72+1800)%의 데미지], 추가 크리티컬 확률 100%, 몬스터 방어율 100% 추가 무시
-#공격 중 스킬을 다시 사용하여 즉시 마무리 공격 사용 가능
-#재규어에 탑승하지 않았다면 탑승한 후에 스킬을 사용하며, 탑승할 때도 무적 적용
-#재사용 대기시간 150초
+        JaguarMaximum = core.DamageSkill("재규어 맥시멈", 2160, 1000+40*vEhc.getV(5,5), 36, cooltime = 150*1000, red=True, modifier=core.CharacterModifier(crit=100, armor_ignore=100)).isV(vEhc,5,5).wrap(core.DamageSkillWrapper)
+        JaguarMaximumFinal = core.DamageSkill("재규어 맥시멈(마무리)", 630, 1800+72*vEhc.getV(5,5), 15, cooltime=-1, modifier=core.CharacterModifier(crit=100, armor_ignore=100)).isV(vEhc,5,5).wrap(core.DamageSkillWrapper)
+        RidingOff = core.DamageSkill("하차 딜레이", 1800, 0, 0, cooltime=-1).wrap(core.DamageSkillWrapper) # 재규어 맥시멈 강제 탑승 해제 딜레이
+
         WildGrenade = core.SummonSkill("와일드 그레네이드", 0, 4500, 600+24*vEhc.getV(2,2), 5, 9999*10000).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
-    
+
+        #Build Graph
         FinalAttack = core.OptionalElement(SilentRampage.is_active, FinalAttack100, FinalAttack70)
         
         WildBalkan.onAfter(FinalAttack)
         WildBalkan.onAfter(AnotherBite)
-    
-        Normal.onAfter(AnotherBite.stackController(0.15, 8000))
-        ClawCut.onAfter(AnotherBite.stackController(0.3, 8000))
-        Crossroad.onAfter(AnotherBite.stackController(0.8, 8000))
-        SonicBoom.onAfter(AnotherBite.stackController(0.4, 8000))
-        JaguarSoul.onAfter(AnotherBite.stackController(1, 8000))
-        RampageAsOne.onAfter(AnotherBite.stackController(1, 8000))
-    
-        Normal.onAfter(core.OptionalElement(JaguerStorm.is_active, Normal_JG))
-        ClawCut.onAfter(core.OptionalElement(JaguerStorm.is_active, ClawCut_JG))
-        Crossroad.onAfter(core.OptionalElement(JaguerStorm.is_active, Crossroad_JG))
-        SonicBoom.onAfter(core.OptionalElement(JaguerStorm.is_active, SonicBoom_JG))
-        JaguarSoul.onAfter(core.OptionalElement(JaguerStorm.is_active, JaguarSoul_JG))
-        RampageAsOne.onAfter(core.OptionalElement(JaguerStorm.is_active, RampageAsOne_JG))
-    
-        AnotherBite.protect_from_running()
+        
+        JaguarMaximum.onAfter(JaguarMaximumFinal)
+        JaguarMaximumFinal.onAfter(AnotherBite.add_debuff(3))
+        JaguarMaximumFinal.onAfter(RidingOff)
+
+        #Jaguar
+        JaguarSelector = None
+        for skill, stormskill, bite, delay in [(Normal, Normal_JG, 0.15, 960), (ClawCut, ClawCut_JG, 0.3, 1530),
+            (Crossroad, Crossroad_JG, 0.8, 990), (SonicBoom, SonicBoom_JG, 0.4, 960),
+            (JaguarSoul, JaguarSoul_JG, 1, 1320), (RampageAsOne, RampageAsOne_JG, 1, 1440)]:
+                if JaguarSelector == None:
+                    JaguarSelector = skill
+                else:
+                    JaguarSelector = core.OptionalElement(skill.is_available, skill, JaguarSelector)
+                skill.onAfter(AnotherBite.add_debuff(bite))
+                stormskill.onAfter(core.RepeatElement(AnotherBite.add_debuff(bite), JAGUAR_STORM_HIT))
+                skill.onAfter(core.OptionalElement(JaguerStorm.is_active, stormskill))
+                skill.onAfter(Jaguar.set_delay(delay))
+                skill.protect_from_running()
+
+        Jaguar.onTick(JaguarSelector)
 
         return(WildBalkan,
                 [globalSkill.maple_heros(chtr.level, combat_level=self._combat),
-                    CriticalReinforce, SoulArrow, Booster, Hauling, BeastForm, SharpEyes, SilentRampage, JaguerStorm,
+                    CriticalReinforce, SoulArrow, Booster, Hauling, BeastForm, SharpEyes, SilentRampage, JaguerStorm, WillOfLiberty, Jaguar,
                     globalSkill.soul_contract()] +\
-                [Normal, ClawCut, Crossroad, SonicBoom, JaguarSoul, RampageAsOne] +\
-                [HuntingUnit, GuidedArrow, RegistanceLineInfantry, WildGrenade] +\
+                [RampageAsOne, JaguarSoul, SonicBoom, Crossroad, ClawCut, Normal] +\
+                [HuntingUnit, DrillContainer, GuidedArrow, RegistanceLineInfantry, WildGrenade, JaguarMaximum] +\
                 [AnotherBite] +\
                 [WildBalkan])

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -7,7 +7,6 @@ from . import globalSkill
 from .jobclass import resistance
 from .jobbranch import bowmen
 from math import ceil
-# TODO: 드릴 컨테이너 추가
 
 class JaguerStack(core.DamageSkillWrapper):
     def __init__(self, level, vEhc):

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1493,38 +1493,6 @@ class StackSkillWrapper(BuffSkillWrapper):
         
     def judge(self, stack, direction):
         return (self.stack-stack)*direction>=0
-
-class TimeStackSkillWrapper(AbstractSkillWrapper):
-    def __init__(self, skill, max_, name = None):
-        super(TimeStackSkillWrapper, self).__init__(skill, name = name)
-        self.stack = 0
-        self._max = max_
-        self.queue = []
-        
-    def addStack(self, vary, left):
-        self.queue.append([vary, left])
-        return ResultObject(0, CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
-
-    def stackController(self, vary, left, name = None):
-        task = Task(self, partial(self.addStack, vary, left))
-        return TaskHolder(task, name = name)
-        
-    def spend_time(self, time):
-        queue = []
-        for el in self.queue:
-            el[1] -= time
-            if el[1] > 0:
-                queue.append(el)
-        self.queue = queue
-    
-    def getStack(self):
-        total = 0 
-        for el in self.queue:
-            total += el[0]
-        return max(min(total, self._max), 0)
-        
-    def get_modifier(self):
-        return CharacterModifier()
         
 class DamageSkillWrapper(AbstractSkillWrapper):
     def __init__(self, skill : DamageSkill, modifier = CharacterModifier(), name = None):


### PR DESCRIPTION
* 재규어 새로 구현
  * SummonSkill의 Tick을 이용해 캐릭터 딜레이와 관계없이 별개의 딜레이를 가지고 동작하도록 함
* 어나더 바이트 새로 구현
  * 현재부터 8초 전까지의 모든 중첩 확률이 실패할 확률을 바탕으로 스택 계산
* 재규어 스톰으로 추가 소환된 재규어도 어나더 바이트 디버프 추가되게 함
* 재규어 포획으로 받는 벞지 추가
* 재규어 스톰 패시브 빠진것 추가
* 재규어 맥시멈 추가
* 드릴 컨테이너 추가
* 안쓰게 된 core.TimeStackWrapper 제거