### PR TITLE
Fix: 패스파인더 스킬

### DIFF
--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -222,12 +222,14 @@ class JobGenerator(ck.JobGenerator):
         ComboAssultBlast.onAfter(ComboAssultBlastArrow)
         ComboAssultDischarge.onAfter(ComboAssultDischargeArrow)
         ComboAssultTransition.onAfter(ComboAssultTransitionArrow)
+
+        TripleImpact.onAfter(TripleImpact.controller(-540, "reduce_cooltime", "쿨타임 지연 540ms"))
         
         AncientAstraDischarge.onAfter(AncientAstraDischargeArrow)
         
         AncientAstraBlastRepeat = core.RepeatElement(AncientAstraBlast, 10)
         AncientAstraDischargeRepeat = core.RepeatElement(AncientAstraDischarge, 60)
-        AncientAstraTransitionRepeat = core.RepeatElement(AncientAstraTransition, 60) 
+        AncientAstraTransitionRepeat = core.RepeatElement(AncientAstraTransition, 60)
         
         # 렐릭 차지 연결
         CardinalDischarge.onAfter(RelicCharge.stackController(10*2))

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -13,7 +13,7 @@ from math import ceil
 class CardinalStateWrapper(core.BuffSkillWrapper):
     def __init__(self, ancient_force_skills):
         '''
-        DISCHARGE / BLAST / TRANSISION
+        DISCHARGE / BLAST / TRANSITION
         '''
         skill = core.BuffSkill("카디널 차지", 0, 99999999)
         super(CardinalStateWrapper, self).__init__(skill)
@@ -74,6 +74,7 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(DisableRule('스플릿 미스텔'), RuleSet.BASE)
         ruleset.add_rule(DisableRule('카디널 트랜지션'), RuleSet.BASE)
         ruleset.add_rule(ConditionRule('콤보 어썰트', '커스 트랜지션', lambda sk: sk.is_time_left(2000, -1)), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule('얼티밋 블래스트', '렐릭 차지', lambda sk: sk.judge(1000, 1)), RuleSet.BASE)
         return ruleset
 
     def get_modifier_optimization_hint(self):
