### PR TITLE
신5차

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -125,6 +125,7 @@ class JobGenerator():
         self.combat = 1
         self.ability_list = Ability_tool.get_ability_set(None, None, None)
         self._use_critical_reinforce = False
+        self.hyperStatPrefixed = 0
             
     def get_ruleset(self):
         return
@@ -287,7 +288,7 @@ class JobGenerator():
 
         # 하이퍼 스탯
         refMDF = get_reference_modifier(chtr)
-        hyperstat = HyperStat.get_hyper_modifier(refMDF, chtr.level, critical_reinforce = self._use_critical_reinforce)
+        hyperstat = HyperStat.get_hyper_modifier(refMDF, chtr.level, self.hyperStatPrefixed, critical_reinforce = self._use_critical_reinforce)
         log_modifier(hyperstat, "hyper stat")
         chtr.apply_modifiers([hyperstat])
         log_buffed_character(chtr)
@@ -824,17 +825,12 @@ class HyperStat():
         return (delta // 10) * (30 + (delta // 10 + 2) * 10) // 2 + (delta % 10 + 1) * (delta // 10 + 3)
     
     @staticmethod
-    def get_hyper_object(mdf, level):    
-        mdf = HyperStat.get_hyper_modifier(mdf, level)
-        return HyperStat(mdf, level)
-    
-    @staticmethod
-    def get_hyper_index(mdf, level, isIndex = True, critical_reinforce = False):
+    def get_hyper_index(mdf, level, prefixed, isIndex = True, critical_reinforce = False):
         '''get_hyper_index(mdf, level) : return enhancement index for matching enhancement type.
         '''
         hyper_size = 8
         idxList = [0 for i in range(hyper_size)]
-        point_left = HyperStat.get_point(level)
+        point_left = HyperStat.get_point(level) - prefixed
         mdfSum = ExMDF()
         while True:
             not_enough = True
@@ -874,8 +870,8 @@ class HyperStat():
             return mdfSum
     
     @staticmethod
-    def get_hyper_modifier(mdf, level, critical_reinforce = False):
-        return HyperStat.get_hyper_index(mdf, level, isIndex = False, critical_reinforce = critical_reinforce)
+    def get_hyper_modifier(mdf, level, prefixed, critical_reinforce = False):
+        return HyperStat.get_hyper_index(mdf, level, prefixed, isIndex = False, critical_reinforce = critical_reinforce)
 
 class Doping():
     dopingListAtt = {"길드의 축복" : ExMDF(att = 20),
@@ -916,10 +912,3 @@ class Personality():
     @staticmethod
     def get_personality(avg_level):
         return ExMDF(armor_ignore = (avg_level // 5) * 0.5, buff_rem = (avg_level // 10) * 1, prop_ignore = 0.5 * (avg_level // 10))
-
-
-def testonly():            
-    test = ExMDF(armor_ignore = 80, pdamage = 100, stat_main = 1000, att = 100)
-    for i in range(140, 220, 5):
-        print("level" + str(i))
-        print(HyperStat.get_hyper_index(test, i))

--- a/dpmModule/jobs/aran.py
+++ b/dpmModule/jobs/aran.py
@@ -14,7 +14,6 @@ from math import ceil
 
 # 최저 콤보 카운트 500 가정
 
-#TODO : 5차 신스킬 적용
 #TODO : 펜릴 크래시 이후에 파이널 블로우가 아닌 다른 스킬이 오면 30ms 딜레이가 추가되어야 함
 #TODO : 게더링 캐쳐로 프리드, 오라웨폰 딜레이도 캔슬해야 함
 
@@ -58,10 +57,10 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(InactiveRule('브랜디쉬 마하(홀더)', '아드레날린 부스트'), RuleSet.BASE)
         ruleset.add_rule(InactiveRule('히어로즈 오쓰', '아드레날린 부스트'), RuleSet.BASE)
         ruleset.add_rule(InactiveRule('쓸만한 샤프 아이즈', '아드레날린 부스트'), RuleSet.BASE)
+        ruleset.add_rule(InactiveRule('쓸만한 컴뱃 오더스', '아드레날린 부스트'), RuleSet.BASE)
         ruleset.add_rule(ConditionRule('소울 컨트랙트', '아드레날린 부스트', check_soul_contract_time), RuleSet.BASE)
-        ruleset.add_rule(ConditionRule('부스트 엔드-헌터즈 타겟팅', '아드레날린 부스트', lambda x:x.is_time_left(10*1000, -1)), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule('부스트 엔드-헌터즈 타겟팅(홀더)', '아드레날린 부스트', lambda x:x.is_time_left(10*1000, -1)), RuleSet.BASE)
         
-        # ruleset.add_rule(InactiveRule('쓸만한 컴뱃 오더스', '아드레날린 부스트'), RuleSet.BASE)
         return ruleset
 
 
@@ -78,7 +77,6 @@ class JobGenerator(ck.JobGenerator):
         소울 컨트랙트는 아드레날린 부스트가 10초 이상 남았다면 사용함
 
         '''
-        JUDGEMENT_DELAY=600
         BOOST_END_HUNTERS_TARGETING_DELAY=1100
         ADRENALINE_GENERATOR_DELAY=600
         ADRENALINE_BOOST_REMAIN = (20+3)*1000
@@ -107,8 +105,6 @@ class JobGenerator(ck.JobGenerator):
 
         AdvancedComboAbility = core.BuffSkill("어드밴스드 콤보 어빌리티", 0, 9999*9999, att=2*10, crit=3*10).wrap(core.BuffSkillWrapper)
         ComboAbility = core.BuffSkill("콤보 어빌리티", 0, 9999*9999, att=2*10).wrap(core.BuffSkillWrapper) 
-        Judgement = core.DamageSkill("저지먼트", JUDGEMENT_DELAY, 380 + (60 + 2 * passive_level) + (20 + passive_level), 4).wrap(core.DamageSkillWrapper)
-        JudgementDot = core.DotSkill("저지먼트(도트)", 0, 1000, 200, 1, 6000, cooltime = -1).wrap(core.SummonSkillWrapper)
 
         BlessingMaha = core.BuffSkill("블레싱 마하", 0, 200*1000, att=30).wrap(core.BuffSkillWrapper)   #펫버프
 
@@ -128,7 +124,8 @@ class JobGenerator(ck.JobGenerator):
         AdrenalineBeyonderThird = core.DamageSkill("비욘더(3타)(아드레날린)", 420, 565 + 10 * ceil(self.combat / 3), 8, modifier=core.CharacterModifier(pdamage=BEYONDER_ADRENALINE_PDAMAGE, armor_ignore=44, crit=100)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         AdrenalineBeyonderWave = core.DamageSkill("비욘더(파동)", 0, 400, 5).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
 
-        BoostEndHuntersTargeting = core.DamageSkill("부스트 엔드-헌터즈 타겟팅", BOOST_END_HUNTERS_TARGETING_DELAY, 1500 + 15 * self.combat + (20 + passive_level), 15*5, cooltime=-1).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        BoostEndHuntersTargetingHolder = core.DamageSkill("부스트 엔드-헌터즈 타겟팅(홀더)", BOOST_END_HUNTERS_TARGETING_DELAY, 0, 0, cooltime=-1).wrap(core.DamageSkillWrapper)
+        BoostEndHuntersTargeting = core.DamageSkill("부스트 엔드-헌터즈 타겟팅", 0, 1500 + 15 * self.combat + (20 + passive_level), 15, cooltime=-1).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
 
         AdrenalineGenerator = core.BuffSkill("아드레날린 제네레이터", ADRENALINE_GENERATOR_DELAY, 0, cooltime=240*1000).wrap(core.BuffSkillWrapper)
         MahaRegion = core.SummonSkill("마하의 영역", 600, 1000, 500, 3, 10*1000, cooltime=150*1000).wrap(core.SummonSkillWrapper) # 게더링캐쳐 캔슬 : 1680 -> 600
@@ -138,9 +135,9 @@ class JobGenerator(ck.JobGenerator):
         InstallMaha = core.BuffSkill("인스톨 마하", 600, (30+vEhc.getV(1,1))*1000, patt=5+vEhc.getV(1,1), cooltime=150*1000, red=True).isV(vEhc, 1, 1).wrap(core.BuffSkillWrapper) # 게더링캐쳐 캔슬 : 960 -> 600
         InstallMahaBlizzard = core.SummonSkill("인스톨 마하(눈보라)", 0, 3000, 450+18*vEhc.getV(1,1), 5, 60*1000, cooltime=-1).isV(vEhc, 1, 1).wrap(core.SummonSkillWrapper)
 
-        BrandishMahaNormal = core.DamageSkill('브랜디쉬 마하', 600, 600+vEhc.getV(2,2)*24 + (20 + passive_level) +100, 15*2, cooltime=-1, red=True, modifier=core.CharacterModifier(boss_pdamage=20)).isV(vEhc, 2, 2).wrap(core.DamageSkillWrapper)  # 게더링캐쳐 캔슬 : 960 -> 600
         BrandishMaha = core.DamageSkill('브랜디쉬 마하(홀더)', 0, 0, 0, cooltime=20*1000, red=True, modifier=core.CharacterModifier(boss_pdamage=20)).isV(vEhc, 2, 2).wrap(core.DamageSkillWrapper)
-        BrandishMahaAdrenaline = core.DamageSkill('브랜디쉬 마하(아드레날린)', 600, 600+vEhc.getV(2,2)*24+(20 + passive_level)+100+150, 15*2, cooltime=-1, modifier=core.CharacterModifier(boss_pdamage=20)).isV(vEhc, 2, 2).wrap(core.DamageSkillWrapper)
+        BrandishMahaNormal = core.DamageSkill('브랜디쉬 마하', 600, 600+vEhc.getV(2,2)*24 + (20 + passive_level) +100, 15, cooltime=-1, red=True, modifier=core.CharacterModifier(boss_pdamage=20)).isV(vEhc, 2, 2).wrap(core.DamageSkillWrapper)  # 게더링캐쳐 캔슬 : 960 -> 600
+        BrandishMahaAdrenaline = core.DamageSkill('브랜디쉬 마하(아드레날린)', 600, 600+vEhc.getV(2,2)*24+(20 + passive_level)+100+150, 15, cooltime=-1, modifier=core.CharacterModifier(boss_pdamage=20)).isV(vEhc, 2, 2).wrap(core.DamageSkillWrapper)
 
         GatheringCatcher = core.DamageSkill('게더링 캐쳐(캔슬)', 0, 170+(20 + passive_level), 2).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
@@ -149,38 +146,54 @@ class JobGenerator(ck.JobGenerator):
         AdrenalinePenrilCrash = core.DamageSkill('펜릴 크래시(아드레날린)', 420, 150+100+500+vEhc.getV(3,3)*5, PenrilCrashHit + 2, modifier=core.CharacterModifier(crit=100, armor_ignore=60,pdamage=PENRIL_ADRENALINE_PDAMAGE)).setV(vEhc, 2, 2, False).isV(vEhc, 3, 3).wrap(core.DamageSkillWrapper)       
         PenrilCrashIceburg = core.DamageSkill('펜릴 크래시(빙산)', 0, 500+vEhc.getV(3,3)*5, 6).setV(vEhc, 2, 2, False).isV(vEhc, 3, 3).wrap(core.DamageSkillWrapper)
         
+        # TODO: 타수가 늘어나는 파이널 어택으로 동작하지만, 스택을 늘리는 스킬 목록이 밝혀지지 않아 일단 총 423타가 나오게 평균으로 해둠
+        BlizzardTempest = core.DamageSkill('블리자드 템페스트', 750, 800+32*vEhc.getV(0,0), 8, cooltime=180*1000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        BlizzardTempestAura = core.SummonSkill('블리자드 템페스트(저주)', 0, 425, 475+19*vEhc.getV(0,0), 9, 20000, cooltime=-1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+
+        MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
+
+        ### Skill Wrapper ###
+
         Combo = core.BuffSkill("아란(콤보)", 0, 99999999)
         Combo = core.StackSkillWrapper(Combo, 1000)
         Combo.set_name_style("콤보 %d만큼 증가")
+
+        # 헌터즈 타게팅
+        BoostEndHuntersTargetingHolder.onAfter(core.RepeatElement(BoostEndHuntersTargeting, 5))
 
         # 인스톨 마하
         InstallMaha.onAfter(InstallMahaBlizzard)
         InstallMaha.onAfter(Combo.stackController(100))
         
         # 브랜디쉬 마하
-        BrandishMaha.onAfter(core.OptionalElement(AdrenalineBoost.is_active, BrandishMahaAdrenaline, BrandishMahaNormal))
+        BrandishMaha.onAfter(core.RepeatElement(core.OptionalElement(AdrenalineBoost.is_active, BrandishMahaAdrenaline, BrandishMahaNormal), 2))
         BrandishMaha.onAfter(core.OptionalElement(InstallMaha.is_active, BrandishMaha.controller(0.5, 'reduce_cooltime_p')))
-        
-        # 파이널어택
-        FinalAttackHolder.onAfter(core.OptionalElement(AdrenalineBoost.is_active, FinalAttackAdrenaline, FinalAttack))
 
         # 콤보 계산, 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 2, 1)
         for sk in [SmashSwing, AdrenalineSmashSwing, FinalBlow, AdrenalineFinalBlow,
-                Judgement, MahaRegionInit, GatheringCatcher,
+                MahaRegionInit, GatheringCatcher,
                 BeyonderFirst, BeyonderSecond, BeyonderThird,
                 AdrenalineBeyonderFirst, AdrenalineBeyonderSecond, AdrenalineBeyonderThird,
-                PenrilCrash, AdrenalinePenrilCrash, BrandishMahaNormal, BrandishMahaAdrenaline]:
-            sk.onAfter(FinalAttackHolder)
+                PenrilCrash, AdrenalinePenrilCrash, BrandishMahaNormal, BrandishMahaAdrenaline, BoostEndHuntersTargeting]:
             sk.onAfter(Combo.stackController(DynamicVariableOperation.reveal_argument(sk.skill.hit)))
             auraweapon_builder.add_aura_weapon(sk)
         
-        BoostEndHuntersTargeting.onAfter(core.RepeatElement(FinalAttackHolder, 5))
-        auraweapon_builder.add_aura_weapon(BoostEndHuntersTargeting)
+        MahaRegion.onTick(Combo.stackController(DynamicVariableOperation.reveal_argument(MahaRegion.skill.hit)))
             
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
 
-        MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
+        # 파이널 어택
+        FinalAttackHolder.onAfter(core.OptionalElement(AdrenalineBoost.is_active, FinalAttackAdrenaline, FinalAttack))
+        for sk in [SmashSwing, AdrenalineSmashSwing, FinalBlow, AdrenalineFinalBlow,
+                BrandishMahaNormal, BrandishMahaAdrenaline,
+                BeyonderFirst, BeyonderSecond, BeyonderThird,
+                AdrenalineBeyonderFirst, AdrenalineBeyonderSecond, AdrenalineBeyonderThird,
+                PenrilCrash, AdrenalinePenrilCrash, BoostEndHuntersTargeting]:
+            sk.onAfter(FinalAttackHolder)
+
+        # 블리자드 템페스트
+        BlizzardTempest.onAfter(BlizzardTempestAura)
 
         # 기본 공격
         BasicAttack = core.DamageSkill("기본 공격", 0,0,0).wrap(core.DamageSkillWrapper)
@@ -226,7 +239,7 @@ class JobGenerator(ck.JobGenerator):
         AdrenalineBoost.onConstraint(core.ConstraintElement('콤보가 1000이상', Combo, partial(Combo.judge,1000,1) ))
         AdrenalineBoost.onAfter(AdrenalineBoostEndDummy.controller(ADRENALINE_BOOST_REMAIN))
         AdrenalineBoost.onAfter(Combo.stackController(-999999999, dtype='set'))
-        AdrenalineBoost.onAfter(BoostEndHuntersTargeting.controller(1))
+        AdrenalineBoost.onAfter(BoostEndHuntersTargetingHolder.controller(1))
         AdrenalineBoostEndDummy.onAfter(Combo.stackController(500, dtype='set'))
         AdrenalineGenerator.onConstraint(core.ConstraintElement('아드레날린부스트가 불가능할때', AdrenalineBoost, AdrenalineBoost.is_not_active))
         AdrenalineGenerator.onAfter(AdrenalineBoost)
@@ -235,8 +248,8 @@ class JobGenerator(ck.JobGenerator):
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), Booster, SmashSwingIncr, SnowCharge, AdvancedComboAbility, ComboAbility,
                     BlessingMaha, AdrenalineBoost, AdrenalineBoostEndDummy,
                     AdrenalineGenerator, 
-                    InstallMaha, InstallMahaBlizzard, Combo, AuraWeaponBuff, AuraWeapon, 
+                    InstallMaha, InstallMahaBlizzard, Combo, AuraWeaponBuff, AuraWeapon, BlizzardTempestAura,
                     globalSkill.soul_contract()] +\
-                [SmashSwingHolder, BrandishMaha, BoostEndHuntersTargeting, MirrorBreak, MirrorSpider] +\
+                [SmashSwingHolder, BrandishMaha, BoostEndHuntersTargetingHolder, BlizzardTempest, MirrorBreak, MirrorSpider] +\
                 [MahaRegion] +\
                 [BasicAttack])

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -126,6 +126,8 @@ class JobGenerator(ck.JobGenerator):
         Elquiness = core.SummonSkill("엘퀴네스", 600, 3030, 380+6*self.combat, 1, (260+5*self.combat)*1000).setV(vEhc, 4, 2, False).wrap(core.SummonSkillWrapper)
         IceAura = core.SummonSkill("아이스 오라", 0, 1200, 0, 1, 999999999).wrap(core.SummonSkillWrapper)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
+        JupyterThunder = core.SummonSkill("주피터 썬더", 630, 330, 300+12*vEhc.getV(0,0), 5, 330*30-1, cooltime=75000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        JupyterThunderDecrement = core.SummonSkill("주피터 썬더(빙결 감소)", 0, 330*5, 0, 0, 330*25-1, cooltime=-1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         
         #FinalAttack
         Blizzard = core.DamageSkill("블리자드", 720, 450+5*self.combat, 8, cooltime = 45 * 1000, red = True).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
@@ -229,11 +231,16 @@ class JobGenerator(ck.JobGenerator):
         #Spirit of Snow
         SpiritOfSnow.onTick(FrostEffect.stackController(3))
 
+        #Jupyter Thunder
+        JupyterThunder.add_runtime_modifier(FrostEffect, applyFrostEffect) # TODO: 블리자드 파택 안터지는게 맞는지 확인할것
+        JupyterThunder.onAfter(JupyterThunderDecrement.controller(330*5))
+        JupyterThunderDecrement.onTick(FrostDecrement)
+
         return(ChainLightening,
                 [Infinity, Meditation, EpicAdventure, OverloadMana, FrostEffect,
                 globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), globalSkill.useful_wind_booster(),
                 globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
-                [IceAgeInit, Blizzard, LighteningSpear, ThunderBrake, MirrorBreak, MirrorSpider] +\
+                [IceAgeInit, Blizzard, JupyterThunder, JupyterThunderDecrement, LighteningSpear, ThunderBrake, MirrorBreak, MirrorSpider] +\
                 [ThunderStorm, Elquiness, IceAura, IceAgeSummon, FrozenOrb, SpiritOfSnow] +\
                 [UnstableMemorize] +\
                 [ChainLightening])

--- a/dpmModule/jobs/archmageTc.py
+++ b/dpmModule/jobs/archmageTc.py
@@ -72,6 +72,7 @@ class JobGenerator(ck.JobGenerator):
         체라-라스피-블자-오브-엘퀴-썬더스톰
         
         썬브 8히트
+        아이스 에이지 장판 2히트
         
         하이퍼 : 
         텔레포트 - 애드 레인지
@@ -85,6 +86,7 @@ class JobGenerator(ck.JobGenerator):
         프로즌 오브 쿨마다 사용, 19타
         '''
         THUNDER_BREAK_HIT = 8
+        ICE_AGE_SUMMON_HIT = 2
 
         ######   Skill   ######
         #Buff skills
@@ -102,7 +104,7 @@ class JobGenerator(ck.JobGenerator):
         LighteningSpearFinalizer = core.DamageSkill("라이트닝 스피어(막타)", 1080, 1500, 7).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         IceAgeInit = core.DamageSkill("아이스 에이지(개시)", 660, 500 + vEhc.getV(2,3)*20, 10, cooltime = 60 * 1000, red = True).isV(vEhc,2,3).wrap(core.DamageSkillWrapper)
-        IceAgeSummon = core.SummonSkill("아이스 에이지(장판)", 0, 810, 125 + vEhc.getV(2,3)*5, 3, 15 * 1000, cooltime = -1).isV(vEhc,2,3).wrap(core.SummonSkillWrapper)
+        IceAgeSummon = core.SummonSkill("아이스 에이지(장판)", 0, 810, 125 + vEhc.getV(2,3)*5, 3*ICE_AGE_SUMMON_HIT, 15 * 1000, cooltime = -1).isV(vEhc,2,3).wrap(core.SummonSkillWrapper)
                 
         # 중첩당 감소량 5%
         # TODO: 썬브가 이전 스킬 딜레이 캔슬하는것 구현해야 함
@@ -212,8 +214,7 @@ class JobGenerator(ck.JobGenerator):
         IceAura.onTick(FrostIncrement)
         
         #Ice Age
-        IceAgeSummon.onTick(BlizzardPassive) # TODO: onTick 실행순서 바뀌면 순서 조정해야 함
-        IceAgeSummon.onTick(FrostIncrement)
+        IceAgeSummon.onTick(core.RepeatElement(FrostIncrement, ICE_AGE_SUMMON_HIT))
         IceAgeInit.onJustAfter(FrostIncrement)
         IceAgeInit.onAfter(BlizzardPassive)
         IceAgeInit.onAfter(IceAgeSummon)

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -432,7 +432,7 @@ class JobGenerator(ck.JobGenerator):
                     InfinitySpell, FloraGoddessBless,
                     globalSkill.maple_heros(chtr.level, name = "레프의 용사", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), globalSkill.soul_contract()
                     ] +\
-                [EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, 
+                [ForeverHungryBeastInit, ForeverHungryBeastTrigger, EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, 
                     CrawlingFear_Link, MemoryOfSource, EndlessPain, RaptRestriction, ReturningHate, Impulse_Connected,
                     UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, 
                     AbyssSpell, RaptRestrictionSummon, RaptRestrictionEnd, DeviousNightmare, DeviousDream, MirrorBreak, MirrorSpider

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -1,5 +1,4 @@
 from ..kernel import core
-from ..kernel.policy import TypebaseFetchingPolicy
 from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
@@ -10,30 +9,6 @@ from .jobbranch import pirates
 from .jobclass import flora
 from . import jobutils
 from math import ceil, floor
-
-class ReturningHateWrapper(core.DamageSkillWrapper):
-    def __init__(self, skill):
-        self.stack = 0
-        self._max = 12
-        super(ReturningHateWrapper, self).__init__(skill)
-        self.modifierInvariantFlag = False
-        
-    def _use(self, skill_modifier):
-        self.cooltimeLeft = self.calculate_cooltime(skill_modifier)
-        if self.cooltimeLeft > 0:
-            self.available = False
-        
-        mdf = self.skill.get_modifier()
-        stack = self.stack
-        self.stack = 0
-        return core.ResultObject(0, mdf.copy(), 320, sname = self._id, spec = 'deal', hit = 6 * stack)
-        
-    def _addStack(self, d):
-        self.stack = min(self.stack + d, self._max)
-        return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
-    
-    def addStack(self, d):
-        return core.TaskHolder(core.Task(self, partial(self._addStack, d)), name = '돌아오는 증오 추가')
 
 # TODO: core쪽으로 옮길 것, .wrap()과 함께 사용 가능하게 할 것
 class MultipleDamageSkillWrapper(core.DamageSkillWrapper):
@@ -46,21 +21,21 @@ class MultipleDamageSkillWrapper(core.DamageSkillWrapper):
         
     def _use(self, skill_modifier):
         self.count += 1
-        self.cooltimeLeft = self.calculate_cooltime(skill_modifier)
         self.timer = self._timeLimit
         if self.count >= self._max:
             self.count = 0
-            self.available = False 
-        return core.ResultObject(self.skill.delay, self.get_modifier(), self.skill.damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
+        return super(MultipleDamageSkillWrapper, self)._use(skill_modifier)
 
     def spend_time(self, time):
-        self.cooltimeLeft -= time
         self.timer -= time
-        if self.cooltimeLeft < 0:
-            self.available = True
-        elif self.timer < 0:
+        if self.timer <= 0:
             self.count = 0
-            self.available = False 
+        super(MultipleDamageSkillWrapper, self).spend_time(time)
+
+    def is_available(self) -> bool:
+        if self.count > 0:
+            return True
+        return super(MultipleDamageSkillWrapper, self).is_available()
         
 
 class DeviousWrapper(core.DamageSkillWrapper):
@@ -240,7 +215,12 @@ class JobGenerator(ck.JobGenerator):
         
         ##### 스펙터 상태일 때 #####
         UpcomingDeath = core.DamageSkill("다가오는 죽음", 0, 450 + 3*passive_level, 2).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
-        ReturningHate = ReturningHateWrapper(core.DamageSkill("돌아오는 증오", 0, 320 + 3*passive_level, 6, cooltime=12000, red=True).setV(vEhc, 0, 2, True))
+        ReturningHateStack = core.StackSkillWrapper(core.BuffSkill("돌아오는 증오(스택)", 0, 99999999), 12)
+        ReturningHate = core.StackDamageSkillWrapper(
+            core.DamageSkill("돌아오는 증오", 0, 320 + 3*passive_level, 6, cooltime=12000, red=True).setV(vEhc, 0, 2, True),
+            ReturningHateStack,
+            lambda sk: sk.stack
+        )
 
         EndlessBadDream = core.DamageSkill("끝나지 않는 흉몽", 540, 445 + 3*passive_level, 6, modifier=BattleArtsHyper).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) # 끝나지 않는 악몽 변형
         EndlessBadDream_Link = core.DamageSkill("끝나지 않는 흉몽(연계)", 180+LINK_DELAY, 445 + 3*passive_level, 6, modifier=BattleArtsHyper).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper) # 끝나지 않는 악몽 변형
@@ -309,7 +289,8 @@ class JobGenerator(ck.JobGenerator):
   
         # 보스 1:1 시 공격 1회 당 다가오는 죽음 1개 생성, 인피니티 스펠 상태 시 강화레벨에 따라 총 3 ~ 4개 생성
         UpcomingDeath_Connected = core.OptionalElement(InfinitySpell.is_active, core.RepeatElement(UpcomingDeath, 3 + vEhc.getV(0,0) // 25), UpcomingDeath)
-        UpcomingDeath.onAfter(ReturningHate.addStack(0.2))
+        UpcomingDeath.onAfter(ReturningHateStack.stackController(0.2))
+        ReturningHate.onJustAfter(ReturningHateStack.stackController(-15))
         
 
         # 기본 연결 설정(레프)

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -278,6 +278,12 @@ class JobGenerator(ck.JobGenerator):
         DeviousNightmare = core.DamageSkill("새어 나오는 악몽", 0, 500 + 20*vEhc.getV(2,2), 9, cooltime = 10 * 1000, red=True).isV(vEhc,2,2).wrap(DeviousWrapper)
         DeviousDream = core.DamageSkill("새어 나오는 흉몽", 0, 600 + 24*vEhc.getV(2,2), 9, cooltime = 10 * 1000, red=True).wrap(DeviousWrapper)
 
+        ForeverHungryBeastInit = core.DamageSkill("영원히 굶주리는 짐승(개시)", 540, 0, 0, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        ForeverHungryBeastTrigger = core.DamageSkill("영원히 굶주리는 짐승(등장)", 0, 0, 0, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        ForeverHungryBeast = core.DamageSkill("영원히 굶주리는 짐승", 0, 1050+42*vEhc.getV(0,0), 5, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 18회 반복
+
+        ### Skill Wrapper ###
+
         SpectorState = SpectorWrapper(MemoryOfSourceBuff, EndlessPainBuff)
         
         # 기본 연결 설정(스펙터)
@@ -336,7 +342,7 @@ class JobGenerator(ck.JobGenerator):
         for skill in [EndlessBadDream, EndlessBadDream_Link, DeviousDream,
             UnfulfilledHunger, UncontrollableChaos, 
             UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, TenaciousInstinct_Link,
-            CrawlingFear_Link, EndlessPainTick, EndlessPainEnd, EndlessPainEnd_Link]:
+            CrawlingFear_Link, EndlessPainTick, EndlessPainEnd, EndlessPainEnd_Link, ForeverHungryBeast]:
             skill.onAfter(UpcomingDeath_Connected)
         MagicCircuitFullDriveStorm.onAfter(core.OptionalElement(SpectorState.is_active, UpcomingDeath_Connected))
         
@@ -357,6 +363,10 @@ class JobGenerator(ck.JobGenerator):
                             ([CrawlingFear_Link, CrawlingFear], "공포")]:
             for skill in skills:
                 skill.onAfter(DeviousDream.reduceCooltime(1000, _id))
+
+        # 5차 - 영원히 굶주리는 짐승
+        ForeverHungryBeastInit.onAfter(ForeverHungryBeastTrigger.controller(9000)) # 9초 후 등장 TODO: 기본 9600+1740ms에 스펙터 스킬 적중시마다 시간 줄어들도록 할것
+        ForeverHungryBeastTrigger.onAfter(core.RepeatElement(ForeverHungryBeast, 18))\
         
         # 기본 공격 : 540ms 중립스킬
         PlainAttack = core.DamageSkill("기본 공격", 0, 0, 0).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/battlemage.py
+++ b/dpmModule/jobs/battlemage.py
@@ -66,6 +66,7 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(ConcurrentRunRule('마스터 오브 데스', '그림 리퍼'), RuleSet.BASE)
         ruleset.add_rule(ConcurrentRunRule('소울 컨트랙트', '유니온 오라'), RuleSet.BASE)
         ruleset.add_rule(ConcurrentRunRule('메이플월드 여신의 축복', '유니온 오라'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('어비셜 라이트닝', '유니온 오라'), RuleSet.BASE)
         return ruleset
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
@@ -95,6 +96,7 @@ class JobGenerator(ck.JobGenerator):
         오라스위칭 미사용
         디버프 오라 사용
         알터 히트율 100%, 50초마다 40초간 유지되는 2개 알터 사용
+        어비셜 라이트닝 명계의 통로 미사용
 
         하이퍼 :
         다크 제네시스-쿨타임 리듀스
@@ -109,7 +111,7 @@ class JobGenerator(ck.JobGenerator):
         
         마스터 오브 데스는 리퍼와 같이 사용함
         알터는 쿨마다 사용함
-        메여축은 유니온 오라와 같이 사용함
+        메여축, 어비셜 라이트닝은 유니온 오라와 같이 사용함
         '''
         OVERLOAD_MANA = core.CharacterModifier(pdamage_indep = 8+vEhc.getV(3,3)//10)
 
@@ -118,8 +120,8 @@ class JobGenerator(ck.JobGenerator):
         MarkStack = core.StackSkillWrapper(core.BuffSkill("징표 스택", 0, 99999*10000), 1)
 
         #Damage Skills
-        DarkLightening = core.DamageSkill("다크 라이트닝", 0, 225, 4, modifier = core.CharacterModifier(pdamage = 60 + self.combat) + OVERLOAD_MANA).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #캔슬
-        DarkLighteningMark = core.DamageSkill("다크 라이트닝(징표)", 0, 350, 4, modifier = core.CharacterModifier(boss_pdamage=20, pdamage = 60 + self.combat)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+        DarkLightning = core.DamageSkill("다크 라이트닝", 0, 225, 4, modifier = core.CharacterModifier(pdamage = 60 + self.combat) + OVERLOAD_MANA).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper) #캔슬
+        DarkLightningMark = core.DamageSkill("다크 라이트닝(징표)", 0, 350, 4, modifier = core.CharacterModifier(boss_pdamage=20, pdamage = 60 + self.combat)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
         #좌우텔 분당 83회 기준.
         FinishBlow = core.DamageSkill("피니쉬 블로우", 720, 330 + 3 * self.combat, 6, modifier = core.CharacterModifier(crit=25 + ceil(self.combat / 2), armor_ignore=2 * ceil((30 + self.combat)/3)) + OVERLOAD_MANA).setV(vEhc, 1, 2, False).wrap(BlowSkillWrapper)
@@ -142,6 +144,8 @@ class JobGenerator(ck.JobGenerator):
         UnionAura = core.BuffSkill("유니온 오라", 810, (vEhc.getV(1,1)//3+30)*1000, cooltime = 100*1000, pdamage=20, boss_pdamage=10, att=vEhc.getV(1,1)*2).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)
         BlackMagicAlter = core.SummonSkill("블랙 매직 알터", 690, 1220, 800+32*vEhc.getV(0,0), 4, 40*1000, cooltime = 50*1000, modifier = OVERLOAD_MANA).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 2개 충전할때 마다 사용
         GrimReaper = GrimReaperWrapper(vEhc, 2, 2, MasterOfDeath)
+        AbyssyalLightning = core.BuffSkill("어비셜 라이트닝", 720, 35000, cooltime=200*1000, red=True).wrap(core.BuffSkillWrapper)
+        AbyssyalDarkLightning = core.DamageSkill("어비셜 라이트닝(칠흑의 번개)", 0, 1100, 5*3, modifier=core.CharacterModifier(crit=100, armor_ignore=20, pdamage_indep=-30)).wrap(core.DamageSkillWrapper)
         
         #Build Graph
         """
@@ -158,25 +162,28 @@ class JobGenerator(ck.JobGenerator):
 
         # 다크 라이트닝
         AddMark = MarkStack.stackController(1, "징표 생성")
-        UseMark = core.OptionalElement(partial(MarkStack.judge, 1, 1), DarkLighteningMark, name = '징표 사용여부 결정')
-        DarkLighteningMark.onAfter(MarkStack.stackController(-1, "징표 사용"))
-        DarkLightening.onAfter(AddMark)
+        UseMark = core.OptionalElement(partial(MarkStack.judge, 1, 1), DarkLightningMark, name = '징표 사용여부 결정')
+        DarkLightningMark.onAfter(MarkStack.stackController(-1, "징표 사용"))
+        DarkLightning.onAfter(AddMark)
+        AbyssyalDarkLightning.onAfter(AddMark)
+
+        UseDarkLightning = core.OptionalElement(AbyssyalLightning.is_active, AbyssyalDarkLightning, DarkLightning)
 
         # 다크 제네시스
         FinalAttackRoulette = Roulette((60 + 2 * self.combat) * 0.01)
         FinalAttack = core.OptionalElement(lambda: DarkGenesis.is_not_usable() and FinalAttackRoulette.draw(), DarkGenesisFinalAttack, name = "다크 제네시스 추가타 검증")
         DarkGenesis.onJustAfter(UseMark)
-        DarkGenesis.onAfter(DarkLightening)
+        DarkGenesis.onAfter(UseDarkLightning)
         DarkGenesisFinalAttack.onJustAfter(UseMark)
         
         # 피니시 블로우
         FinishBlow.registerMOD(MasterOfDeath) # 마스터 오브 데스 스킬 등록
         FinishBlow.onJustAfter(UseMark)
-        FinishBlow.onAfter(DarkLightening)
+        FinishBlow.onAfter(UseDarkLightning)
         FinishBlow.onAfter(FinalAttack)
         ReaperScythe.registerMOD(MasterOfDeath)
         ReaperScythe.onJustAfter(UseMark)
-        ReaperScythe.onAfter(DarkLightening)
+        ReaperScythe.onAfter(UseDarkLightning)
         ReaperScythe.onAfter(FinalAttack)
         BasicAttack = core.DamageSkill('기본공격', 0, 0, 0).wrap(core.DamageSkillWrapper)
         BasicAttack.onAfter(core.OptionalElement(UnionAura.is_active, ReaperScythe, FinishBlow, name = "유니온오라 여부"))
@@ -195,7 +202,7 @@ class JobGenerator(ck.JobGenerator):
         BattlekingBar.onAfter(FinalAttack)
         BattlekingBar.onAfter(BattlekingBar2)
         BattlekingBar2.onJustAfter(UseMark)
-        BattlekingBar2.onAfter(DarkLightening)
+        BattlekingBar2.onAfter(UseDarkLightning)
         BattlekingBar2.onAfter(FinalAttack)
         
         # 블랙 매직 알터
@@ -204,7 +211,7 @@ class JobGenerator(ck.JobGenerator):
 
         return(BasicAttack,
                 [Booster, globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
-                globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), WillOfLiberty, MasterOfDeath, UnionAura,
+                globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), WillOfLiberty, MasterOfDeath, UnionAura, AbyssyalLightning,
                 globalSkill.soul_contract()] +\
                 [DarkGenesis, BattlekingBar] +\
                 [RegistanceLineInfantry, Death, BlackMagicAlter, GrimReaper, MirrorBreak, MirrorSpider] +\

--- a/dpmModule/jobs/bishop.py
+++ b/dpmModule/jobs/bishop.py
@@ -143,7 +143,7 @@ class JobGenerator(ck.JobGenerator):
         Bahamutt.onTick(SacredMark.stackController(25, name="표식(25%)", dtype="set"))
         AngelOfLibra.onTick(SacredMark.stackController(50, name="표식(50%)", dtype="set"))
 
-        for sk in [HolyArrow, ShiningRay, Genesis, BigBang, AngelRay, PeaceMaker, PeaceMakerFinal]:
+        for sk in [HolyArrow, ShiningRay, Genesis, BigBang, AngelRay, PeaceMaker, PeaceMakerFinal, DivinePunishmentTick]:
             sk.onJustAfter(SacredMark.stackController(0, name="표식(소모)", dtype="set"))
             sk.add_runtime_modifier(SacredMark, lambda skill: core.CharacterModifier(pdamage_indep = skill.stack))
         

--- a/dpmModule/jobs/bishop.py
+++ b/dpmModule/jobs/bishop.py
@@ -2,7 +2,7 @@ from ..kernel import core
 from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from ..status.ability import Ability_tool
-from ..execution.rules import RuleSet, SynchronizeRule, InactiveRule, DisableRule
+from ..execution.rules import ConcurrentRunRule, RuleSet, SynchronizeRule, InactiveRule, DisableRule
 from . import globalSkill
 from functools import partial
 from .jobclass import adventurer
@@ -106,6 +106,9 @@ class JobGenerator(ck.JobGenerator):
         PeaceMaker = core.DamageSkill("피스메이커", 0, 350 + 14*vEhc.getV(0,0), 4, cooltime = -1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         PeaceMakerFinal = core.DamageSkill("피스메이커(폭발)", 0, 500 + 20*vEhc.getV(0,0), 8, cooltime = -1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         PeaceMakerFinalBuff = core.BuffSkill("피스메이커(버프)", 0, (8 + SERVERLAG)*1000, pdamage = (5 + vEhc.getV(0,0) // 5) + (12 - PEACEMAKER_HIT), cooltime = -1).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+
+        DivinePunishmentInit = core.DamageSkill("디바인 퍼니시먼트(개시)", 240, 0, 0, cooltime=85000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        DivinePunishmentTick = core.DamageSkill("디바인 퍼니시먼트(키다운)", 240, 150+6*vEhc.getV(0,0), 5+5, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
     
         #Summoning skill
         Bahamutt = core.SummonSkill("바하뮤트", 600, 3030, 500+6*self.combat, 1, 90 * 1000, cooltime = 120 * 1000, rem = True).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)    #최종뎀25%스택
@@ -153,12 +156,14 @@ class JobGenerator(ck.JobGenerator):
         # Libra - Bahamutt exclusive
         AngelOfLibra.onAfter(Bahamutt.controller(1))
         Bahamutt.onConstraint(core.ConstraintElement("리브라와 동시사용 불가", AngelOfLibra, AngelOfLibra.is_not_active))
+
+        DivinePunishmentInit.onAfter(core.RepeatElement(DivinePunishmentTick, 33))
         
         return(AngelRay, 
                 [Booster, SacredMark, Infinity, PeaceMakerFinalBuff, Pray, EpicAdventure, OverloadMana,
                 globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), globalSkill.useful_wind_booster(), AdvancedBless, Heal,
                 globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
                 [PeaceMakerInit] +\
-                [AngelOfLibra, Bahamutt, HeavensDoor, MirrorBreak, MirrorSpider] +\
+                [AngelOfLibra, Bahamutt, HeavensDoor, DivinePunishmentInit, MirrorBreak, MirrorSpider] +\
                 [UnstableMemorize] +\
                 [AngelRay])

--- a/dpmModule/jobs/blaster.py
+++ b/dpmModule/jobs/blaster.py
@@ -109,7 +109,6 @@ class JobGenerator(ck.JobGenerator):
         
         MagnumPunch = core.DamageSkill("매그넘 펀치", 180, 430 + 2*self.combat, 3, modifier = core.CharacterModifier(pdamage = 10, armor_ignore = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         MagnumPunch_Revolve = core.DamageSkill("리볼빙 캐논(매그넘 펀치)", 0, 180 + passive_level, 3).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        MagnumPunch_Revolve_Maximize = core.DamageSkill("리볼빙 캐논(매그넘 펀치)(맥시마이즈)", 0, 180 + passive_level, 3, modifier = core.CharacterModifier(pdamage = 50)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
         Cylinder = core.StackSkillWrapper(core.BuffSkill("실린더 게이지", 0, 9999999), 6)
         Overheat = core.BuffSkill("실린더 과열", 0, 0, cooltime = -1).wrap(core.BuffSkillWrapper)
@@ -122,7 +121,6 @@ class JobGenerator(ck.JobGenerator):
         
         DoublePang = core.DamageSkill("더블 팡", CANCEL_DELAY, 360 + 2*self.combat, 4, modifier = core.CharacterModifier(pdamage = 10, armor_ignore = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         DoublePang_Revolve = core.DamageSkill("리볼빙 캐논(더블 팡)", 0, 180 + passive_level, 3).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        DoublePang_Revolve_Maximize = core.DamageSkill("리볼빙 캐논(더블 팡)(맥시마이즈)", 0, 180 + passive_level, 3, modifier = core.CharacterModifier(pdamage = 50)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
         HammerSmash = core.DamageSkill("해머 스매시", CANCEL_DELAY, 395 + 2*self.combat, 6, modifier = core.CharacterModifier(pdamage = 10, armor_ignore = 20)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         HammerSmashWave = core.SummonSkill("해머 스매시(충격파)", 0, 1500, 150, 2+2, 5000, cooltime = -1).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
@@ -141,7 +139,6 @@ class JobGenerator(ck.JobGenerator):
         
         BunkerBuster = core.BuffSkill("벙커 버스터", 720, 45000, cooltime = 120000, red = True).isV(vEhc, 0, 0).wrap(core.BuffSkillWrapper)
         BunkerBusterAttack = core.DamageSkill("벙커 버스터(공격)", 0, 180 + 7 * vEhc.getV(0,0), 8, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc, 0, 0).wrap(core.DamageSkillWrapper)
-        BunkerBusterAttack_Maximize = core.DamageSkill("벙커 버스터(맥시마이즈)", 0, 180 + 7 * vEhc.getV(0,0), 8, modifier = core.CharacterModifier(pdamage = 50, armor_ignore = 100)).isV(vEhc, 0, 0).wrap(core.DamageSkillWrapper)
         
         BalkanPunch = core.DamageSkill("발칸 펀치", 1140, 1000 + 40 * vEhc.getV(4,4), 6, cooltime = 60 * 1000, red = True).isV(vEhc, 4, 4).wrap(core.DamageSkillWrapper)
         BalkanPunchTick = core.DamageSkill("발칸 펀치(틱)", 150, 450 + 18 * vEhc.getV(4,4), 5).isV(vEhc, 4, 4).wrap(core.DamageSkillWrapper) # 46회 반복
@@ -150,7 +147,11 @@ class JobGenerator(ck.JobGenerator):
         BurningBreaker = core.DamageSkill("버닝 브레이커(준비)", 2010, 0, 0, cooltime = 100*1000, red = True).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper)
         BurningBreakerRush = core.DamageSkill("버닝 브레이커(돌진)", 2220, 1500 + 60*vEhc.getV(1,1), 15, modifier = core.CharacterModifier(armor_ignore = 100, crit = 100)).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper) # 공속 적용됨, 2940ms -> 2220ms
         BurningBreakerExplode = core.DamageSkill("버닝 브레이커(폭발)", 0, 1200+48*vEhc.getV(1,1), 15 * 6, modifier = core.CharacterModifier(armor_ignore = 100, crit = 100)).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper)
-        BurningBreakerExplode_Maximize = core.DamageSkill("버닝 브레이커(폭발,맥시마이즈)", 0, 1200+48*vEhc.getV(1,1), 15 * 6, modifier = core.CharacterModifier(pdamage = 50, armor_ignore = 100, crit = 100)).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper)
+
+        AfterImageShockInit = core.BuffSkill("애프터이미지 쇼크", 0, 180*1000, cooltime=240*1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        AfterImageShockStack = core.StackSkillWrapper(core.BuffSkill("애프터이미지 쇼크(스택)", 0, 99999999), 99)
+        AfterImageShockActive = core.DamageSkill("애프터이미지 쇼크(액티브)", 0, 450+18*vEhc.getV(0,0), 5, cooltime=200).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        AfterImageShockPassive = core.DamageSkill("애프터이미지 쇼크(패시브)", 0, 500+20*vEhc.getV(0,0), 3, cooltime=6000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         #스킬 기본 연계 연결
         ReleaseFileBunker.onAfter(Cylinder.stackController(-6))
@@ -168,27 +169,38 @@ class JobGenerator(ck.JobGenerator):
         BalkanPunchRepeat.onAfter(BalkanPunchEnd)
         
         #맥시마이즈 캐논
-        BurningBreakerExplode_WithMaximize = core.OptionalElement(MaximizeCannon.is_active, BurningBreakerExplode_Maximize, BurningBreakerExplode, name = "맥시마이즈 캐논 여부")
-        
-        BunkerBusterAttack_WithMaximize = core.OptionalElement(MaximizeCannon.is_active, BunkerBusterAttack_Maximize, BunkerBusterAttack, name = "맥시마이즈 캐논 여부")
-        MagnumPunch_Revolve_WithMaximize = core.OptionalElement(MaximizeCannon.is_active, MagnumPunch_Revolve_Maximize, MagnumPunch_Revolve, name = "맥시마이즈 캐논 여부")
-        DoublePang_Revolve_WithMaximize = core.OptionalElement(MaximizeCannon.is_active, DoublePang_Revolve_Maximize, DoublePang_Revolve, name = "맥시마이즈 캐논 여부")
+        for sk in [BurningBreakerExplode, BunkerBusterAttack, MagnumPunch_Revolve, DoublePang_Revolve]:
+            sk.add_runtime_modifier(MaximizeCannon, lambda sk: core.CharacterModifier(pdamage=50*sk.is_active()))
         
         #버닝 브레이커
         BurningBreaker.onAfter(BurningBreakerRush)
-        BurningBreakerRush.onAfter(BurningBreakerExplode_WithMaximize)
+        BurningBreakerRush.onAfter(BurningBreakerExplode)
+
+        #애프터이미지 쇼크 - 패시브
+        UseAfterImageShockPassive = core.OptionalElement(lambda: AfterImageShockStack.judge(0, -1) and AfterImageShockPassive.is_available(), AfterImageShockPassive)
+        for sk in [MagnumPunch, DoublePang, HammerSmash, BalkanPunch, BalkanPunchTick, BurningBreakerExplode]:
+            sk.onAfter(UseAfterImageShockPassive)
+        AfterImageShockPassive.protect_from_running()
+
+        #애프터이미지 쇼크 - 액티브
+        AfterImageShockInit.onAfter(AfterImageShockStack.stackController(99))
+        UseAfterImageShockActive = core.OptionalElement(lambda: AfterImageShockStack.judge(1, 1) and AfterImageShockActive.is_available(), AfterImageShockActive)
+        AfterImageShockActive.onAfter(AfterImageShockStack.stackController(-1))
+        for sk in [MagnumPunch, DoublePang, HammerSmash, BalkanPunch, BalkanPunchTick, BurningBreakerExplode, ReleaseFileBunker]:
+            sk.onAfter(UseAfterImageShockActive)
+        AfterImageShockActive.protect_from_running()
         
         # 리볼빙 캐논 발동
         AddCylinder = core.OptionalElement(Overheat.is_not_active, Cylinder.stackController(1))
         
-        MagnumPunch_Revolve_Final = core.OptionalElement(BunkerBuster.is_active, BunkerBusterAttack_WithMaximize, MagnumPunch_Revolve_WithMaximize)
-        DoublePang_Revolve_Final = core.OptionalElement(BunkerBuster.is_active, BunkerBusterAttack_WithMaximize, DoublePang_Revolve_WithMaximize)
+        MagnumPunch_Revolve_Final = core.OptionalElement(BunkerBuster.is_active, BunkerBusterAttack, MagnumPunch_Revolve)
+        DoublePang_Revolve_Final = core.OptionalElement(BunkerBuster.is_active, BunkerBusterAttack, DoublePang_Revolve)
         MagnumPunch.onAfter(MagnumPunch_Revolve_Final)
         MagnumPunch.onAfter(AddCylinder)
         DoublePang.onAfter(DoublePang_Revolve_Final)
         DoublePang.onAfter(AddCylinder)
 
-        HammerSmash.onAfter(core.OptionalElement(BunkerBuster.is_active, BunkerBusterAttack_WithMaximize))
+        HammerSmash.onAfter(core.OptionalElement(BunkerBuster.is_active, BunkerBusterAttack))
         
         # 기본 콤보
         Mag_Pang = core.DamageSkill("매그-팡", 0, 0, 0).wrap(core.DamageSkillWrapper)
@@ -222,6 +234,6 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
                     Booster, globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), MaximizeCannon, WillOfLiberty, AuraWeaponBuff, AuraWeapon, BunkerBuster, Cylinder, Overheat, HammerSmashDebuff,
                     SoulContract] +\
-                [ReleaseHammer, BurningBreaker, BalkanPunch, MirrorBreak, MirrorSpider] +\
+                [ReleaseHammer, BurningBreaker, BalkanPunch, AfterImageShockInit, AfterImageShockActive, AfterImageShockPassive, MirrorBreak, MirrorSpider] +\
                 [RegistanceLineInfantry, HammerSmashWave] +\
                 [Mag_Pang])

--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -163,7 +163,7 @@ class JobGenerator(ck.JobGenerator):
         Pheonix = core.SummonSkill("피닉스", 0, 2670, 390, 1, 220 * 1000).setV(vEhc, 5, 3, True).wrap(core.SummonSkillWrapper) # 이볼브가 끝나면 자동으로 소환되므로 딜레이 0
         GuidedArrow = GuidedArrowWrapper(vEhc, 4, 4, ArmorPiercing)
         Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(5,5)))*1000, red=True).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
-        MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0) # TODO: 아머 피어싱 적용
+        MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0, break_modifier=MortalBlow) # TODO: 아머 피어싱 적용
         
         #잔영의시 미적용
         QuibberFullBurstBuff = core.BuffSkill("퀴버 풀버스트(버프)", 0, 30 * 1000, cooltime = 120 * 1000, red = True, patt=(5+int(vEhc.getV(2,2)*0.5)), crit_damage=8).wrap(core.BuffSkillWrapper) # 독화살 크뎀을 이쪽에 합침
@@ -172,6 +172,8 @@ class JobGenerator(ck.JobGenerator):
     
         ImageArrow = core.SummonSkill("잔영의 시", 720, 240, 400+16*vEhc.getV(1,1), 3, 3000, cooltime=30000, red = True).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 13 * 3타
         ImageArrowPassive = core.SummonSkill("잔영의 시(패시브)", 0, 2580, 400+16*vEhc.getV(1,1), 3.5*3, 9999999).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # 3~4 * 3타, 잔시 쿨동안 11회 사용
+
+        OpticalIllusion = core.DamageSkill("실루엣 미라주", 0, 400+16*vEhc.getV(0,0), 3, cooltime=7500, modifier=MortalBlow).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
     
         ######   Skill Wrapper   ######
         GrittyGust.onAfter(GrittyGustDOT)
@@ -196,6 +198,12 @@ class JobGenerator(ck.JobGenerator):
         QuibberFullBurstBuff.onAfter(QuibberFullBurstDOT)
         QuibberFullBurstBuff.onAfter(QuibberFullBurst)
 
+        UseOpticalIllusion = core.OptionalElement(OpticalIllusion.is_available, core.RepeatElement(OpticalIllusion, 5), name="쿨타임 체크")
+        for sk in [ArrowOfStorm, GrittyGust]:
+            sk.onAfter(UseOpticalIllusion)
+        OpticalIllusion.protect_from_running()
+        OpticalIllusion.onAfter(AdvancedQuibberAttack)
+
         ArmorPiercing.protect_from_running()
 
         ### Exports ###
@@ -206,6 +214,6 @@ class JobGenerator(ck.JobGenerator):
                     QuibberFullBurstDOT, GrittyGustDOT, ImageArrowPassive,
                     globalSkill.soul_contract()] +\
                 [] +\
-                [Evolve, ArrowFlatter, ArrowRain, Pheonix, GuidedArrow, QuibberFullBurst, ImageArrow, MirrorBreak, MirrorSpider] +\
+                [Evolve, ArrowFlatter, ArrowRain, Pheonix, GuidedArrow, QuibberFullBurst, ImageArrow, MirrorBreak, MirrorSpider, OpticalIllusion] +\
                 [] +\
                 [ArrowOfStorm])

--- a/dpmModule/jobs/cadena.py
+++ b/dpmModule/jobs/cadena.py
@@ -1,3 +1,4 @@
+from ..kernel.graph import DynamicVariableOperation
 from ..kernel import core
 from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
@@ -8,7 +9,6 @@ from .jobbranch import thieves
 from .jobclass import nova
 from math import ceil
 
-#TODO : 5차 신스킬 적용
 ######   Passive Skill   ######
 
 class WeaponVarietyStackWrapper(core.StackSkillWrapper): # TODO: 굳이 관리할 필요 없이 항상 최대 스택 가정해도 되지 않을까?
@@ -70,7 +70,45 @@ class MaelstromWrapper(core.SummonSkillWrapper):
             self.currentTick += 1
             return core.ResultObject(0, self.get_modifier(), self.skill.damage, self.skill.hit, sname = self.skill.name, spec = self.skill.spec)
         else:
-            return core.ResultObject(0, self.disabledModifier, 0, 0, sname = self.skill.name, spec = self.skill.spec)    
+            return core.ResultObject(0, self.disabledModifier, 0, 0, sname = self.skill.name, spec = self.skill.spec)
+
+def comboBuilder(name, skill_list):
+    combo = core.DamageSkill(name, 0, 0, 0).wrap(core.DamageSkillWrapper)
+    for sk in skill_list:
+        combo.onAfter(sk)
+    
+    delaySum = 0
+    cnst_list = []
+    for sk in skill_list:
+        if DynamicVariableOperation.reveal_argument(sk.skill.cooltime) > 0:
+            cnst_list += [core.ConstraintElement(sk._id + "(쿨타임)", sk, partial(sk.is_cooltime_left, delaySum, -1))]
+        delaySum += DynamicVariableOperation.reveal_argument(sk.skill.delay)
+
+    for cnst in cnst_list:
+        combo.onConstraint(cnst)
+
+    return combo
+
+class WeaponVarietyFinaleWrapper(core.DamageSkillWrapper):
+    def __init__(self, vEhc, num1, num2) -> None:
+        skill = core.DamageSkill("웨폰 버라이어티 피날레", 0, 250+10*vEhc.getV(num1,num2), 7*4, cooltime=11000).isV(vEhc,num1,num2) # 7타씩 4회
+        super(WeaponVarietyFinaleWrapper, self).__init__(skill)
+        self.max_stack = 3
+        self.stack = self.max_stack
+        self.tick = 0
+
+    def spend_time(self, time):
+        super(WeaponVarietyFinaleWrapper, self).spend_time(time)
+        if self.cooltimeLeft <= 0:
+            self.cooltimeLeft = self.skill.cooltime
+            self.stack = min(self.stack + 1, self.max_stack)
+
+    def _use(self, skill_modifier) -> core.ResultObject:
+        self.stack -= 1
+        return core.ResultObject(self.get_delay(), self.get_modifier(), self.get_damage(), self.get_hit(), sname = self.skill.name, spec = self.skill.spec)
+
+    def is_available(self) -> bool:
+        return self.stack > 0
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -120,7 +158,7 @@ class JobGenerator(ck.JobGenerator):
         스킬강화순서:
         퓨리-오드-버스트-멜-레투다
         
-        1타캔슬 120ms
+        1타캔슬 150ms
         캔슬 180ms
         
         서먼 스로잉 윙대거 3타 후 폭발
@@ -130,7 +168,7 @@ class JobGenerator(ck.JobGenerator):
         봄-브릭 / 샷건-클로 / 나이프 / 윙대거 / 배트 / 시미터-체이스 / 메일스트롬 4초당 1회 
         '''
         STROKE1_HIT_RATE = 1
-        STROKE1_CANCEL_TIME = 120
+        STROKE1_CANCEL_TIME = 150
         CANCEL_TIME = 180
         WINGDAGGER_HIT = 3
 
@@ -165,11 +203,11 @@ class JobGenerator(ck.JobGenerator):
         #ChainArts_ToughHustleInit = core.DamageSkill("체인아츠:터프허슬", 0, 0, 0, cooltime = 50000).setV(vEhc, 0, 2, False) #지속형		
         #ChainArts_ToughHustle = core.DamageSkill("체인아츠:터프허슬", 5000000, 600 + 7 * self.combat, 2).setV(vEhc, 0, 2, False) #지속형, 6초, 미사용
         
-        # TODO: 향후 딜사이클에 사용될 경우 컴뱃 오더스 적용할것
-        # ChainArts_takedown = core.DamageSkill("체인아츠:테이크다운", 5360, 990, 15, cooltime = 150*1000, modifier = core.CharacterModifier(armor_ignore = 80)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        # ChainArts_takedown_wave = core.DamageSkill("체인아츠:테이크다운(파동)", 0, 600, 16, modifier = core.CharacterModifier(armor_ignore = 80)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        # ChainArts_takedown_final = core.DamageSkill("체인아츠:테이크다운(최종)", 0, 5000, 1, modifier = core.CharacterModifier(armor_ignore = 80)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
-        # ChainArts_takedown_bind = core.BuffSkill("체인아츠:테이크다운(바인드)", 0, 15000, crit = CheapShotII.crit, crit_damage = CheapShotII.crit_damage, cooltime = -1).wrap(core.BuffSkillWrapper)
+        ChainArts_Takedown_Init = core.DamageSkill("체인아츠:테이크다운", 4080, 300+3*self.combat, 2, cooltime = (150-30)*1000, red=True).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        ChainArts_Takedown_Attack = core.DamageSkill("체인아츠:테이크다운(연속 공격)", 2970, 990+15*self.combat, 15, modifier = core.CharacterModifier(armor_ignore = 80)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        ChainArts_Takedown_Wave = core.DamageSkill("체인아츠:테이크다운(파동)", 0, 600+5*self.combat, 4).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper) # 8회 반복
+        ChainArts_Takedown_Final = core.DamageSkill("체인아츠:테이크다운(최종)", 0, 5000, 1, modifier = core.CharacterModifier(armor_ignore = 80)).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
+        ChainArts_Takedown_Bind = core.BuffSkill("체인아츠:테이크다운(바인드)", 0, 10000, crit = CheapShotII.crit, crit_damage = CheapShotII.crit_damage, cooltime = -1).wrap(core.BuffSkillWrapper)
         
         #논체인아츠 스킬
         
@@ -191,6 +229,7 @@ class JobGenerator(ck.JobGenerator):
         SummonBeatingNeedlebat_3 = core.DamageSkill("서먼 비팅 니들배트(3타)", CANCEL_TIME, 715 + 10 * self.combat, 8, modifier = core.CharacterModifier(pdamage = 50 + 20, boss_pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         SummonBeatingNeedlebat_Honmy = core.BuffSkill("서먼 비팅 니들배트(혼미)", 0, 15000, crit = CheapShotII.crit, crit_damage = CheapShotII.crit_damage, cooltime = -1).wrap(core.BuffSkillWrapper)
         
+        # 5차
         VenomBurst = core.DotSkill("베놈 버스트", 0, 1000, 160+6*vEhc.getV(4,4), 1, 99999999).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
         VenomBurst_Poison = core.BuffSkill("베놈 버스트(중독)", 0, 99999999, crit = CheapShotII.crit, crit_damage = CheapShotII.crit_damage, cooltime = -1).isV(vEhc,4,4).wrap(core.BuffSkillWrapper)
         
@@ -206,12 +245,17 @@ class JobGenerator(ck.JobGenerator):
         
         ChainArts_Maelstorm = MaelstromWrapper(vEhc, 8)
         ChainArts_Maelstorm_Slow = core.BuffSkill("체인아츠:메일스트롬(중독)", 0, 4000+6000, crit = CheapShotII.crit, crit_damage = CheapShotII.crit_damage, cooltime = -1).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
+
+        WeaponVarietyFinale = WeaponVarietyFinaleWrapper(vEhc, 0, 0)
+        WeaponVarietyFinaleTrigger = core.StackSkillWrapper(core.BuffSkill("웨폰 버라이어티 피날레(웨버횟수)", 0, 99999999), 4)
         ######   Skill Wrapper   ######
 
         #기본 연계 연결
         #ChainArts_ToughHustleInit.onAfter(ChainArts_ToughHustle) 터프허슬 미사용
-        # ChainArts_takedown.onAfter(ChainArts_takedown_bind)
-        # ChainArts_takedown_bind.onAfters([ChainArts_takedown_wave, ChainArts_takedown_final])
+        ChainArts_Takedown_Init.onBefore(ChainArts_Takedown_Bind)
+        ChainArts_Takedown_Init.onAfter(ChainArts_Takedown_Attack)
+        ChainArts_Takedown_Init.onAfter(core.RepeatElement(ChainArts_Takedown_Wave, 8))
+        ChainArts_Takedown_Init.onAfter(ChainArts_Takedown_Final)
         
         SummonThrowingWingdagger.onAfter(SummonThrowingWingdaggerSummon)
         SummonThrowingWingdaggerSummon.onAfter(SummonThrowingWingdaggerEnd.controller(330*WINGDAGGER_HIT))
@@ -243,63 +287,46 @@ class JobGenerator(ck.JobGenerator):
         SummonBeatingNeedlebat_2.onAfter(SummonBeatingNeedlebat_3)
         SummonBeatingNeedlebat_3.onAfter(WeaponVariety.stackController("배트"))
         SummonBeatingNeedlebat_3.onAfter(SummonBeatingNeedlebat_Honmy)
-        
-        #카데나 딜 사이클들.
-        
-        #샷건-클로
-        ShootgunClawCombo = core.DamageSkill('샷건-클로', 0, 0, 0).wrap(core.DamageSkillWrapper)
-        for i in [ChainArts_Stroke_1_Cancel, SummonShootingShotgun, ChainArts_Stroke_1, ChainArts_Stroke_2_Cancel, SummonScratchingClaw]:
-            ShootgunClawCombo.onAfter(i)
-        
-        for c in [core.ConstraintElement('샷건', SummonShootingShotgun, SummonShootingShotgun.is_available),
-                    core.ConstraintElement('클로', SummonScratchingClaw, SummonScratchingClaw.is_available)]:
-            ShootgunClawCombo.onConstraint(c)
-        
-        #시미터 - 체이스
-        SimiterChaseCombo = core.DamageSkill('시미터 - 체이스', 0, 0, 0).wrap(core.DamageSkillWrapper)
-        for i in [ChainArts_Stroke_1_Cancel, SummonCuttingSimiter, ChainArts_Chais]:
-            SimiterChaseCombo.onAfter(i)
-            
-        for c in [core.ConstraintElement('시미터', SummonCuttingSimiter, SummonCuttingSimiter.is_available)]:
-            SimiterChaseCombo.onConstraint(c)
-            
-        # 나이프
-        KnifeCombo = core.DamageSkill("나이프", 0, 0, 0).wrap(core.DamageSkillWrapper)
-        for i in [ChainArts_Stroke_1_Cancel, SummonSlachingKnife]:
-            KnifeCombo.onAfter(i)
 
-        for c in [core.ConstraintElement('나이프', SummonSlachingKnife, SummonSlachingKnife.is_available)]:
-            KnifeCombo.onConstraint(c)
-            
-        # 봄-브릭
-        BommBrickCombo = core.DamageSkill("봄-브릭", 0, 0, 0).wrap(core.DamageSkillWrapper)
-        for i in [ChainArts_Stroke_1_Cancel, SummonReleasingBoom, ChainArts_Stroke_1_Cancel, SummonStrikingBrick]:
-            BommBrickCombo.onAfter(i)
-            
-        for c in [core.ConstraintElement('봄', SummonReleasingBoom, SummonReleasingBoom.is_available),
-                    core.ConstraintElement('브릭', SummonStrikingBrick, SummonStrikingBrick.is_available)]:
-            BommBrickCombo.onConstraint(c)	
+        # 웨폰 버라이어티 피날레
+        WeaponVarietyFinale.onAfter(WeaponVarietyFinaleTrigger.stackController(-4))
+        WeaponVarietyAttack.onAfter(WeaponVarietyFinaleTrigger.stackController(1))
+        WeaponVarietyAttack.onAfter(
+            core.OptionalElement(lambda: WeaponVarietyFinaleTrigger.judge(4, 1) and WeaponVarietyFinale.is_available(), WeaponVarietyFinale, name="웨버피 발동조건"))
+
+        Reduce2sec = WeaponVarietyFinale.controller(2000, 'reduce_cooltime')
+        Reduce1sec = WeaponVarietyFinale.controller(1000, 'reduce_cooltime')
+        ChainArts_Fury_Damage.onAfter(Reduce1sec)
+        ChainArts_Crush.onAfter(Reduce2sec)
+        ChainArts_Takedown_Init.onAfter(Reduce2sec)
+        ChainArts_Takedown_Attack.onAfter(Reduce2sec)
+        ChainArts_Takedown_Wave.onAfter(Reduce2sec)
+        ChainArts_Takedown_Final.onAfter(Reduce2sec)
         
-        #평타
+        # 카데나 딜 사이클들.
+        
+        # 평타
         NormalAttack = core.DamageSkill("평타", 0, 0, 0).wrap(core.DamageSkillWrapper)
         for i in [ChainArts_Stroke_1, ChainArts_Stroke_2]:
             NormalAttack.onAfter(i)
+        
+        # 샷건-클로
+        ShootgunClawCombo = comboBuilder("샷건-클로", [ChainArts_Stroke_1_Cancel, SummonShootingShotgun, ChainArts_Stroke_1, ChainArts_Stroke_2_Cancel, SummonScratchingClaw])
+        
+        # 시미터 - 체이스
+        SimiterChaseCombo = comboBuilder("시미터-체이스", [ChainArts_Stroke_1_Cancel, SummonCuttingSimiter, ChainArts_Chais])
             
-        #윙대거
-        WingDaggerCombo = core.DamageSkill("윙대거", 0, 0, 0).wrap(core.DamageSkillWrapper)
-        for i in [ChainArts_Stroke_1_Cancel, SummonThrowingWingdagger]:
-            WingDaggerCombo.onAfter(i)
-
-        for c in [core.ConstraintElement('윙대거', SummonThrowingWingdagger, SummonThrowingWingdagger.is_available)]:
-            WingDaggerCombo.onConstraint(c)
+        # 나이프
+        KnifeCombo = comboBuilder("나이프", [ChainArts_Stroke_1_Cancel, SummonSlachingKnife])
             
-        #배트
-        BatCombo = core.DamageSkill("배트", 0, 0, 0).wrap(core.DamageSkillWrapper)
-        for i in [ChainArts_Stroke_1_Cancel, SummonBeatingNeedlebat_1]:
-            BatCombo.onAfter(i)
-
-        for c in [core.ConstraintElement('배트', SummonBeatingNeedlebat_1, SummonBeatingNeedlebat_1.is_available)]:
-           BatCombo.onConstraint(c)
+        # 봄-브릭
+        BommBrickCombo = comboBuilder("봄브릭", [ChainArts_Stroke_1_Cancel, SummonReleasingBoom, ChainArts_Stroke_1_Cancel, SummonStrikingBrick])
+            
+        # 윙대거
+        WingDaggerCombo = comboBuilder("윙대거", [ChainArts_Stroke_1_Cancel, SummonThrowingWingdagger])
+            
+        # 배트
+        BatCombo = comboBuilder("배트", [ChainArts_Stroke_1_Cancel, SummonBeatingNeedlebat_1])
 
         # 메일스트롬
         MaleStromCombo = core.DamageSkill("메일스트롬", 0, 0, 0).wrap(core.DamageSkillWrapper)
@@ -313,7 +340,8 @@ class JobGenerator(ck.JobGenerator):
         # TODO: 퓨리, 프로페셔널 추가타 발동에 터프허슬/테이크다운 추가
         for s in [ChainArts_Stroke_1, ChainArts_Stroke_2, ChainArts_Stroke_1_Cancel, ChainArts_Stroke_2_Cancel,
                                 SummonCuttingSimiter, SummonScratchingClaw, SummonShootingShotgun, SummonSlachingKnife, ChainArts_Chais, SummonThrowingWingdaggerEnd,
-                                SummonReleasingBoom, SummonStrikingBrick, SummonBeatingNeedlebat_1, SummonBeatingNeedlebat_2, SummonBeatingNeedlebat_3]:
+                                ChainArts_Takedown_Init, ChainArts_Takedown_Attack, ChainArts_Takedown_Wave, ChainArts_Takedown_Final, ChainArts_Crush,
+                                SummonReleasingBoom, SummonStrikingBrick, SummonBeatingNeedlebat_1, SummonBeatingNeedlebat_2, SummonBeatingNeedlebat_3, MirrorBreak]:
             s.onAfter(ChainArts_Fury_Use)
         for s in [SummonThrowingWingdaggerSummon, ChainArts_Maelstorm]:
             s.onTick(ChainArts_Fury_Use)
@@ -321,7 +349,8 @@ class JobGenerator(ck.JobGenerator):
         # 프로페셔널 에이전트 추가타
         for s in [ChainArts_Stroke_1, ChainArts_Stroke_2, ChainArts_Stroke_1_Cancel, ChainArts_Stroke_2_Cancel,
                     SummonCuttingSimiter, SummonScratchingClaw, SummonShootingShotgun, SummonSlachingKnife, ChainArts_Chais, SummonThrowingWingdaggerEnd,
-                    SummonReleasingBoom, SummonStrikingBrick, SummonBeatingNeedlebat_1, SummonBeatingNeedlebat_2, SummonBeatingNeedlebat_3,
+                    SummonReleasingBoom, SummonStrikingBrick, SummonBeatingNeedlebat_1, SummonBeatingNeedlebat_2, SummonBeatingNeedlebat_3, ChainArts_Crush,
+                    ChainArts_Takedown_Init, ChainArts_Takedown_Attack, ChainArts_Takedown_Wave, ChainArts_Takedown_Final,
                         ChainArts_Maelstorm, ChainArts_Fury_Damage]:
             s.onAfter(ProfessionalAgent_Attack)
         for s in [SummonThrowingWingdaggerSummon]:
@@ -330,7 +359,7 @@ class JobGenerator(ck.JobGenerator):
         for s in [ChainArts_Fury_Damage, SummonShootingShotgun, SummonScratchingClaw,
                         SummonCuttingSimiter, SummonSlachingKnife,
                             SummonReleasingBoom, SummonStrikingBrick,
-                                SummonBeatingNeedlebat_1, SummonThrowingWingdagger, ChainArts_Maelstorm, WeaponVarietyAttack]:
+                                SummonBeatingNeedlebat_1, SummonThrowingWingdagger, ChainArts_Maelstorm, WeaponVarietyAttack, WeaponVarietyFinale]:
             s.protect_from_running()
 
         return(NormalAttack,
@@ -340,9 +369,9 @@ class JobGenerator(ck.JobGenerator):
                     SummonSlachingKnife_Horror, SummonBeatingNeedlebat_Honmy, VenomBurst_Poison, ChainArts_Maelstorm_Slow,
                     globalSkill.soul_contract(), CheapShotIIBleed, CheapShotIIBleedBuff, CheapShotIIAdventureMageBuff] +\
                 [AD_Odnunce_Final,
-                    WingDaggerCombo, BatCombo, BommBrickCombo, ShootgunClawCombo, SimiterChaseCombo, KnifeCombo, MaleStromCombo, MirrorBreak, MirrorSpider] +\
+                    WingDaggerCombo, BatCombo, BommBrickCombo, ShootgunClawCombo, SimiterChaseCombo, KnifeCombo, MaleStromCombo, ChainArts_Crush, MirrorBreak, MirrorSpider] +\
                 [WeaponVarietyAttack, SummonThrowingWingdaggerSummon, VenomBurst, AD_Odnunce, ChainArts_Maelstorm] +\
-                [ChainArts_Fury_Damage, SummonThrowingWingdaggerEnd, SummonShootingShotgun, SummonScratchingClaw,
+                [ChainArts_Fury_Damage, WeaponVarietyFinale, SummonThrowingWingdaggerEnd, SummonShootingShotgun, SummonScratchingClaw,
                         SummonCuttingSimiter, SummonSlachingKnife,
                             SummonReleasingBoom, SummonStrikingBrick,
                                 SummonBeatingNeedlebat_1, SummonThrowingWingdagger] +\

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -101,7 +101,7 @@ class JobGenerator(ck.JobGenerator):
         SpecialMonkeyEscort_Canon = core.SummonSkill("스페셜 몽키 에스코트", 780, int(45000 / 97), 300+12*vEhc.getV(2,2), 4, (30+int(0.5*vEhc.getV(2,2)))*1000 - 1500, cooltime = 120000, red=True).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         SpecialMonkeyEscort_Boom = core.SummonSkill("스페셜 몽키 에스코트(폭탄)", 0, int(45000 / 17), 450+18*vEhc.getV(2,2), 7, (30+int(0.5*vEhc.getV(2,2)))*5000 - 1500, cooltime = -1, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
 
-        FullMaker = core.SummonSkill("풀 메이커", 720, 360, (700+28*vEhc.getV(0,0)) * 0.45, 3*3, 360*20-1, cooltime=60000, red=True).wrap(core.SummonSkillWrapper)
+        FullMaker = core.SummonSkill("풀 메이커", 720, 360, (700+28*vEhc.getV(0,0)) * 0.45, 3*3, 360*20-1, cooltime=60000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         ### build graph relationships
     
         MonkeyWave.onAfter(MonkeyWaveBuff)

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -100,6 +100,8 @@ class JobGenerator(ck.JobGenerator):
     
         SpecialMonkeyEscort_Canon = core.SummonSkill("스페셜 몽키 에스코트", 780, int(45000 / 97), 300+12*vEhc.getV(2,2), 4, (30+int(0.5*vEhc.getV(2,2)))*1000 - 1500, cooltime = 120000, red=True).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         SpecialMonkeyEscort_Boom = core.SummonSkill("스페셜 몽키 에스코트(폭탄)", 0, int(45000 / 17), 450+18*vEhc.getV(2,2), 7, (30+int(0.5*vEhc.getV(2,2)))*5000 - 1500, cooltime = -1, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
+
+        FullMaker = core.SummonSkill("풀 메이커", 720, 360, (700+28*vEhc.getV(0,0)) * 0.45, 3*3, 360*20-1, cooltime=60000, red=True).wrap(core.SummonSkillWrapper)
         ### build graph relationships
     
         MonkeyWave.onAfter(MonkeyWaveBuff)
@@ -119,7 +121,7 @@ class JobGenerator(ck.JobGenerator):
                     Booster, MonkeyWaveBuff, MonkeyFuriousBuff, MonkeyFuriousDot, OakRulet, Buckshot, MonkeyMagic,
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), EpicAdventure, LuckyDice, Overdrive, PirateFlag,
                     globalSkill.soul_contract()] +\
-                [MonkeyWave, MonkeyFurious, ICBM, MirrorBreak, MirrorSpider] +\
+                [FullMaker, MonkeyWave, MonkeyFurious, ICBM, MirrorBreak, MirrorSpider] +\
                 [OakRuletDOT, SupportMonkeyTwins, RollingCanonRainbow, BFGCannonball, ICBMDOT, SpecialMonkeyEscort_Boom, SpecialMonkeyEscort_Canon] +\
                 [] +\
                 [CanonBuster])

--- a/dpmModule/jobs/darknight.py
+++ b/dpmModule/jobs/darknight.py
@@ -94,6 +94,8 @@ class JobGenerator(ck.JobGenerator):
         PierceCyclone = core.DamageSkill("피어스 사이클론(더미)", 90, 0, 0, cooltime = 180*1000, red = True).wrap(core.DamageSkillWrapper)
         PierceCycloneTick = core.DamageSkill("피어스 사이클론", 360, 400+16*vEhc.getV(3,3), 12, modifier = core.CharacterModifier(crit=100, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper) #25타
         PierceCycloneEnd = core.DamageSkill("피어스 사이클론(종료)", 900, 1500+60*vEhc.getV(3,3), 15, modifier = core.CharacterModifier(crit=100, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)
+        DarknessAura = core.SummonSkill("다크니스 오라", 450, 1530, 400+16*vEhc.getV(0,0), 5, 40000, cooltime=180*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        DarknessAuraFinal = core.DamageSkill("다크니스 오라(폭발)", 450, 650+25*vEhc.getV(0,0), 13*(1+15//3), cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 생명력 3마다 폭발 1회 추가, 생명력 최대 15
         
         ######   Skill Wrapper   ######
     
@@ -121,6 +123,8 @@ class JobGenerator(ck.JobGenerator):
         PierceCyclone_.onAfter(PierceCycloneEnd)
         PierceCyclone.onAfter(PierceCyclone_)
 
+        DarknessAura.onAfter(DarknessAuraFinal.controller(40000))
+
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 2, 1)
         for sk in [GoungnilDescent, GoungnilDescentNoCooltime, DarkImpail, PierceCycloneEnd]:
@@ -129,8 +133,8 @@ class JobGenerator(ck.JobGenerator):
         
         return(BasicAttackWrapped, 
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
-                    Booster, CrossoverChain, Sacrifice, Reincarnation,EpicAdventure, DarkThurst, AuraWeaponBuff, AuraWeapon,
+                    Booster, CrossoverChain, Sacrifice, Reincarnation, EpicAdventure, DarkThurst, AuraWeaponBuff, AuraWeapon,
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
-                [BiholderShock, GoungnilDescent, DarkSpear, PierceCyclone, MirrorBreak, MirrorSpider] +\
+                [DarknessAura, DarknessAuraFinal, BiholderShock, GoungnilDescent, DarkSpear, PierceCyclone, MirrorBreak, MirrorSpider] +\
                 [BiholderDominant, BiholderImpact] +\
                 [BasicAttackWrapped])

--- a/dpmModule/jobs/demonslayer.py
+++ b/dpmModule/jobs/demonslayer.py
@@ -40,7 +40,7 @@ class JobGenerator(ck.JobGenerator):
         return ruleset
     
     def get_modifier_optimization_hint(self):
-        return core.CharacterModifier(armor_ignore = 50, pdamage = 120)
+        return core.CharacterModifier(crit = 50, armor_ignore = 50, pdamage = 120)
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self.combat
@@ -111,7 +111,7 @@ class JobGenerator(ck.JobGenerator):
             
         CallMastema = core.SummonSkill("콜 마스테마", 690, 5000, 1100, 8, (30+vEhc.getV(4,4))*1000, cooltime = 150*1000, red=True).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
         #CallMastemaAnother = core.SummonSkill("콜 마스테마+", 0, ).wrap(core.BuffSkillWrapper)    #러블리 테리토리..데미지 없음.
-        MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0) # TODO: 블블 적용여부 확인할것
+        MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         
         DemonAwakning = core.BuffSkill("데몬 어웨이크닝", 1110, (35 + vEhc.getV(0,0))*1000, cooltime = 120 * 1000, red=True, crit = (50 + int(0.5*vEhc.getV(0,0)))).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         DemonAwakningSummon = core.SummonSkill("데몬 어웨이크닝(더미)", 0, 8000, 0, 0, (35 + vEhc.getV(0,0))*1000, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
@@ -159,7 +159,7 @@ class JobGenerator(ck.JobGenerator):
 
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 3, 2)
-        for sk in [DemonSlashAW1, DemonSlashAW2, DemonSlashAW3, DemonSlashAW4, DemonImpact]:
+        for sk in [DemonSlashAW1, DemonSlashAW2, DemonSlashAW3, DemonSlashAW4, DevilCry, DemonImpact, Cerberus, DemonBaneTick, DemonBane2Tick]:
             auraweapon_builder.add_aura_weapon(sk)
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
 

--- a/dpmModule/jobs/demonslayer.py
+++ b/dpmModule/jobs/demonslayer.py
@@ -18,6 +18,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "데몬슬레이어"
         self.vEnhanceNum = 15
         self.preEmptiveSkills = 1
+        self.hyperStatPrefixed = 85 # DF 8레벨 투자
         
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'reuse', 'mess')
 

--- a/dpmModule/jobs/demonslayer.py
+++ b/dpmModule/jobs/demonslayer.py
@@ -36,6 +36,7 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(InactiveRule('데몬 슬래시(1타)', '데몬 슬래시-리메인타임'), RuleSet.BASE)
         ruleset.add_rule(InactiveRule('서버러스', '데몬 어웨이크닝'), RuleSet.BASE)
         ruleset.add_rule(ConcurrentRunRule('데빌 크라이', '데몬 어웨이크닝'), RuleSet.BASE)
+        ruleset.add_rule(InactiveRule('데몬 베인(개시)', '데몬 어웨이크닝'), RuleSet.BASE)
         return ruleset
     
     def get_modifier_optimization_hint(self):
@@ -68,6 +69,8 @@ class JobGenerator(ck.JobGenerator):
         '''
         코강 순서:
         슬래시-임팩트-서버-익스플로전-메타-데빌크라이
+
+        데몬 베인은 어웨이크닝과 따로 사용
 
         ##### 하이퍼 #####
         # 데몬 슬래시 - 엑스트라 포스, 리인포스, 리메인타임 리인포스
@@ -117,6 +120,13 @@ class JobGenerator(ck.JobGenerator):
         SpiritOfRageEnd = core.DamageSkill("요르문간드(종료)", 0, 900+36*vEhc.getV(3,3), 15, cooltime = -1).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)
         Orthros = core.SummonSkill("오르트로스(네메아)", 510, 2000, 400+16*vEhc.getV(1,1), 12, 40000, cooltime = 120*1000, red=True, modifier = core.CharacterModifier(crit = 100, armor_ignore = 50)).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)
         Orthros_ = core.SummonSkill("오르트로스(게리온)", 0, 3000, 900+36*vEhc.getV(1,1), 10, 40000, cooltime = -1, modifier = core.CharacterModifier(crit = 100, armor_ignore = 50)).isV(vEhc,1,1).wrap(core.SummonSkillWrapper)
+
+        DemonBaneInit = core.DamageSkill("데몬 베인(개시)", 240, 0, 0, cooltime=240*1000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        DemonBaneTick = core.DamageSkill("데몬 베인(1)", 3360/16, 325+13*vEhc.getV(0,0), 6, cooltime=-1, modifier=core.CharacterModifier(crit=50, armor_ignore=30)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 3360ms 16회
+        DemonBane2Pre = core.DamageSkill("데몬 베인(2)(선딜)", 600, 0, 0, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        DemonBane2Tick = core.DamageSkill("데몬 베인(2)", 2400/21, 650+26*vEhc.getV(0,0), 7, cooltime=-1, modifier=core.CharacterModifier(crit=50, armor_ignore=30)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 2400ms 21회
+        DemonBane2After = core.DamageSkill("데몬 베인(2)(후딜)", 240, 0, 0, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        
         ######   Skill Wrapper   ######
         DemonSlashAW1.onAfter(DemonSlashAW2)
         DemonSlashAW2.onAfter(DemonSlashAW3)
@@ -133,6 +143,11 @@ class JobGenerator(ck.JobGenerator):
         
         SpiritOfRage.onAfter(SpiritOfRageEnd.controller((10+int(0.2*vEhc.getV(3,3)))*1000))
         Orthros.onAfter(Orthros_)
+
+        DemonBaneInit.onAfter(core.RepeatElement(DemonBaneTick, 16))
+        DemonBaneInit.onAfter(DemonBane2Pre)
+        DemonBaneInit.onAfter(core.RepeatElement(DemonBane2Tick, 21))
+        DemonBaneInit.onAfter(DemonBane2After)
         
         Metamorphosis.onAfter(MetamorphosisSummon)
         MetamorphosisSummon.onTick(MetamorphosisSummon_BB)
@@ -149,7 +164,7 @@ class JobGenerator(ck.JobGenerator):
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
 
         # 블블 추가타 적용
-        for sk in [DemonSlashAW1, DemonSlashAW2, DemonSlashAW3, DemonSlashAW4, DemonImpact, DevilCry, AuraWeapon]:
+        for sk in [DemonSlashAW1, DemonSlashAW2, DemonSlashAW3, DemonSlashAW4, DemonImpact, DemonBaneTick, DemonBane2Tick, DevilCry, AuraWeapon]:
             jobutils.create_auxilary_attack(sk, 0.9, "(블루 블러드)")
 
         return(BasicAttackWrapper,
@@ -157,5 +172,5 @@ class JobGenerator(ck.JobGenerator):
                     Booster, DemonSlashRemainTime, DevilCryBuff, InfinityForce, Metamorphosis, BlueBlood, DemonFortitude, AuraWeaponBuff, AuraWeapon, DemonAwakning,
                     *demon.AnotherWorldWrapper(vEhc, 0, 0), globalSkill.soul_contract()] +\
                 [Cerberus, DevilCry, DemonSlash1, SpiritOfRageEnd] +\
-                [MetamorphosisSummon, CallMastema, DemonAwakningSummon, SpiritOfRage, Orthros, Orthros_, MirrorBreak, MirrorSpider] +\
+                [MetamorphosisSummon, CallMastema, DemonAwakningSummon, SpiritOfRage, Orthros, Orthros_, DemonBaneInit, MirrorBreak, MirrorSpider] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/dualblade.py
+++ b/dpmModule/jobs/dualblade.py
@@ -101,6 +101,8 @@ class JobGenerator(ck.JobGenerator):
         BladeTornado = core.DamageSkill("블레이드 토네이도", 540, 600+24*vEhc.getV(2,2), 7, red = True, cooltime = 12000, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         BladeTornadoSummon = core.SummonSkill("블레이드 토네이도(소환)", 0, 3000/5, 450+18*vEhc.getV(2,2), 6, 3000-1, cooltime=-1, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
         BladeTornadoSummonMirrorImaging = core.SummonSkill("블레이드 토네이도(소환)(미러이미징)", 0, 540, (450+18*vEhc.getV(2,2)) * 0.7, 6, 3000, cooltime=-1, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)
+
+        HauntedEdge = core.DamageSkill("헌티드 엣지-나찰", 0, 200+8*vEhc.getV(0,0), 4*5, cooltime=14000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         ######   Skill Wrapper   ######
     
@@ -129,8 +131,11 @@ class JobGenerator(ck.JobGenerator):
 
         SuddenRaid.onAfter(FinalCut.controller(0.2, "reduce_cooltime_p"))
 
+        PhantomBlow.onAfter(core.OptionalElement(HauntedEdge.is_available, HauntedEdge, name="헌티드 엣지 쿨타임 체크"))
+        HauntedEdge.protect_from_running()
+
         for sk in [PhantomBlow, SuddenRaid, FinalCut, FlashBang, AsuraTick, 
-            BladeStorm, BladeStormTick, KarmaFury, BladeTornado, HiddenBlade]:
+            BladeStorm, BladeStormTick, KarmaFury, BladeTornado, HiddenBlade, HauntedEdge]:
             jobutils.create_auxilary_attack(sk, 0.7, nametag = '(미러이미징)')
         
         return(PhantomBlow,
@@ -138,6 +143,6 @@ class JobGenerator(ck.JobGenerator):
                     Booster, DarkSight, FinalCutBuff, EpicAdventure, FlashBangDebuff, HiddenBladeBuff, globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat),
                     UltimateDarksight, ReadyToDie, globalSkill.soul_contract()] +\
                 [FinalCut, FlashBang, BladeTornado, SuddenRaid, KarmaFury, BladeStorm, Asura, MirrorBreak, MirrorSpider] +\
-                [SuddenRaidDOT, Venom, BladeTornadoSummon, BladeTornadoSummonMirrorImaging] +\
+                [SuddenRaidDOT, Venom, BladeTornadoSummon, BladeTornadoSummonMirrorImaging, HauntedEdge] +\
                 [] +\
                 [PhantomBlow])

--- a/dpmModule/jobs/eunwol.py
+++ b/dpmModule/jobs/eunwol.py
@@ -139,9 +139,9 @@ class JobGenerator(ck.JobGenerator):
 
         RealSoulAttack = core.DamageSkill("진 귀참", 540, 540+6*vEhc.getV(1,3), 12 + 1, cooltime=6000, red=True, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20) + core.CharacterModifier(armor_ignore=50)).setV(vEhc, 0, 2, False).isV(vEhc,1,3).wrap(core.DamageSkillWrapper)
 
-        ChainBombPunchInit = core.DamageSkill("파쇄 연권(시전)", 390, 0, 0, cooltime=90*1000, red=True).wrap(core.DamageSkillWrapper)
-        ChainBombPunchTick = core.DamageSkill("파쇄 연권(키다운)", 930/8, 400+16*vEhc.getV(0,0), 5, cooltime=-1).wrap(core.DamageSkillWrapper) # 5타씩 8회, 시전+키다운 1320ms
-        ChainBombPunchFinal = core.DamageSkill("파쇄 연권(막타)", 810, 950+38*vEhc.getV(0,0), 15*3, cooltime=-1).wrap(core.DamageSkillWrapper) # 15타씩 3회
+        ChainBombPunchInit = core.DamageSkill("파쇄 연권(시전)", 390, 0, 0, cooltime=90*1000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        ChainBombPunchTick = core.DamageSkill("파쇄 연권(키다운)", 930/8, 400+16*vEhc.getV(0,0), 5, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 5타씩 8회, 시전+키다운 1320ms
+        ChainBombPunchFinal = core.DamageSkill("파쇄 연권(막타)", 810, 950+38*vEhc.getV(0,0), 15*3, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 15타씩 3회
 
         # 파쇄철조 (디버프용)
         BladeImp = core.DamageSkill("파쇄철조-회", 360, 160, 4).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/evan.py
+++ b/dpmModule/jobs/evan.py
@@ -140,7 +140,7 @@ class JobGenerator(ck.JobGenerator):
         하이퍼 : 
         드스 / 드다 / 드브 쿨리듀스
         드다 - 어스 인핸스
-        썬더 보너스 어택
+        드브 - 윈드 보너스 찬스
         
         모든 융합스킬은 5차를 제외하고 전부 캔슬
         
@@ -177,10 +177,10 @@ class JobGenerator(ck.JobGenerator):
 
         ## 융합 스킬
         SwiftOfWind = core.SummonSkill("스위프트 오브 윈드", 0, 360, 215 + self.combat, 2*3, 3360, cooltime=-1, modifier=MDF(pdamage_indep=-35)).setV(vEhc, 3, 2, False).wrap(MirSkillWrapper)
-        SwiftOfThunder = core.SummonSkill("스위프트 오브 썬더", 0, 2280/SWIFT_OF_THUNDER_HIT, 450 + self.combat, 6+1, 2280, cooltime=-1).setV(vEhc, 4, 2, False).wrap(MirSkillWrapper)
+        SwiftOfThunder = core.SummonSkill("스위프트 오브 썬더", 0, 2280/SWIFT_OF_THUNDER_HIT, 450 + self.combat, 6, 2280, cooltime=-1).setV(vEhc, 4, 2, False).wrap(MirSkillWrapper)
         # DiveOfThunder - 안씀
         DiveOfEarth = core.SummonSkill("다이브 오브 어스", 0, 2310/DIVE_OF_EARTH_HIT, 190+self.combat+420+2*self.combat, 6, 2310, cooltime=-1, modifier = MDF(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(MirSkillWrapper)
-        BreathOfWind = core.SummonSkill("브레스 오브 윈드", 0, 450, 215+self.combat+BREATH_OF_WIND_BONUS*(65+self.combat), 5, 3510, cooltime=-1).setV(vEhc, 3, 2, False).wrap(MirSkillWrapper)
+        BreathOfWind = core.SummonSkill("브레스 오브 윈드", 0, 450, 215+self.combat+BREATH_OF_WIND_BONUS*(65+self.combat+85), 5, 3510, cooltime=-1).setV(vEhc, 3, 2, False).wrap(MirSkillWrapper)
         BreathOfEarth = core.SummonSkill("브레스 오브 어스", 0, 450, 280+self.combat, 5, 3510, cooltime=-1).setV(vEhc, 1, 2, False).wrap(MirSkillWrapper)
         
         ### 돌아와!

--- a/dpmModule/jobs/evan.py
+++ b/dpmModule/jobs/evan.py
@@ -10,7 +10,7 @@ from .jobbranch import magicians
 
 class MagicParticleWrapper(core.DamageSkillWrapper):
     def __init__(self, vEhc, upgrade_index, passive_level):
-        skill = core.DamageSkill("마법 잔해", 0, 0, 0, cooltime = 10000).setV(vEhc, upgrade_index, 2, True)
+        skill = core.DamageSkill("마법 잔해", 0, 110, 1, cooltime = 10000).setV(vEhc, upgrade_index, 2, True)
         super(MagicParticleWrapper, self).__init__(skill)
         self.stack = 0
         self.passive_level = passive_level
@@ -25,16 +25,16 @@ class MagicParticleWrapper(core.DamageSkillWrapper):
         return result
 
     def get_damage(self):
-        return 110 + 2*self.passive_level + (100 + self.passive_level) * (self.stack // 5)
+        return self.skill.damage + 2*self.passive_level + (100 + self.passive_level) * (self.stack // 5)
 
     def get_hit(self):
-        return self.stack
+        return self.skill.hit * self.stack
 
 class SpiralOfManaWrapper(core.SummonSkillWrapper):
     def __init__(self, vEhc, num1, num2):
         self.penaltyTime = 0
         skill = core.SummonSkill(
-            "스파이럴 오브 마나", 270, 420, 235+vEhc.getV(num1,num2), 6, 7000, cooltime=5000-50*vEhc.getV(num1,num2), red=True
+            "스파이럴 오브 마나", 360, 420, 235+vEhc.getV(num1,num2), 6, 7000, cooltime=5000-50*vEhc.getV(num1,num2), red=True
         ).setV(vEhc, 0, 2, False).isV(vEhc, num1, num2)
         super(SpiralOfManaWrapper, self).__init__(skill)
 
@@ -185,9 +185,9 @@ class JobGenerator(ck.JobGenerator):
         BreathOfEarth = core.SummonSkill("브레스 오브 어스", 0, 450, 280+self.combat, 5, 3510, cooltime=-1).setV(vEhc, 1, 2, False).wrap(MirSkillWrapper)
         
         ### 돌아와!
-        SwiftBack = core.BuffSkill("스위프트-돌아와!", 660, 60000, cooltime=-1, pdamage_indep = 10).wrap(core.BuffSkillWrapper)
-        DiveBack = core.BuffSkill("다이브-돌아와!", 660, 60000, cooltime=-1, rem=True).wrap(core.BuffSkillWrapper)
-        BreathBack = core.SummonSkill("브레스-돌아와!", 660, 450, 150+self.combat, 1, (30+self.combat // 2)*1000, cooltime=-1).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)
+        SwiftBack = core.BuffSkill("스위프트-돌아와!", 30, 60000, cooltime=-1, pdamage_indep = 10).wrap(core.BuffSkillWrapper)
+        DiveBack = core.BuffSkill("다이브-돌아와!", 30, 60000, cooltime=-1, rem=True).wrap(core.BuffSkillWrapper)
+        BreathBack = core.SummonSkill("브레스-돌아와!", 30, 450, 150+self.combat, 1, (30+self.combat // 2)*1000, cooltime=-1).setV(vEhc, 2, 2, False).wrap(core.SummonSkillWrapper)
         
         # 하이퍼
         SummonOnixDragon = core.SummonSkill("서먼 오닉스 드래곤", 900, 3030, 550, 2, 40000, cooltime = 80000).wrap(core.SummonSkillWrapper)
@@ -204,11 +204,11 @@ class JobGenerator(ck.JobGenerator):
         ElementalBlastBuff = core.BuffSkill("엘리멘탈 블래스트(버프)", 0, 10000, pdamage_indep = 20, cooltime=-1).isV(vEhc,2,3).wrap(core.BuffSkillWrapper)
 
         DragonBreak = core.SummonSkill("드래곤 브레이크", 0, 360, 450+18*vEhc.getV(5,5), 7, 2500, cooltime = 20000, red=True).isV(vEhc,5,5).wrap(MirSkillWrapper)
-        DragonBreakBack = core.SummonSkill("드래곤 브레이크-돌아와!", 660, 510, 150+6*vEhc.getV(5,5), 3, 5000, cooltime=-1).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
+        DragonBreakBack = core.SummonSkill("드래곤 브레이크-돌아와!", 30, 510, 150+6*vEhc.getV(5,5), 3, 5000, cooltime=-1).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
         ImperialBreath = core.SummonSkill("임페리얼 브레스", 0, 240, 600+24*vEhc.getV(5,5), 7, 4000, cooltime=-1).isV(vEhc,5,5).wrap(MirSkillWrapper)
 
         ZodiacRayInit = core.DamageSkill("조디악 레이(개시)", 780, 0, 0, cooltime = 180000, red = True).isV(vEhc,4,2).wrap(core.DamageSkillWrapper) # 딜레이 확인 필요
-        ZodiacRay = core.SummonSkill("조디악 레이", 0, 180, 400+16*vEhc.getV(4,2), 6, 180*74-1, modifier = MDF(armor_ignore = 100), cooltime = -1).isV(vEhc,4,2).wrap(core.SummonSkillWrapper)
+        ZodiacRay = core.SummonSkill("조디악 레이", 0, 180, 400+16*vEhc.getV(4,2), 6, 180*74-1, modifier = MDF(armor_ignore = 100) - MDF(pdamage_indep=10), cooltime = -1).isV(vEhc,4,2).wrap(core.SummonSkillWrapper)
         #14+vlevel//10초간 지속, 남은 시간동안 마법진 해방 딜 180ms마다. : 444타 가정( = 74타)
 
         SpiralOfMana = SpiralOfManaWrapper(vEhc, 0, 0)

--- a/dpmModule/jobs/flamewizard.py
+++ b/dpmModule/jobs/flamewizard.py
@@ -122,6 +122,7 @@ class JobGenerator(ck.JobGenerator):
         SavageFlame.onAfter(StackCheck4)
         SavageFlame.onAfter(SavageFlameStack.stackController(-15))
 
+        SalamanderMischeif.onJustAfter(SalamanderMischeifStack.stackController(-45))
         SalamanderMischeif.onTick(SalamanderMischeifStack.stackController(1))
         SalamanderMischeif.add_runtime_modifier(SalamanderMischeifStack, lambda sk: core.CharacterModifier(pdamage_indep=sk.stack))
         SalamanderMischeif.onJustAfter(SalamanderMischeifBuff.controller(60000))

--- a/dpmModule/jobs/flamewizard.py
+++ b/dpmModule/jobs/flamewizard.py
@@ -95,6 +95,11 @@ class JobGenerator(ck.JobGenerator):
         
         InfinityFlameCircleTick = core.DamageSkill("인피니티 플레임 서클", 180, 500+20*vEhc.getV(3,3), 7, modifier = core.CharacterModifier(crit = 50, armor_ignore = 50)).isV(vEhc,3,3).wrap(core.DamageSkillWrapper) #1틱
         InfinityFlameCircleInit = core.DamageSkill("인피니티 플레임 서클(개시)", 360, 0, 0, cooltime = 15*6*1000).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)
+
+        # 84타
+        SalamanderMischeif = core.SummonSkill("샐리맨더 미스칩", 750, 710, 150+6*vEhc.getV(0,0), 7, 60000, cooltime=90000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        SalamanderMischeifStack = core.StackSkillWrapper(core.BuffSkill("샐리맨더 미스칩(불씨)", 0, 99999999), 15+vEhc.getV(0,0))
+        SalamanderMischeifBuff = core.BuffSkill("샐리맨더 미스칩(버프)", 0, 30000, cooltime=-1, att=15+2*(15+vEhc.getV(0,0))).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         
         ######   Wrappers    ######
     
@@ -116,12 +121,16 @@ class JobGenerator(ck.JobGenerator):
         StackCheck4 = core.OptionalElement(partial(SavageFlameStack.judge, 4, 1), SavageFlame_4, StackCheck3, name = "스택 확인")
         SavageFlame.onAfter(StackCheck4)
         SavageFlame.onAfter(SavageFlameStack.stackController(-15))
+
+        SalamanderMischeif.onTick(SalamanderMischeifStack.stackController(1))
+        SalamanderMischeif.add_runtime_modifier(SalamanderMischeifStack, lambda sk: core.CharacterModifier(pdamage_indep=sk.stack))
+        SalamanderMischeif.onJustAfter(SalamanderMischeifBuff.controller(60000))
         
         return (OrbitalFlame,
                 [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
-                     cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level), WordOfFire, FiresOfCreation, BurningRegion, GloryOfGuardians, OverloadMana, Flame,
+                     cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level), WordOfFire, FiresOfCreation, BurningRegion, GloryOfGuardians, OverloadMana, Flame, SalamanderMischeifBuff,
                     globalSkill.soul_contract()] +\
-                [CygnusPalanks, BlazingOrbital, DragonSlaveInit, SavageFlame, InfinityFlameCircleInit, 
+                [SalamanderMischeif, CygnusPalanks, BlazingOrbital, DragonSlaveInit, SavageFlame, InfinityFlameCircleInit, 
                     InfernoRize, MirrorBreak, MirrorSpider] +\
                 [IgnitionDOT] +\
                 [] +\

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -45,13 +45,13 @@ def useful_advanced_bless(slevel = 1):
     UsefulAdvancedBless = core.BuffSkill("쓸만한 어드밴스드 블레스", 600, usefulSkillRemain(slevel), rem = False, att = 20).wrap(core.BuffSkillWrapper)
     return UsefulAdvancedBless
 
-def SpiderInMirrorBuilder(enhancer, skill_importance, enhance_importance):
+def SpiderInMirrorBuilder(enhancer, skill_importance, enhance_importance, break_modifier=core.CharacterModifier(), spider_modifier=core.CharacterModifier()):
     MirrorBreak = core.DamageSkill(
-        "스파이더 인 미러(공간 붕괴)", 720, 750+30*enhancer.getV(skill_importance, enhance_importance), 12, cooltime = 250*1000, red = True
+        "스파이더 인 미러(공간 붕괴)", 720, 750+30*enhancer.getV(skill_importance, enhance_importance), 12, cooltime = 250*1000, red = True, modifier=break_modifier
     ).wrap(core.DamageSkillWrapper)
     # 5번 연속 공격 후 종료, 재돌입 대기시간 3초
     MirrorSpider = core.SummonSkill(
-        "스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+7*enhancer.getV(skill_importance, enhance_importance), 8*5, 15*1000, cooltime = -1
+        "스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+7*enhancer.getV(skill_importance, enhance_importance), 8*5, 15*1000, cooltime = -1, modifier=spider_modifier
     ).wrap(core.SummonSkillWrapper)
     MirrorBreak.onAfter(MirrorSpider.controller(3000))
     return MirrorSpider, MirrorBreak

--- a/dpmModule/jobs/hero.py
+++ b/dpmModule/jobs/hero.py
@@ -147,8 +147,13 @@ class JobGenerator(ck.JobGenerator):
         ComboInstinctFringe = core.DamageSkill("콤보 인스팅트 균열", 0, 200 + 8*vEhc.getV(1,1), 18).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper)
         ComboInstinctOff = core.BuffSkill("콤보 인스팅트 종료", 0, 1, cooltime = -1).wrap(core.BuffSkillWrapper)
 
+        SwordIllusionInit = core.DamageSkill("소드 일루전(시전)", 660, 0, 0, cooltime=30000, red=True).wrap(core.DamageSkillWrapper)
+        SwordIllusion = core.DamageSkill("소드 일루전", 0, 125+5*vEhc.getV(0,0), 4, cooltime=-1).wrap(core.DamageSkillWrapper)
+        SwordIllusionFinal = core.DamageSkill("소드 일루전(최종)", 0, 250+10*vEhc.getV(0,0), 5, cooltime=-1).wrap(core.DamageSkillWrapper)
+
         ######   Skill Wrapper   ######
         ComboAttack = ComboAttackWrapper(core.BuffSkill("콤보어택", 0, 999999 * 1000), ComboDesfortBuff, vEhc, passive_level)
+        IncreaseCombo = ComboAttack.stackController(1)
         
         #Final attack type
         ComboInstinct.onAfter(ComboInstinctOff.controller(30 * 1000))
@@ -157,9 +162,9 @@ class JobGenerator(ck.JobGenerator):
         InstinctFringeUse = core.OptionalElement(ComboInstinct.is_active, ComboInstinctFringe, name = "콤보 인스팅트 여부")
     
         #레이징 블로우
-        RaisingBlowInrage.onAfters([InstinctFringeUse, RaisingBlowInrageFinalizer, AdvancedFinalAttack, ComboAttack.stackController(1)])
+        RaisingBlowInrage.onAfters([InstinctFringeUse, RaisingBlowInrageFinalizer, AdvancedFinalAttack, IncreaseCombo])
 
-        RisingRage.onAfters([AdvancedFinalAttack, ComboAttack.stackController(1)])
+        RisingRage.onAfters([AdvancedFinalAttack, IncreaseCombo])
     
         Insizing.onBefore(ComboAttack.stackController(-1))
         Insizing.onAfters([InsizingBuff, InsizingDot, AdvancedFinalAttack])
@@ -167,6 +172,13 @@ class JobGenerator(ck.JobGenerator):
         ComboDesfort.onBefores([ComboDesfortBuff, ComboAttack.stackController(-6)]) # TODO: 데스폴트 데미지에 콤보 카운터 어떻게 적용되는지 확인 필요
         ComboDesfort.onAfter(AdvancedFinalAttack)
         ComboDesfort.onConstraint(core.ConstraintElement("콤보 6개 이상", ComboAttack, partial(ComboAttack.judge, 6, 1)))
+
+        SwordIllusionInit.onAfter(core.RepeatElement(SwordIllusion, 12))
+        SwordIllusionInit.onAfter(core.RepeatElement(SwordIllusionFinal, 5))
+        SwordIllusion.onAfter(AdvancedFinalAttack)
+        SwordIllusion.onAfter(IncreaseCombo)
+        SwordIllusionFinal.onAfter(AdvancedFinalAttack)
+        SwordIllusionFinal.onAfter(IncreaseCombo)
 
         Panic.onBefore(ComboAttack.stackController(-2))
         Panic.onAfters([PanicBuff, AdvancedFinalAttack])
@@ -183,6 +195,6 @@ class JobGenerator(ck.JobGenerator):
                     InsizingBuff, InsizingDot, AuraWeaponBuff, AuraWeapon, ComboDesfortBuff, 
                     ComboInstinct, ComboInstinctOff, PanicBuff,
                     globalSkill.soul_contract()] +\
-                [Panic, Insizing, ComboDesfort, RisingRage] +\
+                [Panic, Insizing, ComboDesfort, SwordIllusionInit, RisingRage] +\
                 [SwordOfBurningSoul, MirrorBreak, MirrorSpider] +\
                 [RaisingBlowInrage])

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -232,6 +232,10 @@ class JobGenerator(ck.JobGenerator):
         SoulOfCrystal_Reaction_Domination = core.DamageSkill("리액션:도미네이션(소오크)", 0, 550 * 0.01 * (50 + vEhc.getV(1,0)), 2*2).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         SoulOfCrystal_Reaction_Destruction = core.DamageSkill("리액션:디스트럭션(소오크)", 0, 550 * 0.01 * (50 + vEhc.getV(1,0)), 4*2*2, modifier = core.CharacterModifier(boss_pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         SoulOfCrystal_Reaction_Spectrum = core.DamageSkill("리액션:스펙트럼(소오크)", 0, 1000+40*vEhc.getV(2,1), 5*2, modifier = core.CharacterModifier(boss_pdamage = 20)).wrap(core.DamageSkillWrapper)
+
+        CrystalGate = core.BuffSkill("크리스탈 게이트", 1080, (130+vEhc.getV(0,0))*1000, cooltime=180*1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        CrystalGateBuff = core.BuffSkill("크리스탈 게이트(버프)", 0, 25000, att=5+2*vEhc.getV(0,0)).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        CrystalGateAttack = core.DamageSkill("크리스탈 게이트(폭격)", 0, 450+18*vEhc.getV(0,0), 5, cooltime=1500).wrap(core.DamageSkillWrapper)
         
         #스킬간 연결
 
@@ -266,6 +270,14 @@ class JobGenerator(ck.JobGenerator):
         CrystalSkill_Deus.onAfter(Machina.controller(30000, type_="set_disabled_and_time_left"))
         
         MagicCircuitFullDrive.onAfter(MagicCircuitFullDriveStorm)
+
+        CrystalGate.onAfter(CrystalGateBuff)
+        CrystalGateBuff.onConstraint(core.ConstraintElement("크리스탈 게이트 ON", CrystalGate, CrystalGate.is_active))
+        UseCrystalGateAttack = core.OptionalElement(lambda: CrystalGate.is_active() and CrystalGateAttack.is_available(), CrystalGateAttack, name="폭격 조건 체크")
+        for sk in [Craft_Javelin, Craft_Javelin_AfterOrb, Craft_Orb, Craft_Longinus,
+                    GloryWing_Craft_Javelin, GloryWing_MortalWingbit, CrystalSkill_MortalSwing, CrystalIgnition]:
+            sk.onAfter(UseCrystalGateAttack)
+        CrystalGateAttack.protect_from_running()
         
         #자벨린 이후 바로 오브를 시전합니다.
         Craft_Javelin.onAfter(Craft_Orb)
@@ -309,10 +321,10 @@ class JobGenerator(ck.JobGenerator):
                 [SoulOfCrystalPassive, globalSkill.maple_heros(chtr.level, name = "레프의 용사", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
                     Booster, FastCharge, WraithOfGod, MagicCircuitFullDrive, FloraGoddessBless, SoulOfCrystal,
                     Craft_Javelin_EnhanceBuff, CrystalCharge, GloryWingUse,
-                    OverloadMana, BlessMark, CurseMark,
+                    OverloadMana, BlessMark, CurseMark, CrystalGate, CrystalGateBuff,
                     globalSkill.soul_contract()] +\
                 [CrystalSkill_MortalSwing, GloryWing_MortalWingbit, CrystalIgnitionInit, MirrorBreak, MirrorSpider] +\
                 [Riyo, Machina, CrystalSkill_Deus, CrystalSkill_Deus_Satelite,
-                    GramHolder, MagicCircuitFullDriveStorm] +\
+                    GramHolder, MagicCircuitFullDriveStorm, CrystalGateAttack] +\
                 [Reaction_Domination, Reaction_Destruction, Reaction_Spectrum] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -43,10 +43,8 @@ class UnstableMemorizeWrapper(core.DamageSkillWrapper):
         TODO: 위험한 방식이기 때문에, side-effect에 위험하지 않은 방식으로 변경해야 합니다.
         """
         cooltimeLeft = skill.cooltimeLeft
-        available = skill.is_available()
         result = skill._use(skill_modifier)
         skill.cooltimeLeft = cooltimeLeft
-        skill.available = available
         return result
 
     def add_skill(self, skill: core.AbstractSkillWrapper, weight: int):

--- a/dpmModule/jobs/kaiser.py
+++ b/dpmModule/jobs/kaiser.py
@@ -225,7 +225,7 @@ class JobGenerator(ck.JobGenerator):
         InfernalBreath = core.DamageSkill("인퍼널 브레스", 780, 300 + 4*self.combat, 8, cooltime = (20-self.combat)*1000, red=True).setV(vEhc, 4, 2, True).wrap(core.DamageSkillWrapper)
         InfernalBreath_Tile = core.SummonSkill("인퍼널 브레스(바닥)", 0, 1200, 200 + 3*self.combat, 2, 20000, cooltime = -1).setV(vEhc, 4, 2, True).wrap(core.SummonSkillWrapper)
 
-        Petrified = core.SummonSkill("페트리파이드", 450, 3030, 400, 1, 60000).setV(vEhc, 5, 2, False).wrap(core.SummonSkillWrapper)
+        Petrified = core.SummonSkill("페트리파이드", 450, 3030, 400, 1, 60000).setV(vEhc, 5, 3, False).wrap(core.SummonSkillWrapper)
     
         # 하이퍼
         MajestyOfKaiser = core.BuffSkill("마제스티 오브 카이저", 900, 30000, att = 30, cooltime = 90000).wrap(core.BuffSkillWrapper)
@@ -246,6 +246,10 @@ class JobGenerator(ck.JobGenerator):
         
         DrakeSlasher = DrakeSlasherWrapper(core.DamageSkill("드라코 슬래셔", 540, 500+5*vEhc.getV(0,0), 10+1, cooltime = (7-(vEhc.getV(0,0)//15))*1000, red=True, modifier = core.CharacterModifier(crit=100, armor_ignore=50) + core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).isV(vEhc,0,0), FinalFiguration)
         DrakeSlasher_Projectile = DrakeSlasherProjectileWrapper(core.DamageSkill("드라코 슬래셔(발사)", 0, 500+5*vEhc.getV(0,0), 6+1, cooltime = -1, modifier = core.CharacterModifier(crit=100, armor_ignore=50) + core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).isV(vEhc,0,0), FinalFiguration)
+
+        DragonBlaze = core.SummonSkill("드래곤 블레이즈", 690, 240, 250+10*vEhc.getV(0,0), 6, 20000, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        DragonBlazeAura = core.DamageSkill("드래곤 블레이즈(불의 기운)", 0, 375+15*vEhc.getV(0,0), 5, cooltime=3600).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        DragonBlazeFireball = core.DamageSkill("드래곤 블레이즈(화염구)", 0, 350+14*vEhc.getV(0,0), 3*6, cooltime=10000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         ######   Skill Wrapper   ######
         
@@ -300,6 +304,15 @@ class JobGenerator(ck.JobGenerator):
         
         # 조상님
         GuardianOfNova_1.onAfters([GuardianOfNova_2, GuardianOfNova_3])
+
+        # 드래곤 블레이즈
+        UseDragonBlazeAura = core.OptionalElement(lambda: DragonBlaze.is_active() and DragonBlazeAura.is_available(), DragonBlazeAura)
+        UseDragonBlazeFireball = core.OptionalElement(lambda: DragonBlaze.is_not_active() and DragonBlazeFireball.is_available(), DragonBlazeFireball)
+        for sk in [GigaSlasher, DrakeSlasher, DrakeSlasher_Projectile]:
+            sk.onAfter(UseDragonBlazeAura)
+            sk.onAfter(UseDragonBlazeFireball)
+        DragonBlazeAura.protect_from_running()
+        DragonBlazeFireball.protect_from_running()
         
         # 스택량 계산
         for sk, incr in [[DrakeSlasher, 5],
@@ -320,5 +333,6 @@ class JobGenerator(ck.JobGenerator):
                     SoulContract] +\
                 [AdvancedWillOfSword_Summon, WillOfSwordStrike, AdvancedWillOfSword] +\
                 [Wingbit_1, Wingbit_2, GuardianOfNova_1, GuardianOfNova_2, GuardianOfNova_3] +\
-                [DrakeSlasher, InfernalBreath, InfernalBreath_Tile, Petrified, Prominence, Phanteon, MirrorBreak, MirrorSpider] +\
+                [DragonBlaze, DragonBlazeAura, DragonBlazeFireball, DrakeSlasher,
+                    InfernalBreath, InfernalBreath_Tile, Petrified, Prominence, Phanteon, MirrorBreak, MirrorSpider] +\
                 [BasicAttack])

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -51,6 +51,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "키네시스"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 2
+        self.hyperStatPrefixed = 150 # PP 10레벨 투자
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self.combat

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -43,6 +43,31 @@ class KinesisStackWrapper(core.StackSkillWrapper):
         else:
             return self.judge(stack, 1)
 
+class LawOfGravityDebuffWrapper(core.SummonSkillWrapper):
+    def __init__(self, skill):
+        super(LawOfGravityDebuffWrapper, self).__init__(skill)
+        self.mobPulled = 0
+
+    def _use(self, skill_modifier):
+        self.mobPulled = 0
+        return super(LawOfGravityDebuffWrapper, self)._use(skill_modifier)
+    
+    def _useTick(self):
+        if self.onoff and self.tick <= 0: # TODO: afterTick() 같은 콜백 만들거나 / useTick의 if-else 없애거나 / if 내의 로직을 메소드로 뺴거나 / tickPassed 변수 만들거나 택1
+            self.tick += self.get_delay()
+            result = core.ResultObject(0, self.get_modifier(), self.get_damage(), self.get_hit(), sname = self.skill.name, spec = self.skill.spec)
+            self.mobPulled += 6
+            return result
+        else:
+            return core.ResultObject(0, self.disabledModifier, 0, 0, sname = self.skill.name, spec = self.skill.spec)
+
+    def get_modifier(self):
+        modifier = super(LawOfGravityDebuffWrapper, self).get_modifier()
+        return modifier + core.CharacterModifier(pdamage_indep = min(self.mobPulled * 3, 40)) # TODO: 2 아니면 3인데 실험 필요함
+
+    def get_delay(self):
+        return max(self.skill.delay - self.mobPulled * 300, 1200)
+
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
@@ -156,13 +181,18 @@ class JobGenerator(ck.JobGenerator):
         UltimatePsychicBullet = core.DamageSkill("얼티메이트-싸이킥 불릿", 630, 550 + 22*vEhc.getV(3,3), 6, modifier = ULTIMATE_AWAKENING).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)# -2, 딜레이 420ms + 그랩 210ms
         UltimatePsychicBulletBlackhole = core.SummonSkill("얼티메이트-싸이킥 불릿(블랙홀)", 0, 500, 500+20*vEhc.getV(3,3), 3, 500*4, cooltime = -1, modifier = ULTIMATE_AWAKENING).isV(vEhc,3,3).wrap(core.SummonSkillWrapper)# +1
         
-        PsychicPoint = KinesisStackWrapper(core.BuffSkill("싸이킥 포인트", 0, 999999999), 30 + 10, PsychicOver.is_active) # Issue 43 ; maximum point may 40
+        LawOfGravity = core.DamageSkill("로 오브 그래비티", 720, 400+16*vEhc.getV(0,0), 6, cooltime=60000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        LawOfGravityDebuff = core.SummonSkill("로 오브 그래비티(디버프)", 0, 3600, 500+20*vEhc.getV(0,0), 8, 22000, cooltime=-1).isV(vEhc,0,0).wrap(LawOfGravityDebuffWrapper)
+        LawOfGravityFinal = core.DamageSkill("로 오브 그래비티(폭발)", 0, 600+24*vEhc.getV(0,0), 15, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        
+        PsychicPoint = KinesisStackWrapper(core.BuffSkill("싸이킥 포인트", 0, 999999999), 30 + 10, PsychicOver.is_active)
         
         ### Build Graph ###
 
         ### Telekinesis
-        for sk in [PsychicGrab2, PsychicGroundDamage, PsycoBreakDamage, EverPsychicFinal, PsychicTornadoFinal_1, PsychicTornadoFinal_2]:
+        for sk in [PsychicGrab2, PsychicGroundDamage, PsycoBreakDamage, EverPsychicFinal, PsychicTornadoFinal_1, PsychicTornadoFinal_2, LawOfGravity, LawOfGravityFinal]:
             sk.onAfter(TeleKinesis)
+        LawOfGravityDebuff.onTick(TeleKinesis)
 
         ### 회복의 축복
         AnotherVoid.onTick(AnotherHeal.controller(4000))
@@ -179,8 +209,9 @@ class JobGenerator(ck.JobGenerator):
         PsychicTornado.onAfter(PsychicTornadoFinal_2.controller(20*1000))
         UltimateMovingMatter.onAfter(UltimateMovingMatterFinal)
         UltimatePsychicBullet.onAfter(UltimatePsychicBulletBlackhole)
-        
-        
+        LawOfGravity.onAfter(LawOfGravityDebuff)
+        LawOfGravity.onAfter(LawOfGravityFinal.controller(22000))
+                
         ### Psychic point
         Ultimate_Material.onConstraint(core.ConstraintElement("7포인트", PsychicPoint, partial(PsychicPoint.judge_ultimate,7)))
         Ultimate_Material.onConstraint(core.ConstraintElement("트레인 깔려있으면", UltimateTrain, partial(UltimateTrain.is_time_left, 0, 1))) # 0 -> 2000으로 조절하면 트레인 비중 높은 딜사이클이 됨
@@ -200,7 +231,7 @@ class JobGenerator(ck.JobGenerator):
         
         PsychicGrab2.onBefore(PsychicPoint.stackController(2))
 
-        EverPsychic.onBefore(PsychicPoint.stackController(30 + 10)) # Issue 43, pp maximum may 40 in most case. TODO:hyper point modification
+        EverPsychic.onBefore(PsychicPoint.stackController(30 + 10))
 
         PsychicOverSummon.onTick(PsychicPoint.stackController(1))
         
@@ -220,14 +251,17 @@ class JobGenerator(ck.JobGenerator):
 
         UltimateTrain.onConstraint(core.ConstraintElement("15포인트", PsychicPoint, partial(PsychicPoint.judge_ultimate,15)))
         UltimateTrain.onBefore(PsychicPoint.stackController(-15))
+
+        LawOfGravity.onConstraint(core.ConstraintElement("5포인트", PsychicPoint, partial(PsychicPoint.judge,5,1)))
+        LawOfGravity.onBefore(PsychicPoint.stackController(-5))
         
         return(PsychicGrab2,
                 [globalSkill.maple_heros(chtr.level, name = "이계의 용사", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), globalSkill.useful_wind_booster(),
                     Booster, PsychicShield, PsychicGround, 
                     PsycoBreak, UltimatePsychicBuff, PsychicCharging, 
-                    AnotherGoddessBuff, AnotherVoid, AnotherHeal, PsychicOver, OverloadMana, PsychicPoint,
+                    AnotherGoddessBuff, AnotherVoid, AnotherHeal, PsychicOver, OverloadMana, PsychicPoint, LawOfGravityDebuff,
                     globalSkill.soul_contract()] +\
                 [EverPsychic, Ultimate_Material] +\
                 [PsychicDrain, PsychicForce3, PsychicForce3Dot, UltimateBPM, PsychicOverSummon, PsychicTornado, UltimateMovingMatter, PsychicTornadoFinal_1, PsychicTornadoFinal_2] +\
-                [UltimateTrain, MirrorBreak, MirrorSpider] +\
+                [UltimateTrain, LawOfGravity, LawOfGravityFinal, MirrorBreak, MirrorSpider] +\
                 [PsychicGrab2])

--- a/dpmModule/jobs/kinesis.py
+++ b/dpmModule/jobs/kinesis.py
@@ -53,7 +53,7 @@ class LawOfGravityDebuffWrapper(core.SummonSkillWrapper):
         return super(LawOfGravityDebuffWrapper, self)._use(skill_modifier)
     
     def _useTick(self):
-        if self.onoff and self.tick <= 0: # TODO: afterTick() 같은 콜백 만들거나 / useTick의 if-else 없애거나 / if 내의 로직을 메소드로 뺴거나 / tickPassed 변수 만들거나 택1
+        if self.is_active() and self.tick <= 0: # TODO: afterTick() 같은 콜백 만들거나 / useTick의 if-else 없애거나 / if 내의 로직을 메소드로 뺴거나 / tickPassed 변수 만들거나 택1
             self.tick += self.get_delay()
             result = core.ResultObject(0, self.get_modifier(), self.get_damage(), self.get_hit(), sname = self.skill.name, spec = self.skill.spec)
             self.mobPulled += 6

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -111,7 +111,6 @@ class LightAndDarknessWrapper(core.DamageSkillWrapper):
         self.stack -= 1
         if self.stack <= 0:
             self.cooltimeLeft = 0
-            self.available = True
         return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = '빛과 어둠의 세례 스택 증가', spec = 'graph control')
 
 class LiberationOrbActiveWrapper(core.DamageSkillWrapper):

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -42,7 +42,7 @@ class LuminousStateController(core.BuffSkillWrapper):
             self.stack = LuminousStateController.STACK
             self.currentState = self.state
             self.state = LuminousStateController.EQUAL
-            self.remain = 17 * (1 + 0.01* self.buff_rem) * 1000  #오더스?
+            self.remain = 17 * (1 + 0.01* self.buff_rem) * 1000
             self.equalCallback()
             
         return core.ResultObject(0, core.CharacterModifier(), 0, 0, '루미너스 스택 변경', spec = 'graph control')     
@@ -99,7 +99,7 @@ class PunishingResonatorWrapper(core.SummonSkillWrapper):
 
 class LightAndDarknessWrapper(core.DamageSkillWrapper):
     def __init__(self, vEhc, num1, num2):
-        skill = core.DamageSkill("빛과 어둠의 세례", 840, 15 * vEhc.getV(1,1)+375, 13 * 7, cooltime = 45*1000, red=True, modifier = core.CharacterModifier(armor_ignore = 100, crit = 100)).isV(vEhc,num1,num2)
+        skill = core.DamageSkill("빛과 어둠의 세례", 840, 15 * vEhc.getV(num1,num2)+375, 13 * 7, cooltime = 45*1000, red=True, modifier = core.CharacterModifier(armor_ignore = 100, crit = 100)).isV(vEhc,num1,num2)
         super(LightAndDarknessWrapper, self).__init__(skill)
         self.stack = 12
 
@@ -113,6 +113,29 @@ class LightAndDarknessWrapper(core.DamageSkillWrapper):
             self.cooltimeLeft = 0
             self.available = True
         return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = '빛과 어둠의 세례 스택 증가', spec = 'graph control')
+
+class LiberationOrbActiveWrapper(core.DamageSkillWrapper):
+    def __init__(self, vEhc, num1, num2):
+        self.light = 0
+        self.dark = 0
+        skill = core.DamageSkill("리버레이션 오브(액티브)", 0, 500 + 21 * vEhc.getV(num1,num2), 10, cooltime = 1000, modifier = core.CharacterModifier(crit = 100)).isV(vEhc,num1,num2)
+        super(LiberationOrbActiveWrapper, self).__init__(skill)
+
+    def _setStack(self, light, dark):
+        self.light = light.stack
+        self.dark = dark.stack
+        return self._result_object_cache
+
+    def setStack(self, light, dark):
+        task = core.Task(self, partial(self._setStack, light, dark))
+        return core.TaskHolder(task, name="리버레이션 오브 데미지 설정")
+
+    def get_damage(self):
+        damage = self.skill.damage
+        if self.light == self.dark:
+            damage += 25
+        damage += max(0, self.light + self.dark - 1) * 50
+        return damage
 
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
@@ -161,6 +184,7 @@ class JobGenerator(ck.JobGenerator):
         소울 컨트랙트는 이퀄리브리엄에 맞춰 사용
         퍼니싱 리소네이터는 이퀄리브리엄에 맞춰 사용
         메모라이즈는 이퀄이 아니고 쿨타임이 돌아 있으면 사용
+        리버레이션 오브는 쿨마다 사용
         '''
         ######   Skill   ######
         DarkAffinity = core.CharacterModifier(pdamage_indep = 5) # 어둠 마법 강화
@@ -189,6 +213,11 @@ class JobGenerator(ck.JobGenerator):
         DoorOfTruth = core.SummonSkill("진리의 문", 870, 3030, 375 + 15 * vEhc.getV(4,4), 10, (25 + vEhc.getV(4,4) // 2) * 1000, cooltime = -1).isV(vEhc,3,3).wrap(core.SummonSkillWrapper)   #이퀄시 사용 가능해짐.
         PunishingResonator = PunishingResonatorWrapper(vEhc, 2, 1, LuminousState.getState)
         LightAndDarkness = LightAndDarknessWrapper(vEhc, 0, 0)
+        LiberationOrbPassive = core.DamageSkill("리버레이션 오브(패시브)", 0, 375+15*vEhc.getV(0,0), 4, cooltime=6000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # TODO: 여러번 타격 가능한지 확인할것
+        LiberationOrbStackLight = core.StackSkillWrapper(core.BuffSkill("리버레이션 오브(스택)(빛)", 0, 99999999), 4)
+        LiberationOrbStackDark = core.StackSkillWrapper(core.BuffSkill("리버레이션 오브(스택)(어둠)", 0, 99999999), 4)
+        LiberationOrb = core.BuffSkill("리버레이션 오브", 690, 20000, cooltime=180*1000, red=True).wrap(core.BuffSkillWrapper)
+        LiberationOrbActive = LiberationOrbActiveWrapper(vEhc,0,0)
 
         # Skill Wrapper - Basic Attack
         LightReflection.onAfter(LuminousState.modifyStack(390))
@@ -212,14 +241,35 @@ class JobGenerator(ck.JobGenerator):
         # Skill Wrapper - Light and Darkness
         for absolute in [AbsoluteKillCooltimed, AbsoluteKill]:
             absolute.onAfter(core.create_task('빛과 어둠의 세례 쿨다운 스택 1 감소', LightAndDarkness.reduceStack, LightAndDarkness))
+
+        # Skill Wrapper - Liberation Orb
+        LiberationOrb.onAfter(LiberationOrbActive.setStack(LiberationOrbStackLight, LiberationOrbStackDark))
+        LiberationOrb.onAfter(LiberationOrbStackLight.stackController(-4))
+        LiberationOrb.onAfter(LiberationOrbStackDark.stackController(-4))
+        LiberationOrb.onConstraint(core.ConstraintElement("리버레이션 오브 마력 제한",
+            LiberationOrbStackDark, lambda: LiberationOrbStackDark.stack + LiberationOrbStackLight.stack >= 1))
+
+        LiberationOrbPassive.onAfter(core.OptionalElement(LuminousState.isLight, LiberationOrbStackLight.stackController(1)))
+        LiberationOrbPassive.onAfter(core.OptionalElement(LuminousState.isDark, LiberationOrbStackDark.stackController(1)))
+        
+        UseLiberationOrbPassive = core.OptionalElement(
+            lambda: LiberationOrb.is_not_active() and LiberationOrbPassive.is_available(), LiberationOrbPassive, name="리버레이션 오브(패시브) 조건")
+        UseLiberationOrbActive = core.OptionalElement(
+            lambda: LiberationOrb.is_active() and LiberationOrbActive.is_available(), LiberationOrbActive, name="리버레이션 오브(액티브) 조건")
+        for sk in [LightReflection, Apocalypse, AbsoluteKill, AbsoluteKillCooltimed]:
+            sk.onAfter(UseLiberationOrbPassive)
+            sk.onAfter(UseLiberationOrbActive)
+        
+        LiberationOrbPassive.protect_from_running()
+        LiberationOrbActive.protect_from_running()
         
         SoulContract = globalSkill.soul_contract()
 
         return(Attack, 
                 [LuminousState, globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), globalSkill.useful_wind_booster(),
-                    Booster, PodicMeditaion, DarknessSocery, DarkCrescendo, HerosOath, Memorize, OverloadMana,
+                    Booster, PodicMeditaion, DarknessSocery, DarkCrescendo, HerosOath, Memorize, OverloadMana, LiberationOrb,
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), SoulContract] +\
-                [LightAndDarkness] +\
+                [LightAndDarkness, LiberationOrbActive, LiberationOrbPassive] +\
                 [PunishingResonator, DoorOfTruth, MirrorBreak, MirrorSpider] +\
                 [] +\
                 [Attack])

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -55,7 +55,7 @@ class MechCarrierWrapper(core.SummonSkillWrapper):
         return super(MechCarrierWrapper, self)._use(skill_modifier)
     
     def _useTick(self):
-        if self.onoff and self.tick <= 0: # TODO: afterTick() 같은 콜백 만들자....
+        if self.is_active() and self.tick <= 0: # TODO: afterTick() 같은 콜백 만들자....
             self.tick += self.get_delay()
             hit = self.get_hit()
             self.interceptor = min(self.interceptor + 1, 16)

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -168,6 +168,7 @@ class JobGenerator(ck.JobGenerator):
         BusterCallPenalty = core.BuffSkill("메탈아머 전탄발사(페널티)", 0, 2000, cooltime = -1).wrap(core.BuffSkillWrapper)
 
         MechCarrier = MechCarrierWrapper(vEhc, 0, 0, ROBOT_MASTERY)
+        MechCarrierBuff = core.BuffSkill("메카 캐리어(버프)", 0, MechCarrier.skill.remain, cooltime = -1, pdamage = ROBOT_BUFF).wrap(core.BuffSkillWrapper)
         
         MassiveFire.onAfter(MassiveFire2)
         #### 호밍 미사일 정의 ####
@@ -179,6 +180,7 @@ class JobGenerator(ck.JobGenerator):
         HommingMissleHolder = core.SummonSkill("호밍 미사일(더미)", 0, 660, 0, 0, 99999 * 100000).wrap(core.SummonSkillWrapper)
         
         MultipleOption.onAfter(MultipleOptionBuff)
+        MechCarrier.onAfter(MechCarrierBuff)
         
         IsBuster_B = core.OptionalElement(BusterCallBuff.is_active, HommingMissle_B_Bu, HommingMissle_B)
         IsBuster = core.OptionalElement(BusterCallBuff.is_active, HommingMissle_Bu, HommingMissle_)
@@ -204,7 +206,7 @@ class JobGenerator(ck.JobGenerator):
         
         return(MassiveFire,
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
-                    Booster, WillOfLiberty, LuckyDice, SupportWaverBuff, RobolauncherBuff, RoboFactoryBuff, MultipleOptionBuff, BomberTime, Overdrive,
+                    Booster, WillOfLiberty, LuckyDice, SupportWaverBuff, RobolauncherBuff, RoboFactoryBuff, MultipleOptionBuff, MechCarrierBuff, BomberTime, Overdrive,
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
                 [MicroMissle, MechCarrier, BusterCallInit] +\
                 [HommingMissleHolder, RegistanceLineInfantry, SupportWaver, Robolauncher, RoboFactory, DistortionField, MultipleOption, MirrorBreak, MirrorSpider] +\

--- a/dpmModule/jobs/mercedes.py
+++ b/dpmModule/jobs/mercedes.py
@@ -136,6 +136,8 @@ class JobGenerator(ck.JobGenerator):
         ElementalGhostSpirit = core.DamageSkill("엘리멘탈 고스트(정령의 기운)", 0, 450+15*vEhc.getV(0,0), 8, cooltime=10*1000).wrap(core.DamageSkillWrapper)
         IrkilaBreathInit = core.DamageSkill("이르칼라의 숨결", 900, 0, 0, cooltime = 150 * 1000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         IrkilaBreathTick = core.DamageSkill("이르칼라의 숨결(틱)", 150, 400+16*vEhc.getV(1,1), 8).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        RoyalKnights = core.BuffSkill("로얄 나이츠", 1260, 30000, cooltime=150*1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        RoyalKnightsAttack = core.DamageSkill("로얄 나이츠(공격)", 0, 325+13*vEhc.getV(0,0), 4*4, cooltime=1410).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
 
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
@@ -192,22 +194,27 @@ class JobGenerator(ck.JobGenerator):
         # Sylphidia.onConstraint(core.ConstraintElement("엘고와 따로 사용", ElementalGhost, lambda: ElementalGhost.is_not_active() and ElementalGhost.is_not_usable()))
 
         #Final Attack, Elemental Ghost
-        UseElementalGhostSpirit = core.OptionalElement(lambda: ElementalGhost.is_active() and ElementalGhostSpirit.is_available(), ElementalGhostSpirit, name="정령의 기운 조건")
+        UseElementalGhostSpirit = core.OptionalElement(
+            lambda: ElementalGhost.is_active() and ElementalGhostSpirit.is_available(), ElementalGhostSpirit, name="정령의 기운 조건")
+        UseRoyalNightsAttack = core.OptionalElement(
+            lambda: RoyalKnights.is_active() and RoyalKnightsAttack.is_available(), RoyalKnightsAttack, name="로얄 나이츠 조건")
 
         for wrp in [UnicornSpike, RegendrySpear, LightningEdge, LeapTornado, GustDive,
                     AdvanceStrikeDualShot, AdvanceStrikeDualShot_Link, WrathOfEllil]:
             ElementalGhost.addSkill(wrp, is_fast=False)
             wrp.onAfter(AdvancedFinalAttackSlow)
             wrp.onAfter(UseElementalGhostSpirit)
+            wrp.onAfter(UseRoyalNightsAttack)
         ElementalGhost.addSkill(AdvancedFinalAttackSlow, is_fast=False) # 파택에 잔상 적용하는것과 잔상 공격에 파택 따로 적용하는것 결과적으로 동일함
             
         for wrp in [IshtarRing, IrkilaBreathTick]:
             ElementalGhost.addSkill(wrp, is_fast=True)
             wrp.onAfter(AdvancedFinalAttackFast)
             wrp.onAfter(UseElementalGhostSpirit)
+            wrp.onAfter(UseRoyalNightsAttack)
         ElementalGhost.addSkill(AdvancedFinalAttackFast, is_fast=True)
 
-        for sk in [UnicornSpike, RegendrySpear, WrathOfEllil, ElementalGhostSpirit]:
+        for sk in [UnicornSpike, RegendrySpear, WrathOfEllil, ElementalGhostSpirit, RoyalKnightsAttack]:
             sk.protect_from_running()
 
         for sk in [UnicornSpikeBuff, RegendrySpearBuff, LightningEdgeBuff]:
@@ -215,9 +222,10 @@ class JobGenerator(ck.JobGenerator):
     
         return(BasicAttack,
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), 
-                    Booster, ElvishBlessing, AncientSpirit, HerosOath, Sylphidia.ignore(), CriticalReinforce, UnicornSpikeBuff, RegendrySpearBuff, LightningEdgeBuff, ElementalGhost,
+                    Booster, ElvishBlessing, AncientSpirit, HerosOath, Sylphidia.ignore(), RoyalKnights,
+                    CriticalReinforce, UnicornSpikeBuff, RegendrySpearBuff, LightningEdgeBuff, ElementalGhost,
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
-                [ElementalGhostSpirit, UnicornSpike, RegendrySpear, WrathOfEllil, IrkilaBreathInit] +\
+                [RoyalKnightsAttack, ElementalGhostSpirit,UnicornSpike, RegendrySpear, WrathOfEllil, IrkilaBreathInit] +\
                 [ElementalKnights, ElementalKnights_1, ElementalKnights_2, GuidedArrow, MirrorBreak, MirrorSpider] +\
                 [] +\
                 [BasicAttack])

--- a/dpmModule/jobs/michael.py
+++ b/dpmModule/jobs/michael.py
@@ -103,12 +103,19 @@ class JobGenerator(ck.JobGenerator):
     
         SwordOfSoullight = core.BuffSkill("소드 오브 소울 라이트", 810, 30000, cooltime = 180*1000, red = True, patt = 15 + vEhc.getV(1,1)//2, crit = 100, armor_ignore = 100).isV(vEhc,1,1).wrap(core.BuffSkillWrapper)
         SoullightSlash = core.DamageSkill("소울 라이트 슬래시", 630, 400+16*vEhc.getV(1,1), 12).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+
+        LightOfCourage = core.BuffSkill("라이트 오브 커리지", 750, 25000, cooltime=90*1000, red=True, pdamage=10+vEhc.getV(0,0)//2).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
+        LightOfCourageSummon = core.SummonSkill("라이트 오브 커리지(빛의 검)", 0, 2400, 325+13*vEhc.getV(0,0), 5, 25000, cooltime=-1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        LightOfCourageAttack = core.DamageSkill("라이트 오브 커리지(용기의 빛)", 0, 175+7*vEhc.getV(0,0), 2, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        LightOfCourageFinal = core.DamageSkill("라이트 오브 커리지(용기의 빛)(종료)", 0, 375+15*vEhc.getV(0,0), 10*6, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         ##### Build Graph
         
         # 기본 공격
         BasicAttack = core.OptionalElement(SwordOfSoullight.is_active, SoullightSlash, SoulAssult)
         BasicAttackWrapper = core.DamageSkill('기본 공격',0,0,0).wrap(core.DamageSkillWrapper)
         BasicAttackWrapper.onAfter(BasicAttack)
+
+        FinalAttack.onAfter(core.OptionalElement(LightOfCourage.is_active, LightOfCourageAttack)) # 용기의 빛과 파이널 어택 발동시키는 스킬 목록이 같다고 가정함
         
         SoullightSlash.onAfter(FinalAttack)
         SoulAssult.onAfter(FinalAttack)
@@ -128,7 +135,10 @@ class JobGenerator(ck.JobGenerator):
         ShiningCross.onAfter(ShiningCrossInstall)
         ShiningCross.onAfter(FinalAttack)
         ShiningCrossInstall.onTick(SoulAttack.controller(5000,"set_enabled_and_time_left"))
-        
+
+        # 라이트 오브 커리지
+        LightOfCourage.onAfter(LightOfCourageSummon)
+        LightOfCourage.onAfter(LightOfCourageFinal.controller(25000))
 
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 2, 2)
@@ -139,7 +149,7 @@ class JobGenerator(ck.JobGenerator):
         return(BasicAttackWrapper, 
                 [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
                     GuardOfLight, LoyalGuardBuff, SoulAttack, Booster, Invigorate, SacredCube, cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level),
-                    DeadlyChargeBuff, QueenOfTomorrow, AuraWeaponBuff, AuraWeapon, RoIias, SwordOfSoullight,
+                    DeadlyChargeBuff, QueenOfTomorrow, AuraWeaponBuff, AuraWeapon, RoIias, SwordOfSoullight, LightOfCourage, LightOfCourageSummon, LightOfCourageFinal,
                     globalSkill.soul_contract()] +\
                 [CygnusPalanks, LoyalGuard_5, ShiningCross, DeadlyCharge, ClauSolis, MirrorBreak, MirrorSpider] +\
                 [ShiningCrossInstall, ClauSolisSummon] +\

--- a/dpmModule/jobs/nightwalker.py
+++ b/dpmModule/jobs/nightwalker.py
@@ -45,18 +45,7 @@ class ShadowBatStackWrapper(core.StackSkillWrapper):
         self.batQueue = batQueue
         super(ShadowBatStackWrapper, self).spend_time(time)
 
-class ShadowBatWrapper(core.DamageSkillWrapper):
-    def __init__(self, skill, stackSkill):
-        self.stackSkill = stackSkill
-        super(ShadowBatWrapper, self).__init__(skill)
 
-    def _use(self, skill_modifier):
-        if self.stackSkill.judge(0, -1):
-            raise ValueError("Not enough stack. Consider using OptionalElement.")
-        self.stackSkill.vary(-1)
-        return super(ShadowBatWrapper, self)._use(skill_modifier)
-
-#TODO : 5차 신스킬 적용
 class JobGenerator(ck.JobGenerator):
     def __init__(self):
         super(JobGenerator, self).__init__()
@@ -122,7 +111,7 @@ class JobGenerator(ck.JobGenerator):
         SpiritThrowing = core.BuffSkill("스피릿 스로잉", 0, 180000, rem  = True).wrap(core.BuffSkillWrapper) # 펫버프
 
         ShadowBatStack = ShadowBatStackWrapper(core.BuffSkill("쉐도우 배트(스택)", 0, 0, cooltime=-1))
-        ShadowBat = ShadowBatWrapper(core.DamageSkill("쉐도우 배트", 0, 150 + 120 + 150 + 200 + 4*passive_level, 1).setV(vEhc, 1, 2, True), ShadowBatStack)
+        ShadowBat = core.DamageSkill("쉐도우 배트", 0, 150 + 120 + 150 + 200 + 4*passive_level, 1).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         #점샷기준(400ms)
         QuintupleThrow = core.DamageSkill("퀸터플 스로우", (400 * JUMPRATE + 630 * (1-JUMPRATE)), 340+self.combat, 4, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, pdamage_indep = (JUMPRATE*15))).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
@@ -158,9 +147,27 @@ class JobGenerator(ck.JobGenerator):
 
         ShadowBite = core.DamageSkill("쉐도우 바이트", 630, 600+24*vEhc.getV(2,2), 14, red = True, cooltime = 20000).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         ShadowBiteBuff = core.BuffSkill("쉐도우 바이트(버프)", 0, (15+vEhc.getV(2,2)//10)*1000, pdamage_indep = (8+vEhc.getV(2,2)//4), cooltime = -1).isV(vEhc,2,2).wrap(core.BuffSkillWrapper)
+
+        RapidThrowInit = core.DamageSkill("래피드 스로우(개시)", 120, 0, 0, cooltime=90000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+
+        # 22회 반복
+        RapidThrow = core.DamageSkill("래피드 스로우", 180, 475+19*vEhc.getV(0,0), 3, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        RapidThrow_Sv = core.DamageSkill("래피드 스로우(서번트)", 0, (475+19*vEhc.getV(0,0))*0.7, 3, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        RapidThrow_I50 = core.DamageSkill("래피드 스로우(일루젼 50%)", 0, (475+19*vEhc.getV(0,0))*0.5, 3, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        RapidThrow_I30 = core.DamageSkill("래피드 스로우(일루젼 30%)", 0, (475+19*vEhc.getV(0,0))*0.3, 3, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        RapidThrow_V = core.DamageSkill("래피드 스로우(5차)", 0, (475+19*vEhc.getV(0,0)) * 0.01 * (25+vEhc.getV(0,0)), 3, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+
+        RapidThrowFinal = core.DamageSkill("래피드 스로우(막타)", 480, 850+34*vEhc.getV(0,0), 13, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        RapidThrowFinal_Sv = core.DamageSkill("래피드 스로우(막타)(서번트)", 0, (850+34*vEhc.getV(0,0))*0.7, 13, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        RapidThrowFinal_I50 = core.DamageSkill("래피드 스로우(막타)(일루젼 50%)", 0, (850+34*vEhc.getV(0,0))*0.5, 13, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        RapidThrowFinal_I30 = core.DamageSkill("래피드 스로우(막타)(일루젼 30%)", 0, (850+34*vEhc.getV(0,0))*0.3, 13, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        RapidThrowFinal_V = core.DamageSkill("래피드 스로우(막타)(5차)", 0, (850+34*vEhc.getV(0,0)) * 0.01 * (25+vEhc.getV(0,0)), 13, cooltime=-1, modifier = core.CharacterModifier(pdamage_indep = 15)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         ######   Skill Wrapper   ######
 
         ElementalDarkness.onAfter(ElementalDarknessDOT)
+        ShadowBat.onAfter(ShadowBatStack.stackController(-1))
+        AddBat = ShadowBatStack.add_throw()
+        UseBat = core.RepeatElement(core.OptionalElement(partial(ShadowBatStack.judge, 1, 1), ShadowBat, name = "배트 사출가능 여부"), 5)
 
         ShadowSpearTick = core.OptionalElement(ShadowSpear.is_active, ShadowSpearSmall, name = "스피어ON")
         ShadowSpear.onAfter(ShadowSpearLarge)
@@ -173,20 +180,38 @@ class JobGenerator(ck.JobGenerator):
                             [QuintupleThrow_V, QuintupleThrowFinal_V]]:
             
             start.onAfter(end)
-            start.onAfter(ShadowBatStack.add_throw())
-            end.onAfter(ShadowBatStack.add_throw())
+            start.onAfter(AddBat)
+            end.onAfter(AddBat)
         
         for sk in [QuintupleThrowFinal, QuintupleThrow_Sv, QuintupleThrowFinal_Sv,
                     QuintupleThrow_I50, QuintupleThrowFinal_I50, QuintupleThrow_I30, QuintupleThrowFinal_I30,
-                    QuintupleThrow_V, QuintupleThrowFinal_V, ShadowBite, DominionAttack]:
+                    QuintupleThrow_V, QuintupleThrowFinal_V, RapidThrow, RapidThrow_Sv, RapidThrow_I50, RapidThrow_I30, RapidThrow_V,
+                    RapidThrowFinal, RapidThrowFinal_Sv, RapidThrowFinal_I50, RapidThrowFinal_I30, RapidThrowFinal_V, ShadowBite, DominionAttack]:
             
             sk.onAfter(ShadowSpearTick)
         
-        QuintupleThrow.onAfter(core.RepeatElement(core.OptionalElement(partial(ShadowBatStack.judge, 1, 1), ShadowBat, name = "배트 사출가능 여부"), 5))
+        QuintupleThrow.onAfter(UseBat)
         QuintupleThrow_I50_Use = core.OptionalElement(ShadowElusion.is_active, QuintupleThrow_I50, name = "일루전 여부")
         QuintupleThrow_I30_Use = core.OptionalElement(ShadowElusion.is_active, QuintupleThrow_I30, name = "일루전 여부")
         QuintupleThrow_V_Use = core.OptionalElement(ShadowServentExtend.is_active, QuintupleThrow_V, name = "익스텐드 여부")
         QuintupleThrow.onAfters([QuintupleThrow_Sv, QuintupleThrow_I50_Use, QuintupleThrow_I30_Use, QuintupleThrow_V_Use])
+
+        # 래피드 스로우
+        for sk in [RapidThrow, RapidThrow_Sv, RapidThrow_I50, RapidThrow_I30, RapidThrow_V,
+                    RapidThrowFinal, RapidThrowFinal_Sv, RapidThrowFinal_I50, RapidThrowFinal_I30, RapidThrowFinal_V]:
+            sk.onAfter(AddBat)
+        RapidThrow.onAfter(RapidThrow_Sv)
+        RapidThrow.onAfter(core.OptionalElement(ShadowElusion.is_active, RapidThrow_I50, name = "일루전 여부"))
+        RapidThrow.onAfter(core.OptionalElement(ShadowElusion.is_active, RapidThrow_I30, name = "일루전 여부"))
+        RapidThrow.onAfter(core.OptionalElement(ShadowServentExtend.is_active, RapidThrow_V, name = "익스텐드 여부"))
+        RapidThrow.onAfter(UseBat)
+        RapidThrowFinal.onAfter(RapidThrowFinal_Sv)
+        RapidThrowFinal.onAfter(core.OptionalElement(ShadowElusion.is_active, RapidThrowFinal_I50, name = "일루전 여부"))
+        RapidThrowFinal.onAfter(core.OptionalElement(ShadowElusion.is_active, RapidThrowFinal_I30, name = "일루전 여부"))
+        RapidThrowFinal.onAfter(core.OptionalElement(ShadowServentExtend.is_active, RapidThrowFinal_V, name = "익스텐드 여부"))
+        RapidThrowFinal.onAfter(UseBat)
+        RapidThrowInit.onAfter(core.RepeatElement(RapidThrow, 22))
+        RapidThrowInit.onAfter(RapidThrowFinal)
 
         #도미니언
         Dominion.onAfter(DominionAttack)
@@ -199,7 +224,7 @@ class JobGenerator(ck.JobGenerator):
                     ShadowElusion, ReadyToDie, Dominion, cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level),
                     GloryOfGuardians, ShadowSpear, ShadowServentExtend, ShadowBite, ShadowBiteBuff,
                     globalSkill.soul_contract()] +\
-                [CygnusPalanks, MirrorBreak, MirrorSpider] +\
+                [RapidThrowInit, CygnusPalanks, MirrorBreak, MirrorSpider] +\
                 [ElementalDarknessDOT, ShadowSpearLarge] +\
                 [] +\
                 [QuintupleThrow])

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -75,6 +75,10 @@ class JobGenerator(ck.JobGenerator):
         Sanctuary = core.DamageSkill("생츄어리", 750, 580, 8+2, cooltime = 14 * 0.7 * 1000, red = True, modifier = core.CharacterModifier(boss_pdamage = 30)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
 
         Blast = core.DamageSkill("블래스트", 630, 291, 9+2+1, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
+
+        MightyMjollnirInit = core.DamageSkill("마이티 묠니르(시전)", 630, 0, 0, cooltime=15000).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        MightyMjollnir = core.DamageSkill("마이티 묠니르", 0, 225+9*vEhc.getV(0,0), 6, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        MightyMjollnirWave = core.DamageSkill("마이티 묠니르(충격파)", 0, 250+10*vEhc.getV(0,0), 9, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         #Summon Skills
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
@@ -103,10 +107,13 @@ class JobGenerator(ck.JobGenerator):
                             core.RepeatElement(GrandCrossSmallTick, 15)])
 
         BlessedHammerActive.onAfter(BlessedHammer.controller(30 * 1000))
+
+        MightyMjollnirInit.onAfter(core.RepeatElement(MightyMjollnir, 4))
+        MightyMjollnir.onAfter(MightyMjollnirWave)
         
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 2, 2)
-        for sk in [Blast, Sanctuary, GrandCrossSmallTick, GrandCrossLargeTick]:
+        for sk in [Blast, Sanctuary, GrandCrossSmallTick, GrandCrossLargeTick, MightyMjollnirInit]:
             auraweapon_builder.add_aura_weapon(sk)
         AuraWeaponBuff, AuraWeapon = auraweapon_builder.get_buff()
                         
@@ -114,6 +121,6 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level, combat_level = 2), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
                     Threat, ElementalForce, EpicAdventure, HolyUnity, AuraWeaponBuff, AuraWeapon,
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
-                [LighteningCharge, LighteningChargeDOT, DivineCharge, Sanctuary, GrandCross, MirrorBreak, MirrorSpider] +\
+                [LighteningCharge, LighteningChargeDOT, DivineCharge, Sanctuary, GrandCross, MightyMjollnirInit, MirrorBreak, MirrorSpider] +\
                 [BlessedHammer, BlessedHammerActive] +\
                 [Blast])

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -13,7 +13,7 @@ from math import ceil
 class CardinalStateWrapper(core.BuffSkillWrapper):
     def __init__(self, ancient_force_skills):
         '''
-        DISCHARGE / BLAST / TRANSITION
+        DISCHARGE / BLAST / TRANSITION / NONE
         '''
         skill = core.BuffSkill("카디널 차지", 0, 99999999)
         super(CardinalStateWrapper, self).__init__(skill)
@@ -27,11 +27,11 @@ class CardinalStateWrapper(core.BuffSkillWrapper):
         return False
 
     def _change_state(self, state):
-        assert(state in ["DISCHARGE", "BLAST", "TRANSITION"])
-        if self.state != state:
-            self.state = state
+        assert(state in ["DISCHARGE", "BLAST", "TRANSITION", "NONE"])
+        if self.state != state and state != "NONE" and self.state != "NONE":
             for skill in self.ancient_force_skills:
                 skill.reduce_cooltime(1000)
+        self.state = state
         return self._result_object_cache
         
     def change_state(self, state):
@@ -299,6 +299,11 @@ class JobGenerator(ck.JobGenerator):
         
         ComboAssultHolder.onAfter(ComboAssultOptional)
         AncientAstraHolder.onAfter(AncientAstraOptional)
+
+        ComboAssultHolder.onAfter(CardinalState.change_state("NONE"))
+        AncientAstraHolder.onAfter(CardinalState.change_state("NONE"))
+        ObsidionBarrierBlast.onAfter(CardinalState.change_state("NONE"))
+        RelicUnboundDischarge.onAfter(CardinalState.change_state("NONE"))
         
         # 커스 트랜지션
         ComboAssultDischarge.onAfter(CurseTransition)

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -208,8 +208,8 @@ class JobGenerator(ck.JobGenerator):
 
         ObsidionBarrierBlast = core.SummonSkill("옵시디언 배리어", 60, 510, 400+12*vEhc.getV(4,4), 4, (10+vEhc.getV(4,4)//5)*1000, cooltime = 200*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
 
-        RelicUnboundDischarge = core.SummonSkill("렐릭 언바운드(디스차지)", 600, 360, 500+20*vEhc.getV(0,0), 3, 22000, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
-        # RelicUnboundBlast = core.SummonSkill("렐릭 언바운드(블래스트)", 600, 2000, 625+25*vEhc.getV(0,0), 8*4, 2000*4-1, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        RelicUnboundDischarge = core.SummonSkill("렐릭 언바운드(디스차지)", 600, 360, 500+20*vEhc.getV(0,0), 3, 22000, cooltime=120*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        # RelicUnboundBlast = core.SummonSkill("렐릭 언바운드(블래스트)", 600, 2000, 625+25*vEhc.getV(0,0), 8*4, 2000*4-1, cooltime=120*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         ######   Skill Wrapper   ######
 
         #이볼브 연계 설정

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -109,6 +109,7 @@ class JobGenerator(ck.JobGenerator):
         에인션트 아스트라 사용하지 않음
         콤보 어썰트는 커스 트랜지션의 지속시간이 2초 이하 남았을때 사용
         블래 210ms 디차 270ms (http://m.inven.co.kr/board/maple/2304/17507)
+        렐릭 언바운드 디스차지로 사용
         
         하이퍼
         
@@ -206,6 +207,9 @@ class JobGenerator(ck.JobGenerator):
         RavenTempest = core.SummonSkill("레이븐 템페스트", 540, 250, 400+20*vEhc.getV(0,0), 5, 25*1000, cooltime = 120*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
 
         ObsidionBarrierBlast = core.SummonSkill("옵시디언 배리어", 60, 510, 400+12*vEhc.getV(4,4), 4, (10+vEhc.getV(4,4)//5)*1000, cooltime = 200*1000, red=True, modifier = ANCIENT_ARCHERY).isV(vEhc,4,4).wrap(core.SummonSkillWrapper)
+
+        RelicUnboundDischarge = core.SummonSkill("렐릭 언바운드(디스차지)", 600, 360, 500+20*vEhc.getV(0,0), 3, 22000, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        # RelicUnboundBlast = core.SummonSkill("렐릭 언바운드(블래스트)", 600, 2000, 625+25*vEhc.getV(0,0), 8*4, 2000*4-1, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         ######   Skill Wrapper   ######
 
         #이볼브 연계 설정
@@ -267,6 +271,9 @@ class JobGenerator(ck.JobGenerator):
         UltimateBlast.onConstraint(core.ConstraintElement('200 이상', RelicCharge, partial(RelicCharge.judge, 200, 1)))
         UltimateBlast.onAfter(RelicCharge.stackController(-1000))
         UltimateBlast.add_runtime_modifier(RelicCharge, lambda charge: core.CharacterModifier(pdamage_indep = (charge.stack // 250) * 25))
+
+        RelicUnboundDischarge.onConstraint(core.ConstraintElement('350 이상', RelicCharge, partial(RelicCharge.judge, 350, 1)))
+        RelicUnboundDischarge.onAfter(RelicCharge.stackController(-350))
         
         #카디널 차지 연결
         CardinalBlast.onAfter(core.OptionalElement(partial(CardinalState.is_state, "DISCHARGE"), AdditionalDischarge))
@@ -313,7 +320,7 @@ class JobGenerator(ck.JobGenerator):
                     RelicEvolution, EpicAdventure,
                     AncientGuidance, AdditionalTransition,globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), CriticalReinforce,
                     globalSkill.soul_contract()] +\
-                [AncientAstraHolder, TripleImpact, EdgeOfResonance, 
+                [RelicUnboundDischarge, AncientAstraHolder, TripleImpact, EdgeOfResonance,
                         ComboAssultHolder, UltimateBlast, SplitMistel, CardinalTransition] +\
                 [Evolve, Raven, GuidedArrow, RavenTempest, ObsidionBarrierBlast, MirrorBreak, MirrorSpider] +\
                 [] +\

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -4,7 +4,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from ..execution.rules import ConcurrentRunRule, ConditionRule, DisableRule, RuleSet
+from ..execution.rules import ConditionRule, DisableRule, RuleSet
 from . import globalSkill
 from .jobbranch import bowmen
 from math import ceil
@@ -139,7 +139,7 @@ class JobGenerator(ck.JobGenerator):
         
         # Damage skills
         # 카디널 포스
-        CardinalDischarge = core.DamageSkill("카디널 디스차지", 270, (4 + 1)*2, 300+5*passive_level, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        CardinalDischarge = core.DamageSkill("카디널 디스차지", 210, (4 + 1)*2, 300+5*passive_level, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         AdditionalDischarge = core.DamageSkill("에디셔널 디스차지", 0, 100 + 50 + passive_level, 3*3*(0.4+0.1)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         AdditionalDischargeEvolution = core.DamageSkill("에디셔널 디스차지(렐릭 에볼루션)", 0, 100 + 50 + passive_level, 3*(0.4+0.1)).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
 
@@ -156,7 +156,8 @@ class JobGenerator(ck.JobGenerator):
         SplitMistelBonus = core.DamageSkill("스플릿 미스텔(보너스)", 0, 100+200+4*passive_level, 4 * 2,
                     modifier = ANCIENT_ARCHERY).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
 
-        TripleImpact = core.DamageSkill("트리플 임팩트", 420, 400 + 200+5*passive_level, 5*3, cooltime = 10*1000, red=True,
+        TripleImpactJump = core.DamageSkill("트리플 임팩트(점프)", 420, 0, 0, cooltime=-1).wrap(core.DamageSkillWrapper)
+        TripleImpact = core.DamageSkill("트리플 임팩트", 0, 400 + 200+5*passive_level, 5*3, cooltime = 10*1000, red=True,
                     modifier = ANCIENT_ARCHERY).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
                 
         # 5스택 가정, 다른 스킬 사용 중에 시전가능
@@ -227,7 +228,8 @@ class JobGenerator(ck.JobGenerator):
         ComboAssultDischarge.onAfter(ComboAssultDischargeArrow)
         ComboAssultTransition.onAfter(ComboAssultTransitionArrow)
 
-        TripleImpact.onAfter(TripleImpact.controller(-540, "reduce_cooltime", "쿨타임 지연 540ms"))
+        TripleImpact.onBefore(TripleImpactJump)
+        TripleImpact.onConstraint(core.ConstraintElement("레조넌스 동기화", EdgeOfResonance, EdgeOfResonance.is_usable))
         
         AncientAstraDischarge.onAfter(AncientAstraDischargeArrow)
         

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -84,7 +84,7 @@ class JobGenerator(ck.JobGenerator):
         MileAiguilles = core.DamageSkill("얼티밋 드라이브", 150, 125 + self.combat, 3, modifier = core.CharacterModifier(pdamage = 20, armor_ignore = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
 
         CarteNoir = core.DamageSkill("느와르 카르트", 0, 270, min(chtr.get_modifier().crit/100 + 0.1, 1)).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
-        CarteNoir_ = core.DamageSkill("느와르 카르트(저지먼트)", 0, 270, 10).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
+        Judgement = core.DamageSkill("느와르 카르트(저지먼트)", 0, 270, 10).setV(vEhc, 1, 2, True).wrap(core.DamageSkillWrapper)
         
         PrieredAria = core.BuffSkill("프레이 오브 아리아", 0, (240+7*self.combat)*1000, pdamage = 30+self.combat, armor_ignore = 30+self.combat).wrap(core.BuffSkillWrapper)
 
@@ -110,15 +110,17 @@ class JobGenerator(ck.JobGenerator):
         
         MarkOfPhantom = core.DamageSkill("마크 오브 팬텀", 690, 600+24*vEhc.getV(2,2), 3 * 7, cooltime = 30000, red=True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         MarkOfPhantomEnd = core.DamageSkill("마크 오브 팬텀(최종)", 0, 1200+48*vEhc.getV(2,2), 12).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+
+        LiftBreak = core.DamageSkill("리프트 브레이크", 990, 400+16*vEhc.getV(0,0), 7*7, cooltime=30000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         #### 그래프 빌드
         
+        FinalCut.onAfter(CarteNoir)
         FinalCut.onAfter(FinalCutBuff.controller(1))
         
         CardStack = core.StackSkillWrapper(core.BuffSkill("카드 스택", 0, 99999999), 40, name = "느와르 카르트 스택")
         
         AddCard = CardStack.stackController(1, name = "스택 1 증가")
-        Judgement = CarteNoir_
         Judgement.onAfter(CardStack.stackController(-9999, name = "스택 초기화"))
         
         FullStack = core.OptionalElement(partial(CardStack.judge,40, 1), Judgement, name = "풀스택시")
@@ -142,8 +144,13 @@ class JobGenerator(ck.JobGenerator):
         
         BlackJack.onTick(CarteNoir)
         BlackJack.onAfter(BlackJackFinal.controller(5000))
+        BlackJackFinal.onAfter(CarteNoir)
         
+        MarkOfPhantom.onAfter(core.RepeatElement(CarteNoir, 7))
         MarkOfPhantom.onAfter(MarkOfPhantomEnd)
+        MarkOfPhantomEnd.onAfter(CarteNoir)
+
+        LiftBreak.onAfter(core.RepeatElement(CarteNoir, 7))
 
         MileAiguillesInit.protect_from_running()
         
@@ -154,7 +161,7 @@ class JobGenerator(ck.JobGenerator):
                     TalentOfPhantomII, TalentOfPhantomIII, FinalCutBuff, globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), BoolsEye,
                     JudgementBuff, Booster, PrieredAria, HerosOath, ReadyToDie, JokerBuff,
                     globalSkill.soul_contract()] +\
-                [FinalCut, JokerInit, MarkOfPhantom, BlackJackFinal] +\
+                [FinalCut, JokerInit, MarkOfPhantom, LiftBreak, BlackJackFinal] +\
                 [BlackJack, MirrorBreak, MirrorSpider] +\
                 [MileAiguillesInit] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -124,7 +124,7 @@ class JobGenerator(ck.JobGenerator):
         SonicBlow = core.DamageSkill("소닉 블로우", 900, 0, 0, cooltime = 80 * 1000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         SonicBlowTick = core.DamageSkill("소닉 블로우(틱)", 107, 500+20*vEhc.getV(1,1), 7, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper, name = "소닉 블로우(사용)") # 7 * 15
 
-        ShadowFormation = core.SummonSkill("멸귀참영진", 0, 8000/12, 425+17*vEhc.getV(0,0), 12, 8000-1, cooltime=90000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        ShadowFormation = core.SummonSkill("멸귀참영진", 0, 8000/12, 425+17*vEhc.getV(0,0), 8, 8000-1, cooltime=90000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         ShadowFormationFinal = core.DamageSkill("멸귀참영진(우두머리)", 0, 625+25*vEhc.getV(0,0), 15*4, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         ### build graph relationships

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -123,6 +123,9 @@ class JobGenerator(ck.JobGenerator):
 		# 1.2.324 패치 적용
         SonicBlow = core.DamageSkill("소닉 블로우", 900, 0, 0, cooltime = 80 * 1000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         SonicBlowTick = core.DamageSkill("소닉 블로우(틱)", 107, 500+20*vEhc.getV(1,1), 7, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper, name = "소닉 블로우(사용)") # 7 * 15
+
+        ShadowFormation = core.SummonSkill("멸귀참영진", 0, 8000/12, 425+17*vEhc.getV(0,0), 12, 8000-1, cooltime=90000, red=True).wrap(core.SummonSkillWrapper)
+        ShadowFormationFinal = core.DamageSkill("멸귀참영진(우두머리)", 0, 625+25*vEhc.getV(0,0), 15*4, cooltime=-1).wrap(core.DamageSkillWrapper)
         
         ### build graph relationships
         def isNotDarkSight():
@@ -161,6 +164,8 @@ class JobGenerator(ck.JobGenerator):
         Assasinate2_D.onAfter(UseEviscerate)
         Eviscerate.onAfter(MesoStack.stackController(7*2*0.4, name = "메소 생성"))
         Eviscerate.protect_from_running()
+
+        ShadowFormation.onAfter(ShadowFormationFinal.controller(8000))
         
         Assasinate = core.OptionalElement(AdvancedDarkSight.is_active, Assasinate1_D, Assasinate1, name = "닼사 여부")
         BasicAttackWrapper = core.DamageSkill('기본 공격',0,0,0).wrap(core.DamageSkillWrapper)
@@ -173,7 +178,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
                     Booster, FlipTheCoin, ShadowerInstinct, ShadowPartner, Smoke, AdvancedDarkSight, EpicAdventure, UltimateDarksight, MesoStack,
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), ReadyToDie, globalSkill.soul_contract()] +\
-                [Eviscerate, SonicBlow, BailOfShadow, DarkFlare, MirrorBreak, MirrorSpider]+\
+                [ShadowFormation, ShadowFormationFinal, Eviscerate, SonicBlow, BailOfShadow, DarkFlare, MirrorBreak, MirrorSpider]+\
                 [Venom]+\
                 []+\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -124,8 +124,8 @@ class JobGenerator(ck.JobGenerator):
         SonicBlow = core.DamageSkill("소닉 블로우", 900, 0, 0, cooltime = 80 * 1000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         SonicBlowTick = core.DamageSkill("소닉 블로우(틱)", 107, 500+20*vEhc.getV(1,1), 7, modifier = core.CharacterModifier(armor_ignore = 100)).isV(vEhc,1,1).wrap(core.DamageSkillWrapper, name = "소닉 블로우(사용)") # 7 * 15
 
-        ShadowFormation = core.SummonSkill("멸귀참영진", 0, 8000/12, 425+17*vEhc.getV(0,0), 12, 8000-1, cooltime=90000, red=True).wrap(core.SummonSkillWrapper)
-        ShadowFormationFinal = core.DamageSkill("멸귀참영진(우두머리)", 0, 625+25*vEhc.getV(0,0), 15*4, cooltime=-1).wrap(core.DamageSkillWrapper)
+        ShadowFormation = core.SummonSkill("멸귀참영진", 0, 8000/12, 425+17*vEhc.getV(0,0), 12, 8000-1, cooltime=90000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        ShadowFormationFinal = core.DamageSkill("멸귀참영진(우두머리)", 0, 625+25*vEhc.getV(0,0), 15*4, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         ### build graph relationships
         def isNotDarkSight():

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -101,9 +101,9 @@ class JobGenerator(ck.JobGenerator):
         SplitArrowBuff = core.BuffSkill("스플릿 애로우", 810, 60 * 1000, 120 * 1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         #TODO : 스플릿애로우 계산
 
-        RepeatingCartrige = core.BuffSkill("리피팅 크로스보우 카트리지", 510, 60000, cooltime=120*1000, red=True).wrap(core.BuffSkillWrapper)
+        RepeatingCartrige = core.BuffSkill("리피팅 크로스보우 카트리지", 510, 60000, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         CartrigeStack = core.StackSkillWrapper(core.BuffSkill("카트리지", 0, 99999999), 7)
-        FullBurstShot = core.DamageSkill("풀버스트 샷", 810, 300+12*vEhc.getV(0,0), (9+1)*4, cooltime=-1, modifier=PASSIVE_MODIFIER).wrap(core.DamageSkillWrapper)
+        FullBurstShot = core.DamageSkill("풀버스트 샷", 810, 300+12*vEhc.getV(0,0), (9+1)*4, cooltime=-1, modifier=PASSIVE_MODIFIER).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         FinalAttack = core.DamageSkill("파이널 어택", 0, 150, 0.4, modifier = PASSIVE_MODIFIER).setV(vEhc, 4, 2, True).wrap(core.DamageSkillWrapper)
         

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -31,6 +31,7 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(ConcurrentRunRule('소울 컨트랙트', '크리티컬 리인포스'), RuleSet.BASE)
         ruleset.add_rule(ReservationRule('크리티컬 리인포스', '스플릿 애로우'), RuleSet.BASE)
         ruleset.add_rule(ConcurrentRunRule('스플릿 애로우', '소울 컨트랙트'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('리피팅 크로스보우 카트리지', '소울 컨트랙트'), RuleSet.BASE)
 
         return ruleset
 
@@ -99,6 +100,10 @@ class JobGenerator(ck.JobGenerator):
         SplitArrow = core.DamageSkill("스플릿 애로우(공격)", 0, 600 + vEhc.getV(0,0) * 24, 5+1, modifier = PASSIVE_MODIFIER).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         SplitArrowBuff = core.BuffSkill("스플릿 애로우", 810, 60 * 1000, 120 * 1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         #TODO : 스플릿애로우 계산
+
+        RepeatingCartrige = core.BuffSkill("리피팅 크로스보우 카트리지", 510, 60000, cooltime=120*1000, red=True).wrap(core.BuffSkillWrapper)
+        CartrigeStack = core.StackSkillWrapper(core.BuffSkill("카트리지", 0, 99999999), 7)
+        FullBurstShot = core.DamageSkill("풀버스트 샷", 810, 300+12*vEhc.getV(0,0), (9+1)*4, cooltime=-1, modifier=PASSIVE_MODIFIER).wrap(core.DamageSkillWrapper)
         
         FinalAttack = core.DamageSkill("파이널 어택", 0, 150, 0.4, modifier = PASSIVE_MODIFIER).setV(vEhc, 4, 2, True).wrap(core.DamageSkillWrapper)
         
@@ -112,24 +117,32 @@ class JobGenerator(ck.JobGenerator):
     
         SplitArrowOption = core.OptionalElement(SplitArrowBuff.is_active, SplitArrow, name = "스플릿 애로우 여부 확인")
         Snipping.onAfter(SplitArrowOption)
+        FullBurstShot.onAfter(core.RepeatElement(SplitArrowOption, 4))
     
         TrueSnippingDeal = core.RepeatElement(TrueSnippingTick, 7)
         TrueSnipping.onBefore(ChargedArrowHold.controller(10000, name = "차징 유예"))
         TrueSnipping.onAfter(TrueSnippingDeal)
         
-        ChargedArrowHold.onTick(Snipping) # 완충시 스나이핑 즉시 발사됨
-        ChargedArrowHold.onTick(ChargedArrow)
+        # TODO: 차지드 캔슬 구현할것 / 딜레이 중간에 끊는게 구현되기 전까지 어려움
+        ChargedArrowHold.onTick(core.OptionalElement(partial(CartrigeStack.judge, 0, -1), ChargedArrow)) # 풀버스트샷 도중에는 차지드 동시발사가 안됨
 
         for sk in [Snipping, TrueSnippingTick, ChargedArrow]:
             sk.onAfter(FinalAttack)
+        FullBurstShot.onAfter(core.RepeatElement(FinalAttack, 4))
         
         ChargedArrowHold.set_disabled_and_time_left(5000) # 최초 차징 시간
+
+        RepeatingCartrige.onAfter(CartrigeStack.stackController(7))
+        FullBurstShot.onAfter(CartrigeStack.stackController(-1))
+
+        BasicAttack = core.DamageSkill("기본 공격", 0, 0, 0).wrap(core.DamageSkillWrapper)
+        BasicAttack.onAfter(core.OptionalElement(partial(CartrigeStack.judge, 1, 1), FullBurstShot, Snipping))
         
-        return(Snipping,
+        return(BasicAttack,
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_wind_booster(), globalSkill.useful_combat_orders(),
                     SoulArrow, ElusionStep, SharpEyes, BoolsEye, EpicAdventure, globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat),
-                    CriticalReinforce, SplitArrowBuff, globalSkill.soul_contract()] +\
+                    CriticalReinforce, RepeatingCartrige, SplitArrowBuff, globalSkill.soul_contract()] +\
                 [TrueSnipping, ChargedArrowHold, ChargedArrow] +\
                 [Evolve,Freezer, GuidedArrow, MirrorBreak, MirrorSpider] +\
                 [] +\
-                [Snipping])
+                [BasicAttack])

--- a/dpmModule/jobs/soulmaster.py
+++ b/dpmModule/jobs/soulmaster.py
@@ -89,6 +89,8 @@ class JobGenerator(ck.JobGenerator):
         #소울 이클립스
         SoulEclipse = core.SummonSkill("소울 이클립스", 810, 1000, 450 + 18 * vEhc.getV(3,3), 7, 30 * 1000, cooltime = 180 * 1000, red=True).isV(vEhc,3,3).wrap(core.SummonSkillWrapper)
         SolunaDivide = core.DamageSkill("솔루나 디바이드", 990, 1250 + 50 * vEhc.getV(3,3), 15 * 5, cooltime = -1).isV(vEhc,3,3).wrap(core.DamageSkillWrapper)
+
+        FlareSlash = core.DamageSkill("플레어 슬래시", 0, 550+22*vEhc.getV(0,0), 7*2, cooltime=12000, modifier=FallingMoon).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         
         ######   Skill Wrapper   ######
         
@@ -108,6 +110,16 @@ class JobGenerator(ck.JobGenerator):
         BasicAttackWrapper = core.DamageSkill('기본 공격', 0,0,0).wrap(core.DamageSkillWrapper)
         BasicAttackWrapper.onAfter(BasicAttack)
 
+        # 플레어 슬래시
+        SpeedingDance.onAfter(FlareSlash.controller(300, "reduce_cooltime"))
+        SelestialDanceAttack.onAfter(FlareSlash.controller(900, "reduce_cooltime"))
+        ElisionStyx.onAfter(FlareSlash.controller(1200, "reduce_cooltime"))
+
+        UseFlareSlash = core.OptionalElement(FlareSlash.is_available, FlareSlash, name="플레어 슬래시 쿨타임 체크")
+        SpeedingDance.onAfter(UseFlareSlash)
+        ElisionStyx.onAfter(UseFlareSlash)
+        FlareSlash.protect_from_running()
+
         # 오라 웨폰
         auraweapon_builder = warriors.AuraWeaponBuilder(vEhc, 2, 2, modifier=FallingMoon, hit=6*2)
         for sk in [SpeedingDance, ElisionStyx]:
@@ -119,6 +131,6 @@ class JobGenerator(ck.JobGenerator):
                     NimbleFinger, TrueSight, SolunaTime, SoulForge, cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level),
                     GloryOfGuardians, AuraWeaponBuff, AuraWeapon, globalSkill.soul_contract(), Elision, ElisionBreak, SelestialDanceInit, 
                     ] +\
-                [CygnusPalanks, SolunaDivide] +\
+                [FlareSlash, CygnusPalanks, SolunaDivide] +\
                 [SelestialDanceSummon, SoulEclipse, MirrorBreak, MirrorSpider] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -10,7 +10,7 @@ from .jobclass import cygnus
 from . import jobutils
 from math import ceil
 
-#TODO : 해신강링 딜사이클에 추가
+#TODO : 해신강림 딜사이클에 추가
 
 class LightningWrapper(core.StackSkillWrapper):
     def __init__(self, skill):
@@ -145,14 +145,14 @@ class JobGenerator(ck.JobGenerator):
                         SpearLightningAttack, SpearLightningAttack_Lightning, SpearLightningAttack_Final, SpearLightningAttack_Final_Lightning]:
             jobutils.create_auxilary_attack(skill, CHOOKROI, "(축뢰)")
 
-        for skill in [Destroy, Thunder, DestroyConcat, ThunderConcat, NoiShinChanGeuk,
+        for skill in [Thunder, ThunderConcat, NoiShinChanGeuk,
                         SpearLightningAttack, SpearLightningAttack_Lightning, SpearLightningAttack_Final, SpearLightningAttack_Final_Lightning]:
             skill.onAfter(LightningStack.stackController(1))
 
         for skill in [ShinNoiHapLAttack, CygnusPalanks, NoiShinChanGeukAttack]:
             skill.onTick(LightningStack.stackController(1))
 
-        GioaTan.onAfter(LightningStack.stackController(-2))
+        GioaTan.onAfter(core.OptionalElement(SkyOpen.is_not_active, LightningStack.stackController(-2), name="천지개벽 체크"))
         
         ShinNoiHapLAttack.onTick(ShinNoiHapLAttack_ChookRoi)
         NoiShinChanGeukAttack.onTick(NoiShinChanGeukAttack_ChookRoi)

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -3,6 +3,7 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import MutualRule, ReservationRule, RuleSet, ConcurrentRunRule
 from . import globalSkill
 from . import jobutils
 from .jobbranch import pirates
@@ -32,6 +33,13 @@ class JobGenerator(ck.JobGenerator):
 
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(armor_ignore = 40) # 뇌전 스택으로 평균 35~40%의 방무 적용
+
+    def get_ruleset(self):
+        ruleset = RuleSet()
+        ruleset.add_rule(ReservationRule('소울 컨트랙트', '창뇌연격(시전)'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('창뇌연격(시전)', '소울 컨트랙트'), RuleSet.BASE)
+        ruleset.add_rule(MutualRule('천지개벽', '창뇌연격(시전)'), RuleSet.BASE)
+        return ruleset
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self.combat
@@ -79,7 +87,8 @@ class JobGenerator(ck.JobGenerator):
         벽섬 : 1020ms
         태섬 : 900ms
         
-        모든 스킬은 쿨타임마다 사용
+        소울 컨트랙트를 창뇌연격에 맞춰 사용
+        천지개벽과 창뇌연격이 겹쳐지지 않게 사용
         '''
         passive_level = chtr.get_base_modifier().passive_level + self.combat
         CHOOKROI = 0.7 + 0.01*passive_level

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -133,7 +133,7 @@ class JobGenerator(ck.JobGenerator):
         NoiShinChanGeukAttack = core.SummonSkill("뇌신창격(후속타)", 0, 1000, 200 + 8*vEhc.getV(0,0), 7, 3999, cooltime = -1).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)    #4번 발동
         NoiShinChanGeukAttack_ChookRoi = core.DamageSkill("뇌신창격(후속타)(축뢰)", 0, (200 + 8*vEhc.getV(0,0)) * CHOOKROI, 7).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
 
-        SpearLightningAttackInit = core.DamageSkill("창뇌연격(시전)", 360, 0, 0, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 스로우 블래스팅같은 스택 저장형 스킬이지만... 그냥 12회 반복되는 극딜기로 처리
+        SpearLightningAttackInit = core.DamageSkill("창뇌연격(시전)", 0, 0, 0, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 스로우 블래스팅같은 스택 저장형 스킬이지만... 그냥 12회 반복되는 극딜기로 처리
         SpearLightningAttack = core.DamageSkill("창뇌연격", 240, 375+15*vEhc.getV(0,0), 5, cooltime=-1, modifier = LINK_MASTERY).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         SpearLightningAttack_Lightning = core.DamageSkill("창뇌연격(번개)", 0, 500+20*vEhc.getV(0,0), 4, cooltime=-1, modifier = LINK_MASTERY).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         SpearLightningAttack_Final = core.DamageSkill("창뇌연격(막타)", 450, 600+24*vEhc.getV(0,0), 7, cooltime=-1, modifier = LINK_MASTERY).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/viper.py
+++ b/dpmModule/jobs/viper.py
@@ -149,6 +149,10 @@ class JobGenerator(ck.JobGenerator):
     
         FuriousCharge = core.DamageSkill("퓨리어스 차지", 420, 600+vEhc.getV(4,4)*24, 10, cooltime = 10 * 1000, modifier = core.CharacterModifier(boss_pdamage = 30)).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
 
+        HowlingFistInit = core.DamageSkill("하울링 피스트(개시)", 240, 0, 0, cooltime=90000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        HowlingFistCharge = core.DamageSkill("하울링 피스트(충전)", 240, 425+17*vEhc.getV(0,0), 6, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+        HowlingFistFinal = core.DamageSkill("하울링 피스트(막타)", 1950, 525+21*vEhc.getV(0,0), 10*14, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
+
         ######   Skill Wrapper   ######
         # Energy Charge
         EnergyCharge = EnergyChargeWrapper(passive_level)
@@ -160,6 +164,9 @@ class JobGenerator(ck.JobGenerator):
         StimulateSummon.onTick(EnergyCharge.chargeController(800, force=True))
         FistInrage.onAfter(EnergyCharge.chargeController(700))
         Nautilus.onAfter(EnergyCharge.chargeController(700))
+        MirrorBreak.onAfter(EnergyCharge.chargeController(700))
+        HowlingFistCharge.onAfter(EnergyCharge.chargeController(700))
+        HowlingFistFinal.onAfter(EnergyCharge.chargeController(700*14))
         SerpentScrewDummy.onTick(EnergyCharge.chargeController(-85))
         SerpentScrew.onTick(EnergyCharge.chargeController(-85*0.3))
         FistInrage_T.onAfter(EnergyCharge.chargeController(-150))
@@ -197,13 +204,17 @@ class JobGenerator(ck.JobGenerator):
         SerpentScrew.onConstraint(core.ConstraintElement("에너지 100 이상", EnergyCharge, partial(EnergyCharge.judge, 100, 1)))
         SerpentScrew.onAfter(SerpentScrewDummy)
         EnergyCharge.drainCallback = lambda: [SerpentScrew.set_disabled_and_time_left(1), SerpentScrewDummy.set_disabled_and_time_left(-1)]
+
+        # Howling Fist
+        HowlingFistInit.onAfter(core.RepeatElement(HowlingFistCharge, 8))
+        HowlingFistInit.onAfter(HowlingFistFinal)
             
         return (BasicAttackWrapper,
             [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
                 LuckyDice, Viposition, Stimulate, EpicAdventure, PirateFlag, Overdrive, Transform,
                 UnityOfPowerBuff, DragonStrikeBuff, EnergyCharge,
                 globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
-            [UnityOfPower, Nautilus, DragonStrike, FuriousCharge, TransformEnergyOrbDummy, MirrorBreak, MirrorSpider] +\
+            [UnityOfPower, HowlingFistInit, Nautilus, DragonStrike, FuriousCharge, TransformEnergyOrbDummy, MirrorBreak, MirrorSpider] +\
             [SerpentScrew, SerpentScrewDummy, StimulateSummon] +\
             [] +\
             [BasicAttackWrapper])

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -83,7 +83,7 @@ class JobGenerator(ck.JobGenerator):
         #Summon Skills
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 5, 5)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0) # TODO: 윔 발생여부 확인할것
-        HowlingGail = core.SummonSkill("하울링 게일", 630, 150, 250 + 10*vEhc.getV(1, 1), 3, 150*56-1, cooltime = 20 * 1000).isV(vEhc, 1, 1).wrap(core.SummonSkillWrapper) #56타
+        HowlingGail = core.SummonSkill("하울링 게일", 630, 150, 250 + 10*vEhc.getV(1, 1), 3, 150*58-1, cooltime = 20 * 1000).isV(vEhc, 1, 1).wrap(core.SummonSkillWrapper) #58타
         WindWall = core.SummonSkill("윈드 월", 720, 2000, (550 + vEhc.getV(2, 2)*22) / 2, 5 * 3 , 45 * 1000, cooltime = 90 * 1000, red=True).isV(vEhc, 2, 2).wrap(core.SummonSkillWrapper)
         VortexSphere = core.SummonSkill("볼텍스 스피어", 720, 180, 400+16*vEhc.getV(0,0), 6, 180*17-1, cooltime=35000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 17타
         

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -45,6 +45,8 @@ class JobGenerator(ck.JobGenerator):
         '''
         코강 순서:
         천노-윔-브링어
+
+        하울링게일 56회, 볼텍스 스피어 17회 타격
         
         트라이플링 윔 평균치로 계산
         
@@ -81,8 +83,9 @@ class JobGenerator(ck.JobGenerator):
         #Summon Skills
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 5, 5)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0) # TODO: 윔 발생여부 확인할것
-        HowlingGail = core.SummonSkill("하울링 게일", 630, 10 * 1000 / 33, 250 + 10*vEhc.getV(1, 1), 2 * 3, 10000, cooltime = 20 * 1000).isV(vEhc, 1, 1).wrap(core.SummonSkillWrapper) #딜레이 모름, 허수아비/1스택 기준 64타 (총 66타)
+        HowlingGail = core.SummonSkill("하울링 게일", 630, 150, 250 + 10*vEhc.getV(1, 1), 3, 150*56-1, cooltime = 20 * 1000).isV(vEhc, 1, 1).wrap(core.SummonSkillWrapper) #56타
         WindWall = core.SummonSkill("윈드 월", 720, 2000, (550 + vEhc.getV(2, 2)*22) / 2, 5 * 3 , 45 * 1000, cooltime = 90 * 1000, red=True).isV(vEhc, 2, 2).wrap(core.SummonSkillWrapper)
+        VortexSphere = core.SummonSkill("볼텍스 스피어", 720, 180, 400+16*vEhc.getV(0,0), 6, 180*17-1, cooltime=35000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 17타
         
         ######   Skill Wrapper   #####
         
@@ -93,7 +96,8 @@ class JobGenerator(ck.JobGenerator):
         PinPointPierce.onAfters([PinPointPierceDebuff, TriflingWhim, StormBringer])
         #Summon
         CygnusPalanks.onTicks([core.RepeatElement(TriflingWhim, 5), core.RepeatElement(StormBringer, 5)])
-        HowlingGail.onTicks([core.RepeatElement(TriflingWhim, 2), core.RepeatElement(StormBringer, 2)])
+        HowlingGail.onTicks([TriflingWhim, StormBringer])
+        VortexSphere.onTicks([TriflingWhim, StormBringer])
 
         Mercilesswind.onAfter(MercilesswindDOT)
 
@@ -103,6 +107,6 @@ class JobGenerator(ck.JobGenerator):
                     PinPointPierceDebuff,
                     globalSkill.soul_contract()] +\
                 [Mercilesswind]+\
-                [GuidedArrow, HowlingGail, WindWall, MercilesswindDOT, CygnusPalanks, PinPointPierce, MirrorBreak, MirrorSpider]+\
+                [GuidedArrow, HowlingGail, VortexSphere, WindWall, MercilesswindDOT, CygnusPalanks, PinPointPierce, MirrorBreak, MirrorSpider]+\
                 []+\
                 [SongOfHeaven])

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -223,7 +223,7 @@ class JobGenerator(ck.JobGenerator):
         
         #베타
         ShadowFlashBeta = core.DamageSkill("쉐도우 플래시(베타)", 510, 600+24*vEhc.getV(2,2), 5, cooltime = 40*1000, modifier = extra_dmg(8, False), red = True).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
-        ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 660, 750+30*vEhc.getV(2,2), 12 * 2, modifier = extra_dmg(8, False)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
+        ShadowFlashBetaEnd = core.DamageSkill("쉐도우 플래시(베타)(종료)", 660, 750+30*vEhc.getV(2,2), 12 * 2, modifier = extra_dmg(15, False)).isV(vEhc,2,2).wrap(core.DamageSkillWrapper)
         
         #초월자 륀느의 기원
         RhinneBless = core.BuffSkill("초월자 륀느의 기원", 480, (30+vEhc.getV(0,0)//2)*1000, cooltime = 240000, att = 10+3*vEhc.getV(0,0)).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -229,6 +229,10 @@ class JobGenerator(ck.JobGenerator):
         RhinneBless = core.BuffSkill("초월자 륀느의 기원", 480, (30+vEhc.getV(0,0)//2)*1000, cooltime = 240000, att = 10+3*vEhc.getV(0,0)).wrap(core.BuffSkillWrapper)
         RhinneBlessAttack_hit = core.DamageSkill("초월자 륀느의 기원 (타격)", 0, 125+5*vEhc.getV(0, 0), 5, cooltime = -1).wrap(core.DamageSkillWrapper)
         RhinneBlessAttack = core.OptionalElement(RhinneBless.is_active, RhinneBlessAttack_hit)
+
+        #에고 웨폰
+        EgoWeaponAlpha = core.DamageSkill("에고 웨폰(알파)", 0, 175+7*vEhc.getV(0,0), 6*9, cooltime=15000, red=True).wrap(core.DamageSkillWrapper)
+        EgoWeaponBeta = core.DamageSkill("에고 웨폰(베타)", 0, 175+7*vEhc.getV(0,0), 9*2*3, cooltime=15000, red=True, modifier = extra_dmg(4, False)).wrap(core.DamageSkillWrapper)
         
         ######   Skill Wrapper   ######
         ### 스킬 연결 ###
@@ -319,6 +323,19 @@ class JobGenerator(ck.JobGenerator):
 
         RhinneBless.onAfter(TimeDistortion.controller(1.0, 'reduce_cooltime_p'))
         RhinneBless.onAfter(SoulContract.controller(1.0, 'reduce_cooltime_p'))
+
+        # 에고 웨폰
+        UseEgoWeaponAlpha = core.OptionalElement(EgoWeaponAlpha.is_available, EgoWeaponAlpha)
+        EgoWeaponAlpha.protect_from_running()
+        for sk in [MoonStrike, PierceStrike, FlashAssault, AdvancedSpinCutter, AdvancedRollingCurve, AdvancedRollingAssulter,
+            WindCutter, WindStrike, AdvancedStormBreak, ShadowFlashAlpha, ShadowFlashAlphaEnd]:
+            sk.onAfter(UseEgoWeaponAlpha)
+            
+        UseEgoWeaponBeta = core.OptionalElement(EgoWeaponBeta.is_available, EgoWeaponBeta)
+        EgoWeaponBeta.protect_from_running()
+        for sk in [UpperSlash, AdvancedPowerStomp, FrontSlash, TurningDrive, AdvancedWheelWind, GigaCrash,
+                    JumpingCrash, AdvancedEarthBreak, ShadowFlashBeta, ShadowFlashBetaEnd]:
+            sk.onAfter(UseEgoWeaponBeta)
         
         return(ComboHolder,
                 [globalSkill.maple_heros(chtr.level, name = "륀느의 가호", combat_level = 0), globalSkill.useful_sharp_eyes(), globalSkill.useful_wind_booster(),
@@ -327,5 +344,5 @@ class JobGenerator(ck.JobGenerator):
                     SoulContract]+\
                 [TwinBladeOfTime, ShadowFlashAlpha, ShadowFlashBeta, MirrorBreak, MirrorSpider]+\
                 [AdvancedStormBreakSummon, AdvancedStormBreakElectric, AdvancedEarthBreakElectric, WindCutterSummon, ThrowingWeapon]+\
-                []+\
+                [EgoWeaponAlpha, EgoWeaponBeta]+\
                 [ComboHolder])


### PR DESCRIPTION
resolve #394 
resolve #413 
resolve #327 

## 공통
* 전직업 신5차 추가
* onoff/available 변수 제거 반영
* 하이퍼스탯 고유자원에 빠지는 것 반영

## 팬텀
* 누락된 느와르 카르트 발동 스킬들 추가

## 보우마스터
* 스파이더 인 미러 1타에 모탈 블로우 적용

## 썬콜
* 아이스 에이지 장판
  * 2히트 기준으로 수정
  * 장판에 블리자드 패시브 안터지게함

## 카이저
* 페트리파이드 코강 2% -> 3%

## 아델
* 스톰 퍼뎀, 오더 로직 변경
* 오더 최초 소환 이후 공격까지 지연시간 반영
* 게더링+블로섬 이후 오더 공격주기 초기화되는것 반영
* 오더 공격주기 1020ms로 변경 (영상측정 기반)
* 게더링 액션 딜레이 630ms로 변경 (게더링+디바이드꾹으로 반복 측정함)
* 게더링+블로섬 이후 오더 지연시간 690ms+2010ms로 수정 (영상측정 기반, 블로섬은 추가 확인 필요)

## 제로
* 쉐도우 플래시(베타) 타겟수 15인데 8로 되어있었음

## 스트라이커
* 섬멸이 뇌전 스택을 쌓지 않도록 수정
* 천지개벽 도중 뇌전 스택이 소모되지 않도록 수정

## 패스파인더
* 블래스트/디스차지 각각 210ms씩으로 가능해짐
  * http://www.inven.co.kr/board/maple/2296/51645
* 트리플 임팩트를 레조넌스와 함께 사용하도록 딜사이클을 변경함
* 인챈트 포스 이후 문양 초기화되는것 반영

## 데몬슬레이어
* 대부분 스킬에 크확 달린걸 감안해 크확 50% 여유두게함
* 데빌 크라이, 서버러스, 데몬 베인에 오라웨폰 반응하게함

## 에반
* 돌아와! 30ms로 사용 가능한것 확인됨
* 스오마 시전 딜레이 360ms로 확인됨
* 조디악 레이에 오버로드 마나 적용되지 않아야함
* 마법 잔해 코드 스킬 설명에 더 가깝게 리팩토링

## 아란
* 파이널 어택 안터져야 하는 스킬 몇개 수정
* 헌터즈 타게팅, 브랜디쉬 마하 RepeatElement 사용하게 변경

## 카데나
* 1타캔슬 150ms로 수정 (전분 기반)
* 체인아츠-퓨리, 프로페셔널 추가타에 빠져있던 크러시 추가
* 스인미 1타가 체인아츠-퓨리 발동시킴