### PR TITLE
fix: 블래스터 버닝 브레이커 준비 딜레이

### DIFF
--- a/dpmModule/jobs/blaster.py
+++ b/dpmModule/jobs/blaster.py
@@ -50,7 +50,7 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(InactiveRule('발칸 펀치', '벙커 버스터'), RuleSet.BASE)
         ruleset.add_rule(InactiveRule('발칸 펀치', '맥시마이즈 캐논'), RuleSet.BASE)
 
-        ruleset.add_rule(SynchronizeRule('버닝 브레이커(준비)', '해머 스매시(디버프)', 4500, 1), RuleSet.BASE)
+        ruleset.add_rule(SynchronizeRule('버닝 브레이커(준비)', '해머 스매시(디버프)', 3420, 1), RuleSet.BASE)
         ruleset.add_rule(SynchronizeRule('발칸 펀치', '해머 스매시(디버프)', 8000, 1), RuleSet.BASE)
         
         return ruleset
@@ -143,7 +143,7 @@ class JobGenerator(ck.JobGenerator):
         BalkanPunchTick = core.DamageSkill("발칸 펀치(틱)", 120, 425 + 17 * vEhc.getV(4,4), 8).isV(vEhc, 4, 4).wrap(core.DamageSkillWrapper) # 24회 반복
         BalkanPunchEnd = core.DamageSkill("발칸 펀치(후딜)", 360, 0, 0).isV(vEhc, 4, 4).wrap(core.DamageSkillWrapper)
         
-        BurningBreaker = core.DamageSkill("버닝 브레이커(준비)", 2010, 0, 0, cooltime = 100*1000, red = True).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper)
+        BurningBreaker = core.DamageSkill("버닝 브레이커(준비)", 120+210*5, 0, 0, cooltime = 100*1000, red = True).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper) # 리볼빙*3 매크로 사용, 1->2 120ms, 2~ 210ms 총 1170ms
         BurningBreakerRush = core.DamageSkill("버닝 브레이커(돌진)", 2220, 1500 + 60*vEhc.getV(1,1), 15, modifier = core.CharacterModifier(armor_ignore = 100, crit = 100)).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper) # 공속 적용됨, 2940ms -> 2220ms
         BurningBreakerExplode = core.DamageSkill("버닝 브레이커(폭발)", 0, 1200+48*vEhc.getV(1,1), 15 * 6, modifier = core.CharacterModifier(armor_ignore = 100, crit = 100)).isV(vEhc, 1, 1).wrap(core.DamageSkillWrapper)
 


### PR DESCRIPTION
* 리볼빙 캐논 매크로를 활용하면 훨씬 빨리 준비됨

![image](https://user-images.githubusercontent.com/12782606/93670331-a0255280-fad5-11ea-9689-8b2388316f1a.png)
![image](https://user-images.githubusercontent.com/12782606/93670386-f6929100-fad5-11ea-95ed-8ce8972753a5.png)
![image](https://user-images.githubusercontent.com/12782606/93670337-af0c0500-fad5-11ea-8446-75f988b905b7.png)
![image](https://user-images.githubusercontent.com/12782606/93670345-b92e0380-fad5-11ea-8b2d-4f913781c337.png)

1~2 사이 120ms
2,3,4,5,6 각각 210ms

합 1170ms