### PR TITLE
fix: 메르세데스 스킬

### DIFF
--- a/dpmModule/jobs/mercedes.py
+++ b/dpmModule/jobs/mercedes.py
@@ -1,9 +1,10 @@
+from ..kernel.graph import DynamicVariableOperation
 from ..kernel import core
 from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from ..execution.rules import RuleSet, ReservationRule, ConcurrentRunRule
+from ..execution.rules import RuleSet, ConcurrentRunRule
 from . import globalSkill
 from .jobclass import heroes
 from .jobbranch import bowmen
@@ -12,27 +13,25 @@ from math import ceil
 #TODO : 5차 신스킬 적용
 
 class ElementalGhostWrapper(core.BuffSkillWrapper):
-    def __init__(self, vEhc, target1, target2):
-        skill = core.BuffSkill("엘리멘탈 고스트", 780, (40 + vEhc.getV(0,0))*1000, cooltime = 150 * 1000).isV(vEhc,0,0)#딜레이 모름
+    def __init__(self, vEhc, num1, num2):
+        skill = core.BuffSkill("엘리멘탈 고스트", 720, (40+vEhc.getV(num1,num2))*1000, cooltime=150*1000, red=True)
         super(ElementalGhostWrapper, self).__init__(skill)
-        self.target = [target1, target2]
-        self.vlevel = vEhc.getV(0,0)
-        
-    def spend_time(self, time : int) -> None :  #TODO : can make this process more faster.. maybe
-        self.timeLeft -= time
-        self.cooltimeLeft -= time
-        if self.timeLeft < 0:
-            self.onoff = False
-            self.target[0].pdamage_indep = 0
-            self.target[1].pdamage_indep = 0
-        if self.cooltimeLeft < 0:
-            self.available = True
-    
-    def _use(self, skill_modifier):
-        self.target[0].pdamage_indep = 64.687 * 0.01 * (30 + self.vlevel)
-        self.target[1].pdamage_indep = 184.5 * 0.01 * (30 + self.vlevel)
-        return super(ElementalGhostWrapper, self)._use(skill_modifier)
+        self.ratio = (30 + vEhc.getV(num1, num2)) * 0.01
+        self.prob = 0.9 + 0.7 + 0.5
 
+    def addSkill(self, skill_wrapper, is_fast):
+        p = self.prob
+        if is_fast:
+            p /= 2
+        
+        original_skill = skill_wrapper.skill
+        copial_skill = core.DamageSkill(name = DynamicVariableOperation.reveal_argument(original_skill.name) + f"(엘고)",
+            delay = DynamicVariableOperation.wrap_argument(0),
+            damage = original_skill.damage * DynamicVariableOperation.wrap_argument(self.ratio),
+            hit = original_skill.hit * p,
+            modifier=original_skill._static_skill_modifier).wrap(core.DamageSkillWrapper)
+        
+        skill_wrapper.onAfter(core.OptionalElement(self.is_active, copial_skill, name="엘고 ON"))
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -46,12 +45,9 @@ class JobGenerator(ck.JobGenerator):
 
     def get_ruleset(self):
         ruleset = RuleSet()
-        ruleset.add_rule(ReservationRule('엘리멘탈 고스트', '소울 컨트랙트'), RuleSet.BASE)
-        # ruleset.add_rule(ReservationRule('히어로즈 오쓰', '이르칼라의 숨결'), RuleSet.BASE)
-        # ruleset.add_rule(ReservationRule('크리티컬 리인포스', '이르칼라의 숨결'), RuleSet.BASE)
         ruleset.add_rule(ConcurrentRunRule('크리티컬 리인포스', '엘리멘탈 고스트'), RuleSet.BASE)
-        # ruleset.add_rule(ReservationRule('엘리멘탈 고스트', '이르칼라의 숨결'), RuleSet.BASE)
-        ruleset.add_rule(ConcurrentRunRule('이르칼라의 숨결','엘리멘탈 고스트'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('이르칼라의 숨결', '엘리멘탈 고스트'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('소울 컨트랙트', '엘리멘탈 고스트'), RuleSet.BASE)
         return ruleset
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
@@ -77,7 +73,7 @@ class JobGenerator(ck.JobGenerator):
         WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 30)
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -7.5+0.5*ceil(passive_level/2))        
 
