### PR TITLE
제로 4카5앱 임시 구현

### DIFF
--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -56,14 +56,14 @@ class JobGenerator(ck.JobGenerator):
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
         ResolutionTime = core.InformedCharacterModifier("리졸브 타임",pdamage_indep = 25, stat_main = 50)
+        # 4카5앱 임시 구현 (보공 +30%, 방무 -10%)
+        LuckyHat_Temp = core.InformedCharacterModifier("카오스 벨룸의 헬름 (임시)", boss_pdamage = 30) - core.ExtendedCharacterModifier(armor_ignore = 10)
 
-        return [Mastery, ResolutionTime]
+        return [Mastery, ResolutionTime, LuckyHat_Temp]
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         ArmorSplit = core.InformedCharacterModifier("아머 스플릿", armor_ignore = 50)
-        # 4카5앱 임시 구현 (보공 +30%, 방무 -10%)
-        LuckyHat_Temp = core.InformedCharacterModifier("카오스 벨룸의 헬름 (임시)", boss_pdamage = 30) - core.ExtendedCharacterModifier(armor_ignore = 10)
-        return [ArmorSplit, LuckyHat_Temp]
+        return [ArmorSplit]
 
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(crit = 15, pdamage = 80, armor_ignore = 20, crit_damage = 25)

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -57,7 +57,7 @@ class JobGenerator(ck.JobGenerator):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
         ResolutionTime = core.InformedCharacterModifier("리졸브 타임",pdamage_indep = 25, stat_main = 50)
         # 4카5앱 임시 구현 (보공 +30%, 방무 -10%)
-        LuckyHat_Temp = core.InformedCharacterModifier("카오스 벨룸의 헬름 (임시)", boss_pdamage = 30) - core.ExtendedCharacterModifier(armor_ignore = 10)
+        LuckyHat_Temp = core.InformedCharacterModifier("카오스 벨룸의 헬름 (임시)", boss_pdamage = 30) - core.ExtendedCharacterModifier(armor_ignore = 10, stat_main = 21, stat_sub = 21, att = 3)
 
         return [Mastery, ResolutionTime, LuckyHat_Temp]
 

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -61,7 +61,9 @@ class JobGenerator(ck.JobGenerator):
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         ArmorSplit = core.InformedCharacterModifier("아머 스플릿", armor_ignore = 50)
-        return [ArmorSplit]
+        # 4카5앱 임시 구현 (보공 +30%, 방무 -10%)
+        LuckyHat_Temp = core.InformedCharacterModifier("카오스 벨룸의 헬름 (임시)", boss_pdamage = 30) - core.ExtendedCharacterModifier(armor_ignore = 10)
+        return [ArmorSplit, LuckyHat_Temp]
 
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(crit = 15, pdamage = 80, armor_ignore = 20, crit_damage = 25)

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -56,8 +56,9 @@ class JobGenerator(ck.JobGenerator):
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         Mastery = core.InformedCharacterModifier("숙련도",pdamage_indep = -5)
         ResolutionTime = core.InformedCharacterModifier("리졸브 타임",pdamage_indep = 25, stat_main = 50)
+        # 유니온 6000 기준
         # 4카5앱 임시 구현 (보공 +30%, 방무 -10%)
-        LuckyHat_Temp = core.InformedCharacterModifier("카오스 벨룸의 헬름 (임시)", boss_pdamage = 30) - core.ExtendedCharacterModifier(armor_ignore = 10, stat_main = 21, stat_sub = 21, att = 3)
+        LuckyHat_Temp = core.InformedCharacterModifier("카오스 벨룸의 헬름 (임시)", boss_pdamage = 30) - core.ExtendedCharacterModifier(armor_ignore = 10, stat_main = 21, stat_sub = 21, pstat_main = 5, pstat_sub = 5, att = 3)
 
         return [Mastery, ResolutionTime, LuckyHat_Temp]
 


### PR DESCRIPTION
제로는 해방 이전의 거의 모든 스펙에서 카벨모를 착용해서 보공 30퍼를 더 받습니다.

현재 템셋을 갈아엎기에는 다른 할일이 많으니 일단 직접 적용하는 것으로 대신했습니다. 방무 -10퍼는 카루타 모자 옵션을 빼는 것입니다.

스타포스 및 스탯 차이는 감안하지 않았지만 기존 3카5앱보다는 더 현실적인 수치라고 생각됩니다.