@@ -204,7 +205,7 @@ class JobGenerator(ck.JobGenerator):
             
         RavenTempest = core.SummonSkill("레이븐 템페스트", 540, 250, 400+20*vEhc.getV(0,0), 5, 25*1000, cooltime = 120*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
 
-        ObsidionBarrierBlast = core.SummonSkill("옵시디언 배리어", 60, 480, 400+12*vEhc.getV(4,4), 4, 15000, cooltime = 200*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
+        ObsidionBarrierBlast = core.SummonSkill("옵시디언 배리어", 60, 510, 400+12*vEhc.getV(4,4), 4, (10+vEhc.getV(4,4)//5)*1000, cooltime = 200*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
         ######   Skill Wrapper   ######
 
         #이볼브 연계 설정
@@ -306,7 +307,7 @@ class JobGenerator(ck.JobGenerator):
         ### Exports ###
         return(CardinalBlast,
                 [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_wind_booster(),
-                    AncientBowBooster, CurseTolerance, CurseTransition, SharpEyes,
+                    RelicCharge, AncientBowBooster, CurseTolerance, CurseTransition, SharpEyes,
                     RelicEvolution, EpicAdventure,
                     AncientGuidance, AdditionalTransition, CriticalReinforce,
                     globalSkill.soul_contract()] +\

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -4,6 +4,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import DisableRule, RuleSet
 from . import globalSkill
 from .jobbranch import bowmen
 from math import ceil
@@ -74,6 +75,11 @@ class JobGenerator(ck.JobGenerator):
         self.preEmptiveSkills = 1
         self._combat = 0
 
+    def get_ruleset(self):
+        ruleset = RuleSet()
+        ruleset.add_rule(DisableRule('에인션트 아스트라'), RuleSet.BASE)
+        return ruleset
+
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self._combat
 
@@ -135,7 +141,7 @@ class JobGenerator(ck.JobGenerator):
         
         # Damage skills
         # 카디널 포스
-        CardinalDischarge = core.DamageSkill("카디널 디스차지", 360+5*passive_level, (4 + 1)*2, 300, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        CardinalDischarge = core.DamageSkill("카디널 디스차지", 360, (4 + 1)*2, 300+5*passive_level, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         AdditionalDischarge = core.DamageSkill("에디셔널 디스차지", 0, 100 + 50 + passive_level, 3*(3+1)*(0.4+0.02*passive_level+0.1)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
 
         CardinalBlast = core.DamageSkill("카디널 블래스트", 140, 4 + 1, (400+5*passive_level) * 1.1 * 1.1 * 1.1 * 1.1 * 1.1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
@@ -145,20 +151,20 @@ class JobGenerator(ck.JobGenerator):
         AdditionalTransition = core.BuffSkill("에디셔널 트랜지션", 0, 7000, cooltime = -1).wrap(core.BuffSkillWrapper) #전환시 카디널 디스/블래 사용시 40%확률로 고대 1중첩
 
         # 에인션트 포스
-        SplitMistel = core.DamageSkill("스플릿 미스텔", 540, 200+350+7*passive_level, 4, cooltime = 10*1000,
+        SplitMistel = core.DamageSkill("스플릿 미스텔", 540, 200+350+7*passive_level, 4, cooltime = 10*1000, red=True,
                     modifier = ANCIENT_FORCE).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         SplitMistelBonus = core.DamageSkill("스플릿 미스텔(보너스)", 0, 100+200+4*passive_level, 4 * 2,
                     modifier = ANCIENT_FORCE).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
 
-        TripleImpact = core.DamageSkill("트리플 임팩트", 420, 400 + 200+5*passive_level, 5*3, cooltime = 10*1000,
+        TripleImpact = core.DamageSkill("트리플 임팩트", 420, 400 + 200+5*passive_level, 5*3, cooltime = 10*1000, red=True,
                     modifier = ANCIENT_FORCE).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
                 
         #스택당 최종뎀 50이나 5스택 가정, 엣오레 임의딜레이 720
-        EdgeOfResonance = core.DamageSkill("엣지 오브 레조넌스", 720, 800+15*self._combat, 6, cooltime = 15*1000,
+        EdgeOfResonance = core.DamageSkill("엣지 오브 레조넌스", 720, 800+15*self._combat, 6, cooltime = 15*1000, red=True,
                         modifier = ANCIENT_FORCE + core.CharacterModifier(pdamage_indep = 61.051)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
         # 인챈트 포스
-        ComboAssultHolder = core.DamageSkill("콤보 어썰트", 720, 0, 0, cooltime = 20 * 1000).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        ComboAssultHolder = core.DamageSkill("콤보 어썰트", 720, 0, 0, cooltime = 20 * 1000, red=True).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         
         ComboAssultDischarge = core.DamageSkill("콤보 어썰트(디스차지)", 0, 600+10*self._combat, 7,
                 modifier = ENCHANT_FORCE).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)# 디버프 +1
@@ -176,43 +182,40 @@ class JobGenerator(ck.JobGenerator):
                 modifier = ENCHANT_FORCE).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         
         ## 하이퍼
-        RelicEvolution = core.BuffSkill("렐릭 에볼루션", 0, 0, cooltime = 120*1000).wrap(core.BuffSkillWrapper)
-        #렐릭 게이지 최대로 충전, 딜레이 0-으로 가정
+        RelicEvolution = core.BuffSkill("렐릭 에볼루션", 0, 0, cooltime = 120*1000).wrap(core.BuffSkillWrapper) #렐릭 게이지 최대로 충전, 딜레이 0으로 가정
         
-        AncientAstraHolder = core.DamageSkill("에인션트 아스트라", 630, 0, 0, cooltime = 80*1000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AncientAstraHolder = core.DamageSkill("에인션트 아스트라", 420, 0, 0, cooltime = 80*1000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         
-        # 21회 / 4회 사용
-        AncientAstraDischarge = core.DamageSkill("에인션트 아스트라(디스차지)", 710, 450, 5, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AncientAstraDischarge = core.DamageSkill("에인션트 아스트라(디스차지)", 270, 500, 6, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 16.11초 60*6타
         AncientAstraDischargeArrow = core.DamageSkill("에인션트 아스트라(디스차지)(화살)", 0, 300, 0.3*2*2,
                 modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         
-        AncientAstraBlast = core.DamageSkill("에인션트 아스트라(블래스트)", 3750, 1800, 10, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AncientAstraBlast = core.DamageSkill("에인션트 아스트라(블래스트)", 1570, 1800, 10, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 15.72초 10*10타
         
-        AncientAstraTransition = core.DamageSkill("에인션트 아스트라(트랜지션)", 710, 450, 6*3, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AncientAstraTransition = core.DamageSkill("에인션트 아스트라(트랜지션)", 270, 450, 6, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 16.11초 60*6타
         
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120*1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
         # 5차
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 3, 3)
         
-        Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(5,5)))*1000).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
-        UltimateBlast = core.DamageSkill("얼티밋 블래스트", 1800, 2500+100*vEhc.getV(2,2), 15, cooltime = 120*1000, 
+        Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(5,5)))*1000, red=True).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
+        UltimateBlast = core.DamageSkill("얼티밋 블래스트", 1800, 2000+100*vEhc.getV(2,2), 15, cooltime = 120*1000, red=True, 
                 modifier = core.CharacterModifier(armor_ignore = 100, pdamage_indep = 100) + ANCIENT_FORCE).isV(vEhc, 2,2).wrap(core.DamageSkillWrapper)
             
-        RavenTempest = core.SummonSkill("레이븐 템페스트", 720, 250, 500+20*vEhc.getV(0,0), 5, 25*1000, cooltime = 120*1000, modifier = ANCIENT_FORCE).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        RavenTempest = core.SummonSkill("레이븐 템페스트", 720, 250, 400+20*vEhc.getV(0,0), 5, 25*1000, cooltime = 120*1000, red=True, modifier = ANCIENT_FORCE).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
 
-        ObsidionBarrierBlast = core.SummonSkill("옵시디언 배리어", 60, 480, 500+18*vEhc.getV(4,4), 4, 15000,cooltime = 200*1000, modifier = ENCHANT_FORCE).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
+        ObsidionBarrierBlast = core.SummonSkill("옵시디언 배리어", 60, 480, 400+12*vEhc.getV(4,4), 4, 15000, cooltime = 200*1000, red=True, modifier = ENCHANT_FORCE).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
         ######   Skill Wrapper   ######
 
         #이볼브 연계 설정
         Evolve.onAfter(Raven.controller(1))
         Raven.onConstraint(core.ConstraintElement("이볼브 사용시 사용 금지", Evolve, Evolve.is_not_active))
-        
-    
+
         CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 1, 1, 20)
     
         RelicCharge = RelicChargeStack(AncientGuidance, chtr)
-        CardinalState = CardinalStateWrapper([SplitMistel, EdgeOfResonance, ComboAssultHolder, AncientAstraHolder])
+        CardinalState = CardinalStateWrapper([SplitMistel, TripleImpact, EdgeOfResonance, ComboAssultHolder, AncientAstraHolder])
         
         # 기본적인 스킬연계 연결
         SplitMistel.onAfter(SplitMistelBonus)
@@ -222,12 +225,12 @@ class JobGenerator(ck.JobGenerator):
         
         AncientAstraDischarge.onAfter(AncientAstraDischargeArrow)
         
-        AncientAstraBlastRepeat = core.RepeatElement(AncientAstraBlast, 21)
-        AncientAstraDischargeRepeat = core.RepeatElement(AncientAstraDischarge, 4)
-        AncientAstraTransitionRepeat = core.RepeatElement(AncientAstraTransition, 21) 
+        AncientAstraBlastRepeat = core.RepeatElement(AncientAstraBlast, 10)
+        AncientAstraDischargeRepeat = core.RepeatElement(AncientAstraDischarge, 60)
+        AncientAstraTransitionRepeat = core.RepeatElement(AncientAstraTransition, 60) 
         
         # 렐릭 차지 연결
-        CardinalDischarge.onAfter(RelicCharge.stackController(20))
+        CardinalDischarge.onAfter(RelicCharge.stackController(10*2))
         CardinalBlast.onAfter(RelicCharge.stackController(20))
         CardinalTransition.onAfter(RelicCharge.stackController(20))
         
@@ -246,8 +249,9 @@ class JobGenerator(ck.JobGenerator):
         ComboAssultHolder.onConstraint(core.ConstraintElement('150', RelicCharge, partial(RelicCharge.judge, 150, 1)))
         
         AncientAstraHolder.onConstraint(core.ConstraintElement('300', RelicCharge, partial(RelicCharge.judge, 300, 1)))
-        AncientAstraDischarge.onAfter(RelicCharge.stackController(-300))
-        AncientAstraTransition.onAfter(RelicCharge.stackController(-57))
+        AncientAstraBlast.onAfter(RelicCharge.stackController(-65*1.57))
+        AncientAstraDischarge.onAfter(RelicCharge.stackController(-65*0.27))
+        AncientAstraTransition.onAfter(RelicCharge.stackController(-65*0.27))
         
         RavenTempest.onConstraint(core.ConstraintElement('300', RelicCharge, partial(RelicCharge.judge, 300, 1)))
         RavenTempest.onAfter(RelicCharge.stackController(-300))
@@ -292,14 +296,8 @@ class JobGenerator(ck.JobGenerator):
         CardinalTransition_ForceUse = core.DamageSkill("카디널 트랜지션(강제)", 0, 0, 0, cooltime = 12000).wrap(core.DamageSkillWrapper)
         CardinalTransition_ForceUse.onAfter(CardinalTransition)
         
-        #에인션트 아스트라는 레이븐과 맞추고, 레이븐 이후 트랜지션 전환 후에 사용하도록 스케줄
-        
-        AncientAstraHolder.onBefore(CardinalTransition)
-        #ObsidionBarrierBlast.set_disabled_and_time_left(10000)
-        
-        # 딜비중 높은 극딜기는 가이던스와 싱크로. -> 미사용함.
-        #RavenTempest.onConstraint(core.ConstraintElement("가이던스와 같이", AncientGuidance, AncientGuidance.is_active))
-        #UltimateBlast.onConstraint(core.ConstraintElement("가이던스와 같이", AncientGuidance, AncientGuidance.is_active))
+        # 아스트라는 디스차지로 사용
+        AncientAstraHolder.onBefore(CardinalDischarge)
         
         ### Exports ###
         return(CardinalBlast,

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -76,6 +76,9 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(ConditionRule('콤보 어썰트', '커스 트랜지션', lambda sk: sk.is_time_left(2000, -1)), RuleSet.BASE)
         return ruleset
 
+    def get_modifier_optimization_hint(self):
+        return core.CharacterModifier(pdamage=50, armor_ignore=15, crit_damage=20)
+
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self._combat
 
@@ -105,6 +108,7 @@ class JobGenerator(ck.JobGenerator):
         '''
         에인션트 아스트라 사용하지 않음
         콤보 어썰트는 커스 트랜지션의 지속시간이 2초 이하 남았을때 사용
+        블래 210ms 디차 270ms (http://m.inven.co.kr/board/maple/2304/17507)
         
         하이퍼
         
@@ -120,8 +124,7 @@ class JobGenerator(ck.JobGenerator):
         미스텔 미사용(데미지 감소함)
         '''
         passive_level = chtr.get_base_modifier().passive_level + self._combat
-        ANCIENT_FORCE = core.CharacterModifier(pdamage_indep=10, boss_pdamage=50+20, armor_ignore=20)
-        ENCHANT_FORCE = core.CharacterModifier(pdamage_indep=10, boss_pdamage=50)
+        ANCIENT_ARCHERY = core.CharacterModifier(pdamage_indep=10, boss_pdamage=50+20, armor_ignore=20)
         ######   Skill   ######
         # Buff skills
         AncientBowBooster = core.BuffSkill("에인션트 보우 부스터", 0, 300*1000, rem=True).wrap(core.BuffSkillWrapper)
@@ -131,64 +134,64 @@ class JobGenerator(ck.JobGenerator):
         CurseTransition = core.BuffSkill("커스 트랜지션", 0, 15*1000, crit_damage = 20, cooltime=-1).wrap(core.BuffSkillWrapper) # 5스택 유지 가정
 
         # Summon skills
-        Raven = core.SummonSkill("레이븐", 450, 2670, 390, 4, 220*1000).setV(vEhc, 8, 3, False).wrap(core.SummonSkillWrapper)
+        Raven = core.SummonSkill("레이븐", 0, 2670, 390, 4, 220*1000).setV(vEhc, 8, 3, False).wrap(core.SummonSkillWrapper) # 이볼브 종료시 자동 소환되므로 딜레이 0
         
         # Damage skills
         # 카디널 포스
-        CardinalDischarge = core.DamageSkill("카디널 디스차지", 250, (4 + 1)*2, 300+5*passive_level, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        CardinalDischarge = core.DamageSkill("카디널 디스차지", 270, (4 + 1)*2, 300+5*passive_level, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         AdditionalDischarge = core.DamageSkill("에디셔널 디스차지", 0, 100 + 50 + passive_level, 3*3*(0.4+0.1)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         AdditionalDischargeEvolution = core.DamageSkill("에디셔널 디스차지(렐릭 에볼루션)", 0, 100 + 50 + passive_level, 3*(0.4+0.1)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
 
-        CardinalBlast = core.DamageSkill("카디널 블래스트", 250, 4 + 1, 400+5*passive_level, modifier = core.CharacterModifier(pdamage = 20, pdamage_indep = 61.051)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        CardinalBlast = core.DamageSkill("카디널 블래스트", 210, 4 + 1, 400+5*passive_level, modifier = core.CharacterModifier(pdamage = 20, pdamage_indep = 61.051)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         AdditionalBlast = core.DamageSkill("에디셔널 블래스트", 0, 150 + 50 + passive_level, 2*3*(0.4+0.1)).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         AdditionalBlastEvolution = core.DamageSkill("에디셔널 블래스트(렐릭 에볼루션)", 0, 150 + 50 + passive_level, 3*(0.4+0.1)).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
-        CardinalTransition = core.DamageSkill("카디널 트랜지션", 250, 540+7*passive_level, 5).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        CardinalTransition = core.DamageSkill("카디널 트랜지션", 210, 540+7*passive_level, 5).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         AdditionalTransition = core.BuffSkill("에디셔널 트랜지션", 0, 7000, cooltime = -1).wrap(core.BuffSkillWrapper) #전환시 카디널 디스/블래 사용시 40%확률로 고대 1중첩
 
         # 에인션트 포스
         SplitMistel = core.DamageSkill("스플릿 미스텔", 540, 200+350+7*passive_level, 4, cooltime = 10*1000, red=True,
-                    modifier = ANCIENT_FORCE).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+                    modifier = ANCIENT_ARCHERY).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         SplitMistelBonus = core.DamageSkill("스플릿 미스텔(보너스)", 0, 100+200+4*passive_level, 4 * 2,
-                    modifier = ANCIENT_FORCE).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+                    modifier = ANCIENT_ARCHERY).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
 
         TripleImpact = core.DamageSkill("트리플 임팩트", 420, 400 + 200+5*passive_level, 5*3, cooltime = 10*1000, red=True,
-                    modifier = ANCIENT_FORCE).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+                    modifier = ANCIENT_ARCHERY).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
                 
-        #스택당 최종뎀 50이나 5스택 가정, 엣오레 임의딜레이 720
-        EdgeOfResonance = core.DamageSkill("엣지 오브 레조넌스", 720, 800+15*self._combat, 6, cooltime = 15*1000, red=True,
-                        modifier = ANCIENT_FORCE + core.CharacterModifier(pdamage_indep = 61.051)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        # 5스택 가정, 다른 스킬 사용 중에 시전가능
+        EdgeOfResonance = core.DamageSkill("엣지 오브 레조넌스", 0, 800+15*self._combat, 6, cooltime = 15*1000, red=True,
+                        modifier = ANCIENT_ARCHERY + core.CharacterModifier(pdamage_indep = 61.051)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
         # 인챈트 포스
-        ComboAssultHolder = core.DamageSkill("콤보 어썰트", 720, 0, 0, cooltime = 20 * 1000, red=True).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        ComboAssultHolder = core.DamageSkill("콤보 어썰트", 0, 0, 0, cooltime = 20 * 1000, red=True).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         
-        ComboAssultDischarge = core.DamageSkill("콤보 어썰트(디스차지)", 0, 600+10*self._combat, 7,
-                modifier = ENCHANT_FORCE).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)# 디버프 +1
-        ComboAssultDischargeArrow = core.DamageSkill("콤보 어썰트(디스차지)(화살)", 0, 650+10*self._combat, 5,
-                modifier = ENCHANT_FORCE).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        ComboAssultDischarge = core.DamageSkill("콤보 어썰트(디스차지)", 600, 600+10*self._combat, 7,
+                modifier = ANCIENT_ARCHERY).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)# 디버프 +1
+        ComboAssultDischargeArrow = core.DamageSkill("콤보 어썰트(디스차지)(화살)", 150, 650+10*self._combat, 5,
+                modifier = ANCIENT_ARCHERY).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         
-        ComboAssultBlast = core.DamageSkill("콤보 어썰트(블래스트)", 0, 600+10*self._combat, 8,
-                modifier = ENCHANT_FORCE).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)# 디버프 +1
-        ComboAssultBlastArrow = core.DamageSkill("콤보 어썰트(블래스트)(화살)", 0, 600+10*self._combat, 5,
-                modifier = ENCHANT_FORCE).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        ComboAssultBlast = core.DamageSkill("콤보 어썰트(블래스트)", 600, 600+10*self._combat, 8,
+                modifier = ANCIENT_ARCHERY).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)# 디버프 +1
+        ComboAssultBlastArrow = core.DamageSkill("콤보 어썰트(블래스트)(화살)", 150, 600+10*self._combat, 5,
+                modifier = ANCIENT_ARCHERY).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         
-        ComboAssultTransition = core.DamageSkill("콤보 어썰트(트랜지션)", 0, 600+10*self._combat, 7,
-                modifier = ENCHANT_FORCE).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)# 디버프 +5
-        ComboAssultTransitionArrow = core.DamageSkill("콤보 어썰트(트랜지션)(화살)", 0, 650+10*self._combat, 5,
-                modifier = ENCHANT_FORCE).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        ComboAssultTransition = core.DamageSkill("콤보 어썰트(트랜지션)", 600, 600+10*self._combat, 7,
+                modifier = ANCIENT_ARCHERY).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)# 디버프 +5
+        ComboAssultTransitionArrow = core.DamageSkill("콤보 어썰트(트랜지션)(화살)", 150, 650+10*self._combat, 5,
+                modifier = ANCIENT_ARCHERY).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         
         ## 하이퍼
         RelicEvolution = core.BuffSkill("렐릭 에볼루션", 0, 30*1000, cooltime = 120*1000).wrap(core.BuffSkillWrapper) # 딜레이 0으로 가정
         
         AncientAstraHolder = core.DamageSkill("에인션트 아스트라", 420, 0, 0, cooltime = 80*1000).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         
-        AncientAstraDischarge = core.DamageSkill("에인션트 아스트라(디스차지)", 270, 500, 6, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 16.11초 60*6타
+        AncientAstraDischarge = core.DamageSkill("에인션트 아스트라(디스차지)", 270, 500, 6, modifier = ANCIENT_ARCHERY).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 16.11초 60*6타
         AncientAstraDischargeArrow = core.DamageSkill("에인션트 아스트라(디스차지)(화살)", 0, 300, 0.3*2*2,
-                modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+                modifier = ANCIENT_ARCHERY).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         
-        AncientAstraBlast = core.DamageSkill("에인션트 아스트라(블래스트)", 1570, 1800, 10, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 15.72초 10*10타
+        AncientAstraBlast = core.DamageSkill("에인션트 아스트라(블래스트)", 1570, 1800, 10, modifier = ANCIENT_ARCHERY).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 15.72초 10*10타
         
-        AncientAstraTransition = core.DamageSkill("에인션트 아스트라(트랜지션)", 270, 450, 6, modifier = ENCHANT_FORCE).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 16.11초 60*6타
+        AncientAstraTransition = core.DamageSkill("에인션트 아스트라(트랜지션)", 270, 450, 6, modifier = ANCIENT_ARCHERY).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 16.11초 60*6타
         
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120*1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
@@ -196,12 +199,12 @@ class JobGenerator(ck.JobGenerator):
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 3, 3)
         
         Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(5,5)))*1000, red=True).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
-        UltimateBlast = core.DamageSkill("얼티밋 블래스트", 1800, 2000+100*vEhc.getV(2,2), 15, cooltime = 120*1000, red=True, 
-                modifier = core.CharacterModifier(armor_ignore = 100, pdamage_indep = 100) + ANCIENT_FORCE).isV(vEhc, 2,2).wrap(core.DamageSkillWrapper)
+        UltimateBlast = core.DamageSkill("얼티밋 블래스트", 1350, 2000+100*vEhc.getV(2,2), 15, cooltime = 120*1000, red=True, 
+                modifier = core.CharacterModifier(armor_ignore = 100) + ANCIENT_ARCHERY).isV(vEhc, 2,2).wrap(core.DamageSkillWrapper)
             
-        RavenTempest = core.SummonSkill("레이븐 템페스트", 720, 250, 400+20*vEhc.getV(0,0), 5, 25*1000, cooltime = 120*1000, red=True, modifier = ANCIENT_FORCE).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        RavenTempest = core.SummonSkill("레이븐 템페스트", 540, 250, 400+20*vEhc.getV(0,0), 5, 25*1000, cooltime = 120*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
 
-        ObsidionBarrierBlast = core.SummonSkill("옵시디언 배리어", 60, 480, 400+12*vEhc.getV(4,4), 4, 15000, cooltime = 200*1000, red=True, modifier = ENCHANT_FORCE).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
+        ObsidionBarrierBlast = core.SummonSkill("옵시디언 배리어", 60, 480, 400+12*vEhc.getV(4,4), 4, 15000, cooltime = 200*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
         ######   Skill Wrapper   ######
 
         #이볼브 연계 설정
@@ -257,6 +260,10 @@ class JobGenerator(ck.JobGenerator):
         ObsidionBarrierBlast.onAfter(RelicCharge.stackController(-500))
         
         RelicEvolution.onAfter(RelicCharge.stackController(1000))
+
+        UltimateBlast.onConstraint(core.ConstraintElement('200 이상', RelicCharge, partial(RelicCharge.judge, 200, 1)))
+        UltimateBlast.onAfter(RelicCharge.stackController(-1000))
+        UltimateBlast.add_runtime_modifier(RelicCharge, lambda charge: core.CharacterModifier(pdamage_indep = (charge.stack // 250) * 25))
         
         #카디널 차지 연결
         CardinalBlast.onAfter(core.OptionalElement(partial(CardinalState.is_state, "DISCHARGE"), AdditionalDischarge))


### PR DESCRIPTION
fix #176 
fix #46 
fix #122 

## 공통
* 쿨감 적용
* 코드 순서 정리

## 카디널 포스
* 카디널 디스차지 컴뱃 값 잘못 입력된것 수정
* 카디널 포스 스킬 딜레이 실험 기반으로 수정
  * 클라상으로도 cancelableTime 210ms, 블래에만 있는 updatableTime 60ms로 어느정도 맞아떨어짐
* 렐릭 에볼루션의 마법 화살 추가 발사가 항상 적용되던것 수정
* 에디셔널 디스차지/블래스트/트랜지션 발동 조건을 게임 로직과 동일하게 맞춤

## 에인션트 포스, 인챈트 포스
* 에인션트 포스, 인챈트 포스 modifier 상수 분리
* 에인션트 포스 하이퍼가 인챈트 포스에도 적용되도록 수정
* 콤보 어썰트(블래스트)에 에인션트 포스 modifier 적용된것 인챈트 포스로 수정
* 레이븐 템페스트에 누락된 에인션트 포스 modifier 적용
* 엣지 오브 레조넌스 다른 스킬 사용중에 시전 가능한것 반영해 딜레이 제거
* 콤보 어썰트(디스차지)(화살) 타수 수정
* 콤보 어썰트(트랜지션) 타수 수정
* 콤보 어썰트 딜레이 활대/화살 공격 각각 분리해서 적용
* 상태 전환시 쿨감되는 스킬에 트리플 임팩트 빠진것 추가
* 트리플 임팩트가 사용 후 약 540ms 후에 쿨타임이 돌아가는 것을 반영

## 렐릭 게이지
* 카디널 블래스트가 렐릭 게이지 쌓지 않던것 수정
* 에인션트 가이던스 활성화 게이지가 렐릭 차지가 최대일때도 쌓이던것 수정

## 에인션트 아스트라
* 딜레이,퍼뎀,타수 수정

## 얼티밋 블래스트
* 퍼뎀 수정
* 딜레이에 공속 적용
* 렐릭 게이지 소모하지 않던것 수정
* 항상 렐릭 게이지 1000을 가정하고 최종뎀 적용하던것 사용시 게이지 참조하도록 수정

## 레이븐 템페스트
* 딜레이에 공속 적용
   퍼뎀 수정

## 옵시디언 배리어
* 퍼뎀, 공격주기, 지속시간 수정

## 딜사이클
* 커스 트랜지션 갱신은 말뚝딜에선 콤보 어썰트만으로 가능하므로 딜사이클 수정
  * 트랜지션 사용하지 않음
  * 커스 트랜지션의 지속시간이 2초 이하 남았을때 콤보 어썰트 사용
* 얼티밋 블래스트를 게이지 1000일때만 사용하도록 함
* 에인션트 안쓰는게 dpm이 높으므로 딜사이클에서 제거

## 기타
* 레이븐은 이볼브 종료시 자동 소환되므로 시전 딜레이 제거
* 불필요한 CardinalBlastBasic 제거