-        IgnisRoarStack = core.InformedCharacterModifier("이그니스 로어(스택)",pdamage_indep = 2*10)#유지되나?       
+        IgnisRoarStack = core.InformedCharacterModifier("이그니스 로어(스택)",pdamage_indep = 2*10)
         
         return [WeaponConstant, Mastery, IgnisRoarStack]
         
@@ -86,84 +82,142 @@ class JobGenerator(ck.JobGenerator):
         
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
+        하이퍼
+        이슈타르의 링-리인포스, 이그노어 가드, 보스 킬러
+        레전드리 스피어-리듀스 아머, 링크드 리인포스
+
         코강 순서
+        이슈, 스듀/파택, 엘리멘탈, 래쓰오브엔릴, 레전드리, 유니콘, 맆토/다이브
         
-        이슈, 스듀/파택, 엘리멘탈, 래쓰오브엔릴, 레전드리, 유니콘
-        
-        엘리멘탈 고스트는 최종뎀으로 계산되며 각각 64.687, 184.5%의 최종뎀을 받음
-        최종뎀으로 계산함으로서 맥뎀 부분에서 약간의 오류가 발생할 수 있으나 미미함
-        소울 컨트랙트, 히어로즈 오쓰, 크리티컬 리인포스는 모두 이르칼라와 함께 사용되도록 함
+        엘리멘탈 고스트, 이르칼라의 숨결, 크리티컬 리인포스, 소울 컨트랙트를 함께 사용
+
+        실피디아 사용하지 않음
+
+        엘고 연계
+        스듀-엔릴-스듀-유니콘-스듀-스피어-맆토-거다
         '''
         passive_level = chtr.get_base_modifier().passive_level + self._combat
 
-        #Buff skills
+        # Buff skill
         Booster = core.BuffSkill("부스터", 0, 180000, rem = True).wrap(core.BuffSkillWrapper)
-        HerosOath = core.BuffSkill("히어로즈 오쓰", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
+        AncientSpirit = core.BuffSkill("엔시언트 스피릿", 0, (200+5*self._combat) * 1000, patt = 30+self._combat, rem=True).wrap(core.BuffSkillWrapper)
+
+        # Summon skill
+        ElementalKnights = core.DamageSkill("엘리멘탈 나이트", 0, 0, 0, cooltime=120*1000, red=True).setV(vEhc, 2, 3, False).wrap(core.DamageSkillWrapper) #도트 반영필요
+        ElementalKnights_1 = core.SummonSkill("엘리멘탈 나이트(1)", 0, 1470, (385+385+485)/3, 1, 210 * 1000, cooltime=-1, rem=True).setV(vEhc, 2, 3, False).wrap(core.SummonSkillWrapper)
+        ElementalKnights_2 = core.SummonSkill("엘리멘탈 나이트(2)", 0, 1470, (385+385+485)/3, 1, 210 * 1000, cooltime=-1, rem=True).setV(vEhc, 2, 3, False).wrap(core.SummonSkillWrapper)
         
-        UnicornSpike = core.DamageSkill("유니콘 스파이크", 780, 315+100 + 2*self._combat, 5, modifier = core.CharacterModifier(crit=100), cooltime = 30 * 1000).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)#딜레이 모름
-        UnicornSpikeBuff = core.BuffSkill("유니콘 스파이크(버프)", 0, 30 * 1000, pdamage = 30, cooltime = -1).wrap(core.BuffSkillWrapper)  #직접시전 금지
-        
+        # Damage skill
         IshtarRing = core.DamageSkill("이슈타르의 링", 120, 220 + self._combat, 2, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-        RegendrySpear = core.DamageSkill("레전드리 스피어", 660, 700 + 10*self._combat, 3, modifier = core.CharacterModifier(crit=100, pdamage = 20), cooltime = 30 * 1000).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)  #870 -> 660
-        RegendrySpearBuff = core.BuffSkill("레전드리 스피어(버프)", 0, (30+self._combat) * 1000, armor_ignore = 30+20+self._combat, cooltime = 99999 * 1000).wrap(core.BuffSkillWrapper) #직접시전 금지
         
-        AncientSpirit = core.BuffSkill("엔시언트 스피릿", 780, (200+5*self._combat) * 1000, patt = 30+self._combat).wrap(core.BuffSkillWrapper)#딜레이 모름    
-    
-        AdvanceStrikeDualShot = core.DamageSkill("어드밴스드 스트라이크 듀얼샷", 480, 380, 4).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #630 -> 480
-    
-        ElementalKnights = core.SummonSkill("엘리멘탈 나이트", 680, 1500, (385+385+485)/3, 210/120, 120 *1000).setV(vEhc, 2, 3, False).wrap(core.SummonSkillWrapper) #가동률을 타수로 반영, 210/360 가동률 100% 도트 반영필요, 딜레이 모름.
+        # 연계 스킬들 - 연계시 딜레이로 작성
+        UnicornSpike = core.DamageSkill("유니콘 스파이크", 450, 315+100 + 2*self._combat, 5, modifier = core.CharacterModifier(crit=100), cooltime = 10 * 1000, red=True).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        UnicornSpikeBuff = core.BuffSkill("유니콘 스파이크(버프)", 0, 30 * 1000, pdamage = 30, cooltime = -1).wrap(core.BuffSkillWrapper)  #직접시전 금지
+        RegendrySpear = core.DamageSkill("레전드리 스피어", 690, 700 + 10*self._combat, 3, cooltime = 5 * 1000, red=True, modifier = core.CharacterModifier(crit=100)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        RegendrySpearBuff = core.BuffSkill("레전드리 스피어(버프)", 0, (30+self._combat) * 1000, armor_ignore = 30+20+self._combat, cooltime = -1).wrap(core.BuffSkillWrapper) #직접시전 금지
+        LightningEdge = core.DamageSkill("라이트닝 엣지", 630, 420 + 5*self._combat, 3).wrap(core.DamageSkillWrapper)
+        LightningEdgeBuff = core.BuffSkill("라이트닝 엣지(버프)", 0, 30000, cooltime=-1).wrap(core.BuffSkillWrapper)
+        LeapTornado = core.DamageSkill("리프 토네이도", 390, 390+30+3*self._combat, 0).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        GustDive = core.DamageSkill("거스트 다이브", 480, 430 + 3*self._combat, 4).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         
-        ElvishBlessing = core.BuffSkill("엘비시 블레싱", 780, 60 * 1000, cooltime = 90 * 1000, att = 80).wrap(core.BuffSkillWrapper) #딜레이 모름!
-        
+        AdvanceStrikeDualShot = core.DamageSkill("어드밴스드 스트라이크 듀얼샷", 480, 380, 4).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvanceStrikeDualShot_Link = core.DamageSkill("어드밴스드 스트라이크 듀얼샷(연계)", 360, 380, 4).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+
         AdvancedFinalAttackFast = core.DamageSkill("어드밴스드 파이널 어택(속사)", 0, 120 + passive_level, 2*0.01*(75 + passive_level)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedFinalAttackSlow = core.DamageSkill("어드밴스드 파이널 어택(일반)", 0, 120 + passive_level, 2*0.01*(75 + passive_level)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
     
-        WrathOfEllil = core.DamageSkill("래쓰 오브 엔릴", 600, 400, 10, cooltime = 7 * 1000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)#연꼐시 1초 감소, 딜레이 모름!=>7초로 감소 반영.
+        # Hyper
+        ElvishBlessing = core.BuffSkill("엘비시 블레싱", 900, 60 * 1000, cooltime = 90 * 1000, att = 80).wrap(core.BuffSkillWrapper)
+        WrathOfEllil = core.DamageSkill("래쓰 오브 엔릴", 210, 400, 10, cooltime = 8 * 1000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper) #연계시 딜레이
+        HerosOath = core.BuffSkill("히어로즈 오쓰", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
-        Sylphidia = core.BuffSkill("실피디아", 0, (30 + 0.5*vEhc.getV(5,5)) * 1000, cooltime = 150 * 1000, patt = (5+0.5*vEhc.getV(5,5))).isV(vEhc,5,5).wrap(core.BuffSkillWrapper)  #정보 없음..
-        
-        IrkilaBreathInit = core.DamageSkill("이르칼라의 숨결", 720, 0, 0, cooltime = 150 * 1000).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
-        IrkilaBreathTick = core.DamageSkill("이르칼라의 숨결(틱)", 150, 425+15*vEhc.getV(1,1), 8).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        # 5th
+        Sylphidia = core.BuffSkill("실피디아", 0, (30 + vEhc.getV(5,5)//2) * 1000, cooltime = 150 * 1000, red=True, patt = (5+vEhc.getV(5,5)//2)).isV(vEhc,5,5).wrap(core.BuffSkillWrapper) # 정보 없음
+        ElementalGhost = ElementalGhostWrapper(vEhc, 0, 0)
+        ElementalGhostSpirit = core.DamageSkill("엘리멘탈 고스트(정령의 기운)", 0, 450+15*vEhc.getV(0,0), 8, cooltime=10*1000).wrap(core.DamageSkillWrapper)
+        IrkilaBreathInit = core.DamageSkill("이르칼라의 숨결", 900, 0, 0, cooltime = 150 * 1000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        IrkilaBreathTick = core.DamageSkill("이르칼라의 숨결(틱)", 150, 400+16*vEhc.getV(1,1), 8).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
 
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)
-
-        ElementalGhostFast = core.CharacterModifier()
-        ElementalGhostSlow = core.CharacterModifier()
     
         ######   Skill Wrapper   ######
         #Buff
-        ElementalGhost = ElementalGhostWrapper(vEhc, ElementalGhostFast, ElementalGhostSlow)
-        Frid = heroes.FridWrapper(vEhc, 3, 3)
-        
-        AdvancedFinalAttackFast.modifier = ElementalGhostFast
-        AdvancedFinalAttackSlow.modifier = ElementalGhostSlow
-        
         CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 2, 2, 10)
+
+        #Summon
+        ElementalKnights.onAfter(core.OptionalElement(ElementalKnights_1.is_active, ElementalKnights_2, ElementalKnights_1))
     
         #Damage
-        UnicornSpike.onAfter(UnicornSpikeBuff.controller(1))
-        RegendrySpear.onAfter(RegendrySpearBuff.controller(1))
-        WrathOfEllil.onAfter(AdvanceStrikeDualShot)
+        UnicornSpike.onAfter(UnicornSpikeBuff)
+        RegendrySpear.onAfter(RegendrySpearBuff)
+        LightningEdge.onAfter(LightningEdgeBuff)
+        IshtarRing.add_runtime_modifier(LightningEdgeBuff, lambda sk: core.CharacterModifier(pdamage = sk.is_active() * 20))
     
         IrkilaBreath = core.RepeatElement(IrkilaBreathTick, 52)
         IrkilaBreathInit.onAfter(IrkilaBreath)
+
+        #Cooldown
+        LinkAttack = core.DamageSkill("연계", 0, 0, 0).wrap(core.DamageSkillWrapper)
+        LinkAttack.onAfter(WrathOfEllil.controller(1000, "reduce_cooltime"))
+        LinkAttack.onAfter(UnicornSpike.controller(1000, "reduce_cooltime"))
+        LinkAttack.onAfter(RegendrySpear.controller(1000, "reduce_cooltime"))
+        LinkAttack.onAfter(ElementalGhostSpirit.controller(1000, "reduce_cooltime"))
         
-        # 극딜기 몰아서 사용하기
-        SoulContract = globalSkill.soul_contract()
-            
-        for wrp in [UnicornSpike, AdvanceStrikeDualShot, RegendrySpear, WrathOfEllil]:
+        #Deal Cycle
+        DebuffCombo = core.DamageSkill("디버프 콤보", 0, 0, 0).wrap(core.DamageSkillWrapper)
+        DebuffComboList = [AdvanceStrikeDualShot_Link, WrathOfEllil, AdvanceStrikeDualShot_Link,
+                            UnicornSpike, AdvanceStrikeDualShot_Link, LightningEdge, AdvanceStrikeDualShot_Link,
+                            RegendrySpear, WrathOfEllil, AdvanceStrikeDualShot]
+        DebuffCombo.onAfter(DebuffComboList[0])
+        for sk in DebuffComboList[1:]:
+            DebuffCombo.onAfter(sk)
+            DebuffCombo.onAfter(LinkAttack)
+
+        ElementalGhostCombo = core.DamageSkill("엘고 콤보", 0, 0, 0).wrap(core.DamageSkillWrapper)
+        ElementalGhostComboList = [AdvanceStrikeDualShot_Link, WrathOfEllil, AdvanceStrikeDualShot_Link,
+                                    UnicornSpike, AdvanceStrikeDualShot_Link, RegendrySpear, LeapTornado, GustDive]
+        ElementalGhostCombo.onAfter(ElementalGhostComboList[0])
+        for sk in ElementalGhostComboList[1:]:
+            ElementalGhostCombo.onAfter(sk)
+            ElementalGhostCombo.onAfter(LinkAttack)
+
+        BasicAttack = core.DamageSkill("기본 공격", 0, 0, 0).wrap(core.DamageSkillWrapper)
+        BasicAttack.onAfter(
+            core.OptionalElement(ElementalGhost.is_active, ElementalGhostCombo,
+                core.OptionalElement(UnicornSpikeBuff.is_not_active, DebuffCombo, IshtarRing)
+            )
+        )
+
+        # TODO: 실피디아 사용시 연계 딜레이와 디버프 콤보 조사하고, 딜 증가하는지 확인할 것
+        # Sylphidia.onConstraint(core.ConstraintElement("엘고와 따로 사용", ElementalGhost, lambda: ElementalGhost.is_not_active() and ElementalGhost.is_not_usable()))
+
+        #Final Attack, Elemental Ghost
+        UseElementalGhostSpirit = core.OptionalElement(lambda: ElementalGhost.is_active() and ElementalGhostSpirit.is_available(), ElementalGhostSpirit, name="정령의 기운 조건")
+
+        for wrp in [UnicornSpike, RegendrySpear, LightningEdge, LeapTornado, GustDive,
+                    AdvanceStrikeDualShot, AdvanceStrikeDualShot_Link, WrathOfEllil]:
+            ElementalGhost.addSkill(wrp, is_fast=False)
             wrp.onAfter(AdvancedFinalAttackSlow)
-            wrp.modifier = ElementalGhostSlow
+            wrp.onAfter(UseElementalGhostSpirit)
+        ElementalGhost.addSkill(AdvancedFinalAttackSlow, is_fast=False) # 파택에 잔상 적용하는것과 잔상 공격에 파택 따로 적용하는것 결과적으로 동일함
             
         for wrp in [IshtarRing, IrkilaBreathTick]:
+            ElementalGhost.addSkill(wrp, is_fast=True)
             wrp.onAfter(AdvancedFinalAttackFast)
-            wrp.modifier = ElementalGhostFast
+            wrp.onAfter(UseElementalGhostSpirit)
+        ElementalGhost.addSkill(AdvancedFinalAttackFast, is_fast=True)
+
+        for sk in [UnicornSpike, RegendrySpear, WrathOfEllil, ElementalGhostSpirit]:
+            sk.protect_from_running()
+
+        for sk in [UnicornSpikeBuff, RegendrySpearBuff, LightningEdgeBuff]:
+            sk.set_disabled_and_time_left(1) # 버프 묻은 채로 측정 시작
     
-        return(IshtarRing,
+        return(BasicAttack,
                 [globalSkill.maple_heros(chtr.level, combat_level=self._combat), globalSkill.useful_sharp_eyes(), 
-                    Booster, ElvishBlessing, AncientSpirit, HerosOath, Frid, Sylphidia.ignore(), CriticalReinforce, UnicornSpikeBuff, RegendrySpearBuff, ElementalGhost,
-                    SoulContract] +\
-                [UnicornSpike, RegendrySpear, WrathOfEllil, IrkilaBreathInit] +\
-                [ElementalKnights, GuidedArrow] +\
+                    Booster, ElvishBlessing, AncientSpirit, HerosOath, Sylphidia.ignore(), CriticalReinforce, UnicornSpikeBuff, RegendrySpearBuff, LightningEdgeBuff, ElementalGhost,
+                    globalSkill.soul_contract()] +\
+                [ElementalGhostSpirit, UnicornSpike, RegendrySpear, WrathOfEllil, IrkilaBreathInit] +\
+                [ElementalKnights, ElementalKnights_1, ElementalKnights_2, GuidedArrow] +\
                 [] +\
-                [IshtarRing])
+                [BasicAttack])


### PR DESCRIPTION
* 엘리멘탈 고스트를 최종뎀 증가가 아닌 잔상 데미지 이어붙이는 것으로 처리
  * 연산량이 많이 늘어나긴 하는데, 일단 맥뎀 생각해서 구현해둠
* 엘리멘탈 나이트 2개체 소환되게 함
* 스킬 딜레이 전부 수정
* 쿨감 받는 스킬 전부 적용
* 엘리멘탈 고스트 도중 연계 딜사이클 적용
* 디버프 리필 연계 딜사이클 적용
* 크리인, 엘고, 이르칼라, 소울 컨트랙트 맞춰쓰게 함