### PR TITLE
fix: 제로 스킬

### DIFF
--- a/dpmModule/item/Absolab.py
+++ b/dpmModule/item/Absolab.py
@@ -72,6 +72,11 @@ class Factory():
         return WeaponFactory.getBlade(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
     
     @staticmethod
+    def getZeroSubweapon(_type, potential = it.ExMDF(), additional_potential = it.ExMDF(), bonusElse = it.ExMDF()):
+
+        return WeaponFactory.getZeroSubweapon(_type, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
+    
+    @staticmethod
     def getSetOption(rank):
         li = [it.ExMDF(), 
                 it.ExMDF(att = 20), 

--- a/dpmModule/item/Arcane.py
+++ b/dpmModule/item/Arcane.py
@@ -68,6 +68,11 @@ class Factory():
         return WeaponFactory.getBlade(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
     
     @staticmethod
+    def getZeroSubweapon(_type, potential = it.ExMDF(), additional_potential = it.ExMDF(), bonusElse = it.ExMDF()):
+
+        return WeaponFactory.getZeroSubweapon(_type, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
+    
+    @staticmethod
     def getSetOption(rank):
         li = [it.ExMDF(), 
                 it.ExMDF(att = 30), 

--- a/dpmModule/item/Default.py
+++ b/dpmModule/item/Default.py
@@ -27,5 +27,7 @@ def getEmblem(potential = it.ExMDF(), additional_potential = it.ExMDF()):
 def get_subweapon_covering_exception(_type, star, elist, potential = it.ExMDF(), additional_potential = it.ExMDF(), factory_hook=None):
     if _type == '블레이드':
         return factory_hook.getBlade(_type, star=star, elist=elist, potential = potential, additional_potential = additional_potential)
+    elif _type == '제로무기':
+        return factory_hook.getZeroSubweapon(_type, potential = potential, additional_potential = additional_potential)
     else:
         return getSubweapon(potential=potential, additional_potential=additional_potential)

--- a/dpmModule/item/ItemKernel.py
+++ b/dpmModule/item/ItemKernel.py
@@ -338,6 +338,14 @@ class WeaponFactoryClass():
         item.set_potential(potential)
         item.set_additional_potential(additional_potential)
         return item
+
+    def getZeroSubweapon(self, _type, potential = ExMDF(), additional_potential = ExMDF(), bonusElse = ExMDF()):
+        assert(_type == '제로무기')
+        item = Item(name = "제로보조", main_option = self.modifier, level = self.level)
+        item.add_main_option(bonusElse)
+        item.set_potential(potential)
+        item.set_additional_potential(additional_potential)
+        return item
     
     def getMap(self, _type):
         return self.valueMap[self.typeMap[_type]]

--- a/dpmModule/item/RootAbyss.py
+++ b/dpmModule/item/RootAbyss.py
@@ -61,6 +61,11 @@ class Factory():
     def getBlade(_type, star, elist, potential = it.ExMDF(), additional_potential = it.ExMDF(), bonusElse = it.ExMDF()):
 
         return WeaponFactory.getBlade(_type, star = star, elist = elist, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
+    
+    @staticmethod
+    def getZeroSubweapon(_type, potential = it.ExMDF(), additional_potential = it.ExMDF(), bonusElse = it.ExMDF()):
+
+        return WeaponFactory.getZeroSubweapon(_type, potential = potential, additional_potential = additional_potential, bonusElse = bonusElse)
 
     @staticmethod
     def getSetOption(rank):

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -3,6 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import RuleSet, MutualRule
 from . import globalSkill
 from .jobbranch import warriors
 from math import ceil
@@ -12,42 +13,28 @@ from math import ceil
 '''
 어시스트 매커니즘 정리
 
-항상 알파: 스핀 커터 오라, 롤링 커브 오라, 롤링 어썰터 오라
-항상 베타: 파워 스텀프 충격파
-
-알파 스킬에 대검 마스터리의 데미지 증가 적용 여부는 아직 모름
+항상 알파 스탯 적용: 스핀 커터 오라, 롤링 커브 오라, 롤링 어썰터 오라
+항상 베타 스탯 적용: 파워 스텀프 충격파
 
 https://github.com/Monolith11/memo/wiki/Zero-Skill-Mechanics
 '''
 
-# 현재로는 계산 알고리즘 작성 구문에서 연산과정에 접근을 할 수 없도록 캡슐화되어 있으므로 사용 불가능
-'''
-class LimitBreakNew():
-    def __init__(self, enhancer, skill_importance, enhance_importance):
-        self.damage_start = 0
-        self.damage_end = 0
-        self.analytics = core.Analytics()
-        self.vLevel = enhancer.getV(skill_importance, enhance_importance)
+class CriticalBindWrapper(core.BuffSkillWrapper):
+    def __init__(self, alphaState: core.BuffSkillWrapper, betaState: core.BuffSkillWrapper):
+        skill = core.BuffSkill("크리티컬 바인드", 0, 4000, cooltime=35000, crit=30, crit_damage=20)
+        super(CriticalBindWrapper, self).__init__(skill)
+        self.alphaState = alphaState
+        self.betaState = betaState
 
-        self.LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*self.vLevel, 5).isV(enhancer, skill_importance, enhance_importance).wrap(core.DamageSkillWrapper)
-        self.LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+self.vLevel//2)*1000, pdamage_indep = (30+self.vLevel//5) * 1.2 + 20, cooltime = 240*1000).isV(enhancer, skill_importance, enhance_importance).wrap(core.BuffSkillWrapper)
-        self.LimitBreak.onAfter(self.LimitBreakAttack)
-        
-    def LimitBreakStart(self):
-        self.damage_start = self.analytics.total_damage
-        return LimitBreak
+    def get_modifier(self):
+        if self.alphaState.is_not_active():
+            return self.disabledModifier
+        return super(CriticalBindWrapper, self).get_modifier()
 
-    def LimitBreakEnd(self):
-        self.damage_end = self.analytics.total_damage - self.damage_start
-        # 지속시간 동안 가한 데미지의 20% / 15
-        # 퍼뎀이 아니라 고정값으로 뜨게 수정해야 함
-        return core.DamageSkill("리미트 브레이크(막타)", 0, damage_end / 75, 15).wrap(core.DamageSkillWrapper)
-    def get_buff(self):
-        return self.LimitBreak
-
-# LimitBreakSet = LimitBreakNew(vEhc, 0, 0)
-# LimitBreak = LimitBreakSet.get_buff()
-'''
+    def is_usable(self):
+        if self.betaState.is_not_active():
+            return False
+        return super(CriticalBindWrapper, self).is_usable()
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -60,29 +47,31 @@ class JobGenerator(ck.JobGenerator):
         self.preEmptiveSkills = 2
         self._combat = 0
 
-        # 베타 무기 기본공 +4
-        self.Alpha = core.CharacterModifier(pdamage_indep = 34, crit = 40, att = 40, armor_ignore = 30, crit_damage = 50)
-        self.Beta = core.CharacterModifier(pdamage_indep = 49, crit = 15, boss_pdamage = 30, att = 80 + 4)
+    def get_ruleset(self):
+        ruleset = RuleSet()
+        ruleset.add_rule(MutualRule('타임 홀딩', '소울 컨트랙트'), RuleSet.BASE)
+        ruleset.add_rule(MutualRule('타임 홀딩', '타임 디스토션'), RuleSet.BASE)
+        return ruleset
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
         ResolutionTime = core.InformedCharacterModifier("리졸브 타임",pdamage_indep = 25, stat_main = 50)
-        AlphaState = core.InformedCharacterModifier("상태-알파") + self.Alpha.extend()
 
-        return [Mastery, ResolutionTime, AlphaState]
+        return [Mastery, ResolutionTime]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         ArmorSplit = core.InformedCharacterModifier("아머 스플릿", armor_ignore = 50)
         return [ArmorSplit]
 
     def get_modifier_optimization_hint(self):
-        return core.CharacterModifier(crit = 15, pdamage = 30, armor_ignore = 20)
+        return core.CharacterModifier(crit = 15, pdamage = 80, armor_ignore = 20, crit_damage = 25)
         
     def generate(self, vEhc, chtr : ck.AbstractCharacter, combat : bool = False):
         '''
         마스터리 별개로 적용 : 알파 : 1.34, 베타 : 1.49
         
         디바인 스위프트 사용
+        리미트 브레이크 도중에만 디바인 포스 사용
 
         코강 순서
         
@@ -100,38 +89,33 @@ class JobGenerator(ck.JobGenerator):
         어파스 기준
         '''
         #### 마스터리 ####
-        # 알파: 크리티컬 바인드 크뎀 평균값 적용
-        # 베타: 패시브 스킬 차이만큼 적용
-        # extra_dmg(x, y): x = 타겟 수, y = 코강으로 인한 타겟수 증가여부
-        #### 마스터리 ####
-        AlphaMastery = self.Alpha
-        BetaMastery = self.Beta
-
-        AlphaBetaDiff = BetaMastery - AlphaMastery
+        AlphaMDF = core.CharacterModifier(pdamage_indep = 34, crit = 40, att = 40, armor_ignore = 30, crit_damage = 50)
+        BetaMDF = core.CharacterModifier(pdamage_indep = 49, crit = 15, boss_pdamage = 30, att = 80 + 4)
         
-        # 알파: 크리티컬 바인드 크뎀 평균값 적용
-        AlphaState = core.BuffSkill("상태-알파", 0, 9999*10000, cooltime = -1, crit_damage = (20*4/35)).wrap(core.BuffSkillWrapper)
+        AlphaState = core.BuffSkill("상태-알파", 0, 9999*10000, cooltime = -1,
+            pdamage_indep = AlphaMDF.pdamage_indep,
+            crit = AlphaMDF.crit,
+            boss_pdamage = AlphaMDF.boss_pdamage,
+            att = AlphaMDF.att,
+            armor_ignore = AlphaMDF.armor_ignore,
+            crit_damage = AlphaMDF.crit_damage).wrap(core.BuffSkillWrapper)
         BetaState = core.BuffSkill("상태-베타", 0, 9999*10000, cooltime = -1,
-            pdamage_indep = AlphaBetaDiff.pdamage_indep,
-            crit = AlphaBetaDiff.crit,
-            boss_pdamage = AlphaBetaDiff.boss_pdamage,
-            att = AlphaBetaDiff.att,
-            armor_ignore = AlphaBetaDiff.armor_ignore,
-            crit_damage = AlphaBetaDiff.crit_damage
+            pdamage_indep = BetaMDF.pdamage_indep,
+            crit = BetaMDF.crit,
+            boss_pdamage = BetaMDF.boss_pdamage,
+            att = BetaMDF.att,
+            armor_ignore = BetaMDF.armor_ignore,
+            crit_damage = BetaMDF.crit_damage
         ).wrap(core.BuffSkillWrapper)
 
-        OnlyAlpha = core.CharacterModifier(crit_damage = (20*4/35)) - AlphaBetaDiff
-        OnlyBeta = core.CharacterModifier() - OnlyAlpha
-
-        Assist = core.BuffSkill("어시스트 상태", 0, 3000, cooltime = -1, rem = False, red = False).wrap(core.BuffSkillWrapper)
-
+        # extra_dmg(x, y): x = 타겟 수, y = 코강으로 인한 타겟수 증가여부
         extra_dmg = lambda x, y : (core.CharacterModifier(pdamage = (x - 1 + int(y))*8))
 
         #### 알파 ####
-        MoonStrike = core.DamageSkill("문 스트라이크", 390, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        MoonStrike = core.DamageSkill("문 스트라이크", 330, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         MoonStrikeTAG = core.DamageSkill("문 스트라이크(태그)", 0, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
-        PierceStrike = core.DamageSkill("피어스 쓰러스트", 510, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        PierceStrike = core.DamageSkill("피어스 쓰러스트", 360, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         PierceStrikeTAG = core.DamageSkill("피어스 쓰러스트(태그)", 0, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
         '''
@@ -140,86 +124,74 @@ class JobGenerator(ck.JobGenerator):
         ShadowStrike = core.DamageSkill("쉐도우 스트라이크", ?, 195, 8)
         ShadowStrikeAura = core.DamageSkill("쉐도우 스트라이크", 0, 310, 1)
         '''
-        FlashAssault = core.DamageSkill("플래시 어썰터", 480, 165, 8).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        FlashAssault = core.DamageSkill("플래시 어썰터", 270, 165, 8).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         FlashAssaultTAG = core.DamageSkill("플래시 어썰터(태그)", 0, 165, 8).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        
-        ### Dummy Skills
-        _SpinCutter = core.DamageSkill("스핀 커터", 630, 260, 10).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) 
-        _RollingCurve = core.DamageSkill("롤링 커브", 960, 365, 12).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        _RollingAssulter = core.DamageSkill("롤링 어썰터", 960, 375, 12).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        _StormBreak = core.DamageSkill("스톰 브레이크", 690, 335, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        ### Dummy SKill End 
 
-        AdvancedSpinCutter = core.DamageSkill("어드밴스드 스핀 커터", 630, 260+3*self._combat, 10).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedSpinCutter = core.DamageSkill("어드밴스드 스핀 커터", 270, 260+3*self._combat, 10).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedSpinCutterTAG = core.DamageSkill("어드밴스드 스핀 커터(태그)", 0, 260+3*self._combat, 10).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedSpinCutterAura = core.DamageSkill("어드밴스드 스핀 커터(오라)", 0, 130+3*self._combat, 4).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedSpinCutterAuraTAG = core.DamageSkill("어드밴스드 스핀 커터(오라)(태그)", 0, 130+3*self._combat, 4, modifier = OnlyAlpha).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedSpinCutterAuraTAG = core.DamageSkill("어드밴스드 스핀 커터(오라)(태그)", 0, 130+3*self._combat, 4, modifier=AlphaMDF-BetaMDF).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) # 항상 알파 스탯이 적용됨
         
         AdvancedRollingCurve = core.DamageSkill("어드밴스드 롤링 커브", 960, 365+3*self._combat, 12).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedRollingCurveTAG = core.DamageSkill("어드밴스드 롤링 커브(태그)", 0, 365+3*self._combat, 12).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedRollingCurveAura = core.DamageSkill("어드밴스드 롤링 커브(오라)", 0, 350+self._combat, 2).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingCurveAuraTAG = core.DamageSkill("어드밴스드 롤링 커브(오라)(태그)", 0, 350+self._combat, 2*2, modifier = OnlyAlpha).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingCurveAuraTAG = core.DamageSkill("어드밴스드 롤링 커브(오라)(태그)", 0, 350+self._combat, 2*2, modifier=AlphaMDF-BetaMDF).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper) # 항상 알파 스탯이 적용됨, 각 투사체가 2회 타격함
         
         AdvancedRollingAssulter = core.DamageSkill("어드밴스드 롤링 어썰터", 960, 375+2*self._combat, 12).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedRollingAssulterTAG = core.DamageSkill("어드밴스드 롤링 어썰터(태그)", 0, 375+2*self._combat, 12).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedRollingAssulterAura = core.DamageSkill("어드밴스드 롤링 어썰터(오라)", 0, 250+self._combat, 3).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedRollingAssulterAuraTAG = core.DamageSkill("어드밴스드 롤링 어썰터(오라)(태그)", 0, 250+self._combat, 3*4, modifier = OnlyAlpha).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedRollingAssulterAuraTAG = core.DamageSkill("어드밴스드 롤링 어썰터(오라)(태그)", 0, 250+self._combat, 3*2*2, modifier=AlphaMDF-BetaMDF).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper) # 항상 알파 스탯이 적용됨, 2회 사출, 각 투사체가 2회 타격함
         
-        WindCutter = core.DamageSkill("윈드 커터", 540, 165, 8).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        WindCutter = core.DamageSkill("윈드 커터", 420, 165, 8).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         WindCutterSummon = core.SummonSkill("윈드 커터(소환)", 0, 500, 110, 3, 3000, cooltime=-1).setV(vEhc, 7, 2, False).wrap(core.SummonSkillWrapper)
-        #WindCutterSummon = core.DamageSkill("윈드 커터(소환)", 0, 110, 3*3).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper) #3타 타격
 
-        WindStrike = core.DamageSkill("윈드 스트라이크",600, 250, 8).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        WindStrike = core.DamageSkill("윈드 스트라이크", 480, 250, 8).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
 
-        StormBreak = core.DamageSkill("어드밴스드 스톰 브레이크", 690, 335+2*self._combat, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        StormBreakSummon = core.SummonSkill("어드밴스드 스톰 브레이크(소환)", 0, 500, 335+2*self._combat, 4, 3000, cooltime=-1).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        #StormBreakSummon = core.DamageSkill("어드밴스드 스톰 브레이크(소환)", 0, 335+2*self._combat, 4).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) #2타 타격
-        StormBreakElectric = core.SummonSkill("어드밴스드 스톰 브레이크(전기)", 0, 1000, 230+2*self._combat, 1, (3+ ceil(self._combat /10))*1000, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        #StormBreakElectric = core.DamageSkill("어드밴스드 스톰 브레이크(전기)", 0, 230+2*self._combat, 3+ceil(self._combat /10), cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedStormBreak = core.DamageSkill("어드밴스드 스톰 브레이크", 690, 335+2*self._combat, 10).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedStormBreakSummon = core.SummonSkill("어드밴스드 스톰 브레이크(소환)", 0, 500, 335+2*self._combat, 4, 3000, cooltime=-1).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
+        AdvancedStormBreakElectric = core.SummonSkill("어드밴스드 스톰 브레이크(전기)", 0, 1000, 230+2*self._combat, 1, (3+ ceil(self._combat /10))*1000, cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
 
         # 도트스킬은 크뎀 미적용이므로 AlphaSkill 추가할 필요없음.
         DivineLeer = core.DotSkill("디바인 리어", 0, 1000, 200, 1, 99999999).wrap(core.SummonSkillWrapper)
 
         #### 베타 ####
 
-        UpperStrike = core.DamageSkill("어퍼 슬래시", 690, 210, 6, modifier = extra_dmg(6, True)).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        UpperStrikeTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6, modifier = extra_dmg(6, True)).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UpperSlash = core.DamageSkill("어퍼 슬래시", 390, 210, 6, modifier = extra_dmg(6, True)).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        UpperSlashTAG = core.DamageSkill("어퍼 슬래시(태그)", 0, 210, 6, modifier = extra_dmg(6, True)).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
-        AirRiot = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330 + 5*self._combat, 9, modifier = extra_dmg(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330 + 5*self._combat, 9, modifier = extra_dmg(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330 + 5*self._combat, 9, modifier = extra_dmg(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
-        AirRiotWaveTAG = core.DamageSkill("어드밴스드 파워 스텀프(파동)(태그)", 0, 330 + 5*self._combat, 9, modifier = OnlyBeta).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AdvancedPowerStomp = core.DamageSkill("어드밴스드 파워 스텀프", 570, 330 + 5*self._combat, 9, modifier = extra_dmg(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AdvancedPowerStompTAG = core.DamageSkill("어드밴스드 파워 스텀프(태그)", 0, 330 + 5*self._combat, 9, modifier = extra_dmg(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AdvancedPowerStompWave = core.DamageSkill("어드밴스드 파워 스텀프(파동)", 0, 330 + 5*self._combat, 9, modifier = extra_dmg(6, True)).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        AdvancedPowerStompWaveTAG = core.DamageSkill("어드밴스드 파워 스텀프(파동)(태그)", 0, 330 + 5*self._combat, 9, modifier = extra_dmg(6, True) + BetaMDF-AlphaMDF).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper) # 항상 베타 스탯이 적용됨
         
         THROWINGHIT = 5
-        FlashCut = core.DamageSkill("프론트 슬래시", 630, 205, 6, modifier = extra_dmg(6, True)).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
+        FrontSlash = core.DamageSkill("프론트 슬래시", 450, 205, 6, modifier = extra_dmg(6, True)).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 360, 300, 550 + 5*self._combat, 2, THROWINGHIT*300, cooltime=-1, modifier = extra_dmg(6, True)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
-        #ThrowingWeapon = core.DamageSkill("어드밴스드 스로잉 웨폰", 360, 550 + 5*self._combat, 2 * 5, modifier = extra_dmg(6, True)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)    #5타 = 1.5s
         
-        SpinDriver = core.DamageSkill("터닝 드라이브", 540, 260, 6, modifier = extra_dmg(6, True)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 540, 200+2*self._combat, 2*7, modifier = extra_dmg(6, True)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
+        TurningDrive = core.DamageSkill("터닝 드라이브", 360, 260, 6, modifier = extra_dmg(6, True)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedWheelWind = core.DamageSkill("어드밴스드 휠 윈드", 900, 200+2*self._combat, 2*7, modifier = extra_dmg(6, True)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)     #   0.1초당 1타, 최대 7초, 7타로 적용
         
-        GigaCrash = core.DamageSkill("기가 크래시", 630, 250, 6, modifier = extra_dmg(6, True)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        GigaCrash = core.DamageSkill("기가 크래시", 540, 250, 6, modifier = extra_dmg(6, True)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         GigaCrashTAG = core.DamageSkill("기가 크래시(태그)", 0, 250, 6, modifier = extra_dmg(6, True)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
         
-        FallingStar = core.DamageSkill("점핑 크래시", 660, 225, 6, modifier = extra_dmg(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
-        # 충격파 값 포함
-        FallingStarTAG = core.DamageSkill("점핑 크래시(태그)", 0, 225, 6, modifier = extra_dmg(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
-        FallingStarWave = core.DamageSkill("점핑 크래시(충격파)", 0, 225, 3, modifier = extra_dmg(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        JumpingCrash = core.DamageSkill("점핑 크래시", 300, 225, 6, modifier = extra_dmg(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        JumpingCrashTAG = core.DamageSkill("점핑 크래시(태그)", 0, 225, 6, modifier = extra_dmg(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
+        JumpingCrashWave = core.DamageSkill("점핑 크래시(충격파)", 0, 225, 3, modifier = extra_dmg(6, True)).setV(vEhc, 8, 2, False).wrap(core.DamageSkillWrapper)
         
-        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 1170, 380+3*self._combat, 10, modifier = extra_dmg(6, True)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        AdvancedEarthBreak = core.DamageSkill("어드밴스드 어스 브레이크", 630+390, 380+3*self._combat, 10, modifier = extra_dmg(6, True)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedEarthBreakTAG = core.DamageSkill("어드밴스드 어스 브레이크(태그)", 0, 380+3*self._combat, 10, modifier = extra_dmg(6, True)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) 
         
         AdvancedEarthBreakWave = core.DamageSkill("어드밴스드 어스 브레이크(파동)", 0, 285+3*self._combat, 10, modifier = extra_dmg(6, True)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        
-        #AdvancedEarthBreakElectric = core.DotSkill("어드밴스드 어스 브레이크(전기)", 340+3*self._combat, 5).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
-        #AdvancedEarthBreakElectric = core.DamageSkill("어드밴스드 어스 브레이크(전기)", 0, 340+3*self._combat, 5, modifier = extra_dmg(6, True), cooltime = -1).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         AdvancedEarthBreakElectric = core.SummonSkill("어드밴스드 어스 브레이크(전기)", 0, 1000, 340+3*self._combat, 1, 5000, cooltime = -1, modifier = extra_dmg(6, True)).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
 
+        CriticalBind = CriticalBindWrapper(AlphaState, BetaState)
+
+        #### 초월자 스킬 ####
 
         DoubleTime = core.BuffSkill("래피드 타임", 0, 9999*10000, crit = 20, pdamage = 10).wrap(core.BuffSkillWrapper)
         TimeDistortion = core.BuffSkill("타임 디스토션", 540, 30000, cooltime = 240 * 1000, pdamage = 25).wrap(core.BuffSkillWrapper)
         TimeHolding = core.BuffSkill("타임 홀딩", 1080, 90000, cooltime = 180*1000, pdamage = 10, red = False).wrap(core.BuffSkillWrapper) #  쿨타임 초기화.(타임 리와 / 리미트 브레이크 제외)
-        IntensiveTime = core.BuffSkill("인탠시브 타임", 0, 40*60*1000, patt = 4).wrap(core.BuffSkillWrapper)
+        # 인탠시브 타임 - 기본 도핑에 영메 포함되어 있음
 
         # 알파 4410ms 베타 4980ms
         #ShadowRain = core.DamageSkill("쉐도우 레인", 0, 1400, 14, cooltime = 300*1000).wrap(core.DamageSkillWrapper)
@@ -232,27 +204,26 @@ class JobGenerator(ck.JobGenerator):
         
         LimitBreakAttack = core.DamageSkill("리미트 브레이크", 0, 400+15*vEhc.getV(0,0), 5, modifier = extra_dmg(15, False)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         # 리미트 브레이크 중에는 디바인 포스 사용 (공격력 20 증가)
-        LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+vEhc.getV(0,0)//2)*1000, pdamage_indep = (30+vEhc.getV(0,0)//5) *1.2 + 20, att = 20, cooltime = 240*1000).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        # 리미트 브레이크 막타뎀을 임시로 최종뎀으로 처리, (1+0.36)*(1+0.2)-1 = 0.36*1.2 + 0.2
+        LimitBreak = core.BuffSkill("리미트 브레이크(버프)", 450, (30+vEhc.getV(0,0)//2)*1000, pdamage_indep = (30+vEhc.getV(0,0)//5) *1.2 + 20, att = 20, cooltime = 240*1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        LimitBreakCDR = core.SummonSkill("리미트 브레이크(재사용 대기시간 감소)", 0, 1000, 0, 0, (30+vEhc.getV(0,0)//2)*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         
         #LimitBreakFinal = core.DamageSkill("리미트 브레이크 (막타)", 0, '''지속시간 동안 가한 데미지의 20% / 15''', 15)
         # 베타로 사용함.
-        TwinBladeOfTime = core.DamageSkill("조인트 어택", 0, 0, 0, cooltime = 120*1000, modifier = extra_dmg(12, False)).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_1 = core.DamageSkill("조인트 어택(1)", 3480, 875+35*vEhc.getV(1,1), 8, modifier = extra_dmg(12, False)).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_2 = core.DamageSkill("조인트 어택(2)", 0, 835+33*vEhc.getV(1,1), 8, modifier = extra_dmg(12, False)).wrap(core.DamageSkillWrapper)
-        TwinBladeOfTime_3 = core.DamageSkill("조인트 어택(3)", 0, 1000+40*vEhc.getV(1,1), 13, modifier = extra_dmg(12, False)).wrap(core.DamageSkillWrapper)
-        # 45타수가 시스템상으로 잘 반영되는지 확인필요.
-        TwinBladeOfTime_end = core.DamageSkill("조인트 어택(4)", 0, 900+36*vEhc.getV(1,1), 45, modifier = (extra_dmg(12, False) + core.CharacterModifier(armor_ignore = 100))).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime = core.DamageSkill("조인트 어택", 0, 0, 0, cooltime = 120*1000, red=True, modifier = extra_dmg(12, False)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_1 = core.DamageSkill("조인트 어택(1)", 3540, 875+35*vEhc.getV(1,1), 8, modifier = extra_dmg(12, False)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_2 = core.DamageSkill("조인트 어택(2)", 0, 835+33*vEhc.getV(1,1), 8, modifier = extra_dmg(12, False)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_3 = core.DamageSkill("조인트 어택(3)", 0, 1000+40*vEhc.getV(1,1), 13, modifier = extra_dmg(12, False)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        TwinBladeOfTime_end = core.DamageSkill("조인트 어택(4)", 1050, 900+36*vEhc.getV(1,1), 15*3, modifier = (extra_dmg(12, False) + core.CharacterModifier(armor_ignore = 100))).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         
         #알파
-        ShadowFlashAlpha = core.DamageSkill("쉐도우 플래시(알파)", 670, 500+20*vEhc.getV(2,2), 6, cooltime = 40*1000, red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
-        ShadowFlashAlphaEnd = core.DamageSkill("쉐도우 플래시(알파)(종료)", 0, 400+16*vEhc.getV(2,2), 15*3).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashAlpha = core.DamageSkill("쉐도우 플래시(알파)", 510, 500+20*vEhc.getV(2,2), 6, cooltime = 40*1000, red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashAlphaEnd = core.DamageSkill("쉐도우 플래시(알파)(종료)", 660, 400+16*vEhc.getV(2,2), 15*3).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         #베타
-        ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 670, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, modifier = extra_dmg(8, False), red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
-        ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 0, 750+30*vEhc.getV(2,2), 12 * 2, modifier = extra_dmg(8, False)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 510, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, modifier = extra_dmg(8, False), red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 660, 750+30*vEhc.getV(2,2), 12 * 2, modifier = extra_dmg(8, False)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
-        ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)
-
         #초월자 륀느의 기원
         '''
         RhinneBless = core.BuffSkill("초월자 륀느의 기원", 630, 30+vEhc.getV(0, 0)//2, cooltime = 240000, att = 10+3*vEhc.getV(0, 0)).wrap(core.BuffSkillWrapper)
@@ -262,119 +233,87 @@ class JobGenerator(ck.JobGenerator):
 
 
         ######   Skill Wrapper   ######
-        
-        '''제로의 콤보 사용방식 정리!
-        터닝드라이브-휠윈드 /  프론트슬래시-쓰로잉웨폰 / 어퍼슬래시-파워스텀프 / 
-        롤커 - 어드밴스드롤어 / 플래시어썰터-스핀커터 / 문스트라이크 - 피어스쓰러스트
-        
-        윈드커터-윈드스트라이크-스톰브레이크 / 문스트라이크-피어스쓰러스트 / 문스트라이크-피어스 쓰러스트 /
-        기가크래시-점핑크래시-어드어스브레이크 / 어퍼슬래시-파워스텀프 / 어퍼슬래시-파워스텀프/
-        '''
-
         ### 스킬 연결 ###
         ### 알파 ###
-        MoonStrike.onAfter(PierceStrike)
-        MoonStrikeTAG.onAfter(PierceStrikeTAG)
-        
-        FlashAssault.onAfter(AdvancedSpinCutter)
         AdvancedSpinCutter.onAfter(AdvancedSpinCutterAura)
-        
-        FlashAssaultTAG.onAfter(AdvancedSpinCutterTAG)
         AdvancedSpinCutterTAG.onAfter(AdvancedSpinCutterAuraTAG)
         
         AdvancedRollingCurve.onAfter(AdvancedRollingCurveAura)
         AdvancedRollingCurveTAG.onAfter(AdvancedRollingCurveAuraTAG)
         
-        AdvancedRollingCurve.onAfter(AdvancedRollingAssulter)
-        AdvancedRollingCurveTAG.onAfter(AdvancedRollingAssulterTAG)
-        
         AdvancedRollingAssulter.onAfter(AdvancedRollingAssulterAura)
         AdvancedRollingAssulterTAG.onAfter(AdvancedRollingAssulterAuraTAG)
         
         WindCutter.onAfter(WindCutterSummon)
-        WindCutter.onAfter(WindStrike)
-        WindStrike.onAfter(StormBreak)
-        StormBreak.onAfters([StormBreakElectric, StormBreakSummon])
+        AdvancedStormBreak.onAfter(AdvancedStormBreakElectric)
+        AdvancedStormBreak.onAfter(AdvancedStormBreakSummon)
         
         ### 베타 ###
-        UpperStrike.onAfter(AirRiot)
-        UpperStrikeTAG.onAfter(AirRiotTAG)
-        
-        AirRiot.onAfter(AirRiotWave)
-        AirRiotTAG.onAfter(AirRiotWaveTAG)
-        
-        FlashCut.onAfter(ThrowingWeapon)
-        SpinDriver.onAfter(AdvancedWheelWind)
-        
-        GigaCrash.onAfter(FallingStar)
-        FallingStar.onAfters([AdvancedEarthBreak, FallingStarWave])
+        AdvancedPowerStomp.onAfter(AdvancedPowerStompWave)
+        AdvancedPowerStompTAG.onAfter(AdvancedPowerStompWaveTAG)
+                
+        JumpingCrash.onAfter(JumpingCrashWave)
         AdvancedEarthBreak.onAfter(AdvancedEarthBreakWave)
         AdvancedEarthBreak.onAfter(AdvancedEarthBreakElectric)
         
-        GigaCrashTAG.onAfter(FallingStarTAG)
-        FallingStarTAG.onAfters([AdvancedEarthBreakTAG, FallingStarWave])
+        JumpingCrashTAG.onAfter(JumpingCrashWave)
         AdvancedEarthBreakTAG.onAfter(AdvancedEarthBreakWave)
         AdvancedEarthBreakTAG.onAfter(AdvancedEarthBreakElectric)
         
-        ### 어시스트 연결 ###
-        SpinDriver.onAfter(AdvancedRollingCurveTAG)
-        FlashCut.onAfter(FlashAssaultTAG)
-        UpperStrike.onAfter(MoonStrikeTAG)
-        
-        WindCutter.onAfter(GigaCrashTAG)
-        MoonStrike.onAfter(UpperStrikeTAG)
-        
         ### 상태 태그! ###
         SetAlpha = core.GraphElement("알파로 태그")
-        #SetAlpha.onAfter(AlphaState)
-        #SetAlpha.onAfter(BetaState.controller(-1))
-        SetAlpha.onAfters([AlphaState, BetaState.controller(-1), Assist])
+        SetAlpha.onAfter(AlphaState)
+        SetAlpha.onAfter(BetaState.controller(-1))
         SetBeta = core.GraphElement("베타로 태그")
-        #SetBeta.onAfter(BetaState)
-        #SetBeta.onAfter(AlphaState.controller(-1))
-        SetBeta.onAfters([BetaState, AlphaState.controller(-1), Assist])
+        SetBeta.onAfter(BetaState)
+        SetBeta.onAfter(AlphaState.controller(-1))
+
+        AlphaState.controller(1) # 알파로 시작
+        
+        ### 어파스 생성
+        # 윈커(0ms) - 윈스(420ms) - 스톰(900ms) - 문스(1590ms) - 피어싱(1920ms) - 문스(2280ms) - 피어싱(2610ms) - 2970ms -> 태그 쿨타임 대기 +130ms
+        # 기가(0ms) -       점핑(630ms) -     어스(1290ms) -    어스 후딜 도중 문스 사용, 어퍼 씹힘 -   어파스(2850ms)
+        TagCooltimeWait = core.DamageSkill("태그 쿨타임 대기(알파)", 130, 0, 0, cooltime=-1).wrap(core.DamageSkillWrapper)
+        AlphaCombo = [SetAlpha, WindCutter, GigaCrashTAG, WindStrike, JumpingCrashTAG, AdvancedStormBreak, AdvancedEarthBreakTAG,
+                        MoonStrike, PierceStrike, MoonStrike, PierceStrike, AdvancedPowerStompTAG, TagCooltimeWait]
+        # 터닝(0ms) - 휠윈(360ms) - 프런트(1260ms) - 스로잉(1710ms) - 어퍼(2190ms) - 어파스(2580ms) - 3150ms -> 태그 쿨타임 대기 0ms
+        # 롤커(0ms) -         롤어(960ms) -  플래시 씹힘 -    스핀(1920ms) -  문스 씹힘 -  피어싱(2640ms)
+        BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind, AdvancedRollingAssulterTAG,
+                        FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, UpperSlash, AdvancedPowerStomp, PierceStrikeTAG]
+        ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)
+        for sk in AlphaCombo + BetaCombo:
+            ComboHolder.onAfter(sk)
+
+        ### 타임 홀딩 초기화 ###
+        TimeHolding.onAfter(TimeDistortion.controller(1.0, "reduce_cooltime_p"))
+        TimeHolding.onAfter(SoulContract.controller(1.0, "reduce_cooltime_p"))
         
         ### 5차 스킬들 ###
-        TwinBladeOfTime.onAfters([TwinBladeOfTime_end, TwinBladeOfTime_3, TwinBladeOfTime_2, TwinBladeOfTime_1])
+        TwinBladeOfTime.onBefore(SetBeta)
+        for sk in [TwinBladeOfTime_1, TwinBladeOfTime_2, TwinBladeOfTime_3, TwinBladeOfTime_end]:
+            TwinBladeOfTime.onAfter(sk)
         ShadowFlashAlpha.onAfter(ShadowFlashAlphaEnd)
         ShadowFlashBeta.onAfter(ShadowFlashBetaEnd)
         LimitBreak.onAfter(LimitBreakAttack)
-
-        LimitBreakCDR = core.BuffSkill("리미트 브레이크(재사용 대기시간 감소)", 0, 0, cooltime = -1).wrap(core.BuffSkillWrapper)
         LimitBreak.onAfter(LimitBreakCDR)
         for sk in [TimeDistortion, SoulContract]:
             # 재사용 대기시간 초기화의 효과를 받지 않는 스킬을 제외한 스킬의 재사용 대기시간이 (기본 200%에 5레벨마다 10%씩) 더 빠르게 감소
-            LimitBreakCDR.onAfter(sk.controller(2000 + 20 * vEhc.getV(0, 0), 'reduce_cooltime'))
-        
-        # 리미트 브레이크 지속시간동안 쿨감효과 반복
-        LimitBreakCDR.onAfter(core.OptionalElement(LimitBreak.is_active, LimitBreakCDR.controller(1000)))
-
-        StateTAG = core.OptionalElement(AlphaState.is_active, SetBeta, SetAlpha)
-        
-        ### 국콤 생성
-        li = [SetAlpha, WindCutter, MoonStrike, MoonStrike, SetBeta, SpinDriver, FlashCut, UpperStrike]
-        li.reverse()
-        ComboHolder.onAfters(li)
-
-        TimeHolding.onAfter(TimeDistortion.controller(1))
-
-        def aura_weapon_beta(betaState):
-            return extra_dmg(10, False) if betaState.is_active() else core.CharacterModifier()
+            LimitBreakCDR.onTick(sk.controller(2000 + 20 * vEhc.getV(0, 0), 'reduce_cooltime'))
         
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 3, 3)
         for sk in [MoonStrike, PierceStrike, FlashAssault, AdvancedSpinCutter,
-                    AdvancedRollingCurve, AdvancedRollingAssulter, StormBreak, UpperStrike, AirRiot, GigaCrash,
-                    FallingStar, AdvancedEarthBreak, TwinBladeOfTime_end]:
+                    AdvancedRollingCurve, AdvancedRollingAssulter, AdvancedStormBreak, UpperSlash, AdvancedPowerStomp, GigaCrash,
+                    JumpingCrash, AdvancedEarthBreak, TwinBladeOfTime_end]:
             auraweapon_builder.add_aura_weapon(sk)
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
-        AuraWeapon.add_runtime_modifier(BetaState, aura_weapon_beta)
+        AuraWeapon.add_runtime_modifier(BetaState, lambda beta: extra_dmg(10, False) if beta.is_active() else core.CharacterModifier()) # 베타시 오라 웨폰에 대검 마스터리 적용
 
         '''
         스킬 사용 후 초월자 륀느의 기원 발동
         for sk in [MoonStrike, PierceStrike, FlashAssault, AdvancedSpinCutter,
-                    AdvancedRollingCurve, AdvancedRollingAssulter, StormBreak, UpperStrike, AirRiot, GigaCrash,
-                    FallingStar, AdvancedEarthBreak]:
+                    AdvancedRollingCurve, AdvancedRollingAssulter, AdvancedStormBreak, UpperSlash, AdvancedPowerStomp, GigaCrash,
+                    JumpingCrash, AdvancedEarthBreak]:
             sk.onAfter(RhinneBlessAttack)
 
         스킬 쿨타임 초기화
@@ -383,9 +322,9 @@ class JobGenerator(ck.JobGenerator):
 
         return(ComboHolder,
                 [globalSkill.maple_heros(chtr.level, name = "륀느의 가호", combat_level = 0), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
-                    AlphaState, BetaState, DivineLeer, AuraWeaponBuff, AuraWeapon, DoubleTime, TimeDistortion, TimeHolding, IntensiveTime, LimitBreak,
+                    AlphaState, BetaState, DivineLeer, AuraWeaponBuff, AuraWeapon, DoubleTime, TimeDistortion, TimeHolding, LimitBreak, LimitBreakCDR, CriticalBind,
                     SoulContract]+\
                 [TwinBladeOfTime, ShadowFlashAlpha, ShadowFlashBeta]+\
-                [StormBreakSummon, StormBreakElectric, AdvancedEarthBreakElectric, WindCutterSummon, ThrowingWeapon]+\
+                [AdvancedStormBreakSummon, AdvancedStormBreakElectric, AdvancedEarthBreakElectric, WindCutterSummon, ThrowingWeapon]+\
                 []+\
                 [ComboHolder])


### PR DESCRIPTION
* 제로가 보조무기에서 보공,방무 한번 더 받는것 적용
* 어파스 콤보에서 씹히는 어시 제거
* 콤보 구현 방식 변경 - 일일이 이어붙이게 함
  * 자동 연결되는 스킬을 미리 이어붙여두면 중간에 끊을수가 없어짐
* 알파,베타 스탯 적용 다른 방식으로 구현
  * 이렇게 해야 무보엠/유니온 최적화가 더 잘됨
* 스킬 딜레이 전부 수정
* 기본 도핑에 영메 포함했으므로 인탠시브 타임 제거
* 리밋브 쿨타임 가속 효과를 더 정확하게 적용
* 크리티컬 바인드를 평균 가동률이 아닌 베타가 적용하는 디버프로 변경
* 조인트 어택을 사용하기 전에 무조건 베타로 변경하도록 함