### PR TITLE
fix: 데몬슬레이어 리메인타임 계산

### DIFF
--- a/dpmModule/jobs/demonslayer.py
+++ b/dpmModule/jobs/demonslayer.py
@@ -80,12 +80,12 @@ class JobGenerator(ck.JobGenerator):
         DemonSlashRemainTime = core.BuffSkill("데몬 슬래시-리메인타임", 0, 4000, cooltime = -1, pdamage_indep = 10).wrap(core.BuffSkillWrapper)
         
         # 1타만 사용시 딜레이가 2타로 이어질때보다 김.
-        DemonSlash1 = core.DamageSkill("데몬 슬래시(1타)", 390, 110, 2, modifier = core.CharacterModifier(pdamage = 370, pdamage_indep = -10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        DemonSlash1 = core.DamageSkill("데몬 슬래시(1타)", 390, 110, 2, modifier = core.CharacterModifier(pdamage = 370) - core.CharacterModifier(pdamage_indep = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
-        DemonSlashAW1 = core.DamageSkill("데몬 슬래시 강화(1타)", 270, 600, 3, modifier = core.CharacterModifier(pdamage = 150+50, armor_ignore = 50, pdamage_indep = -10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-        DemonSlashAW2 = core.DamageSkill("데몬 슬래시 강화(2타)", 270, 600, 3, modifier = core.CharacterModifier(pdamage = 150+50, armor_ignore = 50, pdamage_indep = -10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-        DemonSlashAW3 = core.DamageSkill("데몬 슬래시 강화(3타)", 360, 700, 3, modifier = core.CharacterModifier(pdamage = 150+50, armor_ignore = 50, pdamage_indep = -10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
-        DemonSlashAW4 = core.DamageSkill("데몬 슬래시 강화(4타)", 360, 800, 3, modifier = core.CharacterModifier(pdamage = 150+50, armor_ignore = 50, pdamage_indep = -10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        DemonSlashAW1 = core.DamageSkill("데몬 슬래시 강화(1타)", 270, 600, 3, modifier = core.CharacterModifier(pdamage = 150+50, armor_ignore = 50) - core.CharacterModifier(pdamage_indep = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        DemonSlashAW2 = core.DamageSkill("데몬 슬래시 강화(2타)", 270, 600, 3, modifier = core.CharacterModifier(pdamage = 150+50, armor_ignore = 50) - core.CharacterModifier(pdamage_indep = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        DemonSlashAW3 = core.DamageSkill("데몬 슬래시 강화(3타)", 360, 700, 3, modifier = core.CharacterModifier(pdamage = 150+50, armor_ignore = 50) - core.CharacterModifier(pdamage_indep = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        DemonSlashAW4 = core.DamageSkill("데몬 슬래시 강화(4타)", 360, 800, 3, modifier = core.CharacterModifier(pdamage = 150+50, armor_ignore = 50) - core.CharacterModifier(pdamage_indep = 10)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
         DemonImpact = core.DamageSkill("데몬 임팩트", 660, 460 + 4 * self.combat, (6+1), modifier = core.CharacterModifier(crit = 100, armor_ignore = 30 + ceil(self.combat / 3), boss_pdamage = 40 + self.combat, pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
 


### PR DESCRIPTION
* 데몬 슬래시에 최종뎀 10%를 빼는것과 최종뎀-10%를 적용하는 것은 다름
* `*0.9`와 `/1.1`의 차이, 이 경우에는 후자가 맞음