### PR TITLE
fix: 모험가 궁수 소환수

### DIFF
--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -6,6 +6,7 @@ from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, ConcurrentRunRule
 from . import globalSkill
 from .jobbranch import bowmen
+from .jobclass import adventurer
 from math import ceil
 
 """
@@ -137,7 +138,7 @@ class JobGenerator(ck.JobGenerator):
         ######   Skill   ######
         #Buff skills
         SoulArrow = core.BuffSkill("소울 애로우", 0, 300 * 1000, att = 30).wrap(core.BuffSkillWrapper) # 펫버프
-        AdvancedQuibber = core.BuffSkill("어드밴스드 퀴버", 0, 30 * 1000, crit_damage = 8).wrap(core.BuffSkillWrapper)   #쿨타임 무시 가능, 딜레이 없앰
+        AdvancedQuibber = core.BuffSkill("어드밴스드 퀴버", 0, 30 * 1000, crit_damage = 8).wrap(core.BuffSkillWrapper)   #쿨타임 무시 가능, 딜레이 0
         SharpEyes = core.BuffSkill("샤프 아이즈", 690, 300 * 1000, crit = 20 + 5 + ceil(self.combat / 2), crit_damage = 15 + ceil(self.combat / 2), armor_ignore = 5).wrap(core.BuffSkillWrapper)
         Preparation = core.BuffSkill("프리퍼레이션", 900, 30 * 1000, cooltime = 90 * 1000, att = 50, boss_pdamage = 20).wrap(core.BuffSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
@@ -159,9 +160,9 @@ class JobGenerator(ck.JobGenerator):
         ArrowRain = core.SummonSkill("애로우 레인", 0, 1440, 600+vEhc.getV(0,0)*24, 8, (40+vEhc.getV(0,0))*1000, cooltime = -1, modifier=MortalBlow).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 5초마다 3.5회 공격, 대략 1440ms당 1회
         
         #Summon Skills
-        Pheonix = core.SummonSkill("피닉스", 0, 2670, 390, 1, 220 * 1000).setV(vEhc, 5, 3, True).wrap(core.SummonSkillWrapper) # 이볼브가 끝나면 자동으로 소환되므로 딜레이 0
+        Pheonix = core.SummonSkill("피닉스", 0, 1710, 390, 1, 220 * 1000).setV(vEhc, 5, 3, True).wrap(core.SummonSkillWrapper) # 이볼브가 끝나면 자동으로 소환되므로 딜레이 0
         GuidedArrow = GuidedArrowWrapper(vEhc, 4, 4, ArmorPiercing)
-        Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(5,5)))*1000, red=True).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
+        Evolve = adventurer.EvolveWrapper(vEhc, 5, 5, Pheonix)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0, break_modifier=MortalBlow) # TODO: 아머 피어싱 적용
         
         #잔영의시 미적용
@@ -176,10 +177,6 @@ class JobGenerator(ck.JobGenerator):
     
         ######   Skill Wrapper   ######
         GrittyGust.onAfter(GrittyGustDOT)
-
-        #이볼브 연계 설정
-        Evolve.onAfter(Pheonix.controller(1))
-        Pheonix.onConstraint(core.ConstraintElement("이볼브 사용시 사용 금지", Evolve, Evolve.is_not_active))
             
         CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 22.5) #Maybe need to sync
 
@@ -213,6 +210,6 @@ class JobGenerator(ck.JobGenerator):
                     QuibberFullBurstDOT, GrittyGustDOT, ImageArrowPassive,
                     globalSkill.soul_contract()] +\
                 [] +\
-                [Evolve, ArrowFlatter, ArrowRain, Pheonix, GuidedArrow, QuibberFullBurst, ImageArrow, MirrorBreak, MirrorSpider, OpticalIllusion] +\
+                [Pheonix, Evolve, ArrowFlatter, ArrowRain, GuidedArrow, QuibberFullBurst, ImageArrow, MirrorBreak, MirrorSpider, OpticalIllusion] +\
                 [] +\
                 [ArrowOfStorm])

--- a/dpmModule/jobs/jobclass/adventurer.py
+++ b/dpmModule/jobs/jobclass/adventurer.py
@@ -88,7 +88,9 @@ def BlitzShieldWrappers(vEhc, num1, num2):
     BlitzShieldDummy.onAfter(BlitzShield)
     return BlitzShieldDummy, BlitzShield
 
-# 아직 사용하지 말것! 연계 설정 추가 필요
-def EvolveWrapper(vEhc, num1, num2):
-    Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(num1, num2)*15, 7, 40*1000, cooltime = (121-int(0.5*vEhc.getV(num1, num2)))*1000).isV(vEhc,num1, num2).wrap(core.SummonSkillWrapper)
+def EvolveWrapper(vEhc, num1, num2, bird: core.SummonSkillWrapper):
+    Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(num1, num2)*15, 7, 40*1000, cooltime = (120-vEhc.getV(num1, num2)//2)*1000, red=True).isV(vEhc, num1, num2).wrap(core.SummonSkillWrapper)
+    Evolve.onAfter(bird.controller(1))
+    Evolve.onConstraint(core.ConstraintElement(bird._id+" 있을때 사용 가능", bird, bird.is_active))
+    bird.onConstraint(core.ConstraintElement("이볼브 지속중 사용 금지", Evolve, Evolve.is_not_active))
     return Evolve

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -7,6 +7,7 @@ from ..status.ability import Ability_tool
 from ..execution.rules import RuleSet, MutualRule, ConcurrentRunRule, ReservationRule
 from . import globalSkill
 from .jobbranch import bowmen
+from .jobclass import adventurer
 from math import ceil
 
 class JobGenerator(ck.JobGenerator):
@@ -89,10 +90,10 @@ class JobGenerator(ck.JobGenerator):
         ChargedArrow = core.DamageSkill("차지드 애로우", 0, 750 + vEhc.getV(1,1)*30, 10+1, cooltime = -1, modifier = PASSIVE_MODIFIER).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         ChargedArrowHold = core.SummonSkill("차지드 애로우(더미)", 0, 10000, 0, 0, 9999999, cooltime = -1).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # TODO: 공격 주기에 쿨감 적용해야 함
         #Summon Skills
-        Freezer = core.SummonSkill("프리저", 900, 3030, 390, 1, 220 * 1000).setV(vEhc, 3, 3, False).wrap(core.SummonSkillWrapper)
-        GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)
+        Freezer = core.SummonSkill("프리저", 0, 1710, 390 if distance <= 280 else 0, 1, 220 * 1000).setV(vEhc, 3, 3, False).wrap(core.SummonSkillWrapper) # 이볼브 종료시 자동소환되므로 딜레이 0, 사거리 280보다 멀면 공격안함
+        Evolve = adventurer.EvolveWrapper(vEhc, 5, 5, Freezer)
         
-        Evolve = core.SummonSkill("이볼브", 600, 3330, 450+vEhc.getV(5,5)*15, 7, 40*1000, cooltime = (int(121-0.5*vEhc.getV(5,5)))*1000, red=True).isV(vEhc,5,5).wrap(core.SummonSkillWrapper)
+        GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         
         SplitArrow = core.DamageSkill("스플릿 애로우(공격)", 0, 600 + vEhc.getV(0,0) * 24, 5+1, modifier = PASSIVE_MODIFIER).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
@@ -106,10 +107,6 @@ class JobGenerator(ck.JobGenerator):
         FinalAttack = core.DamageSkill("파이널 어택", 0, 150, 0.4, modifier = PASSIVE_MODIFIER).setV(vEhc, 4, 2, True).wrap(core.DamageSkillWrapper)
         
         ######   Skill Wrapper   ######
-        
-        #이볼브 연계 설정
-        Evolve.onAfter(Freezer.controller(1))
-        Freezer.onConstraint(core.ConstraintElement("이볼브 사용시 사용 금지", Evolve, Evolve.is_not_active))
         
         CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 20+20) # 샤프 아이즈 20 + 불스아이 20. 불스아이를 항상 크리인에 맞춰쓰므로 가동률 고려 X
     
@@ -141,6 +138,6 @@ class JobGenerator(ck.JobGenerator):
                     SoulArrow, SharpEyes, BoolsEye, EpicAdventure, globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat),
                     CriticalReinforce, RepeatingCartrige, SplitArrowBuff, globalSkill.soul_contract()] +\
                 [TrueSnipping, ChargedArrowHold, ChargedArrow] +\
-                [Evolve,Freezer, GuidedArrow, MirrorBreak, MirrorSpider] +\
+                [Freezer, Evolve, GuidedArrow, MirrorBreak, MirrorSpider] +\
                 [] +\
                 [BasicAttack])

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -65,17 +65,16 @@ class JobGenerator(ck.JobGenerator):
         
         스나, 피어싱, 롱레트, 프리저
         '''
-        distance = 400
+        DISTANCE = 400
         passive_level = chtr.get_base_modifier().passive_level + self.combat
-        WEAKNESS_FINDING = core.CharacterModifier(armor_ignore = min(ceil((20+passive_level)/2) + distance//40 * ceil((20+passive_level)/5), 30 + (20+passive_level)))
-        DISTANCING_SENSE = core.CharacterModifier(pdamage_indep = max(min((distance-200)//18*4, 30+(10+passive_level)), 0))
+        WEAKNESS_FINDING = core.CharacterModifier(armor_ignore = min(ceil((20+passive_level)/2) + DISTANCE//40 * ceil((20+passive_level)/5), 30 + (20+passive_level)))
+        DISTANCING_SENSE = core.CharacterModifier(pdamage_indep = max(min((DISTANCE-200)//18*4, 30+(10+passive_level)), 0))
         LASTMAN_STANDING = core.CharacterModifier(pdamage_indep = 20 + 2*passive_level)
         PASSIVE_MODIFIER = WEAKNESS_FINDING + DISTANCING_SENSE + LASTMAN_STANDING
         
         #Buff skills
         SoulArrow = core.BuffSkill("소울 애로우", 0, 300 * 1000, att = 30, rem = True).wrap(core.BuffSkillWrapper)
         SharpEyes = core.BuffSkill("샤프 아이즈", 660, (300+10*self.combat) * 1000, crit = 20 + ceil(self.combat/2), crit_damage = 15 + ceil(self.combat/2), rem = True).wrap(core.BuffSkillWrapper)
-        #크리티컬 리인포스 - >재정의 필요함..
         
         BoolsEye = core.BuffSkill("불스아이", 960, 30 * 1000, cooltime = 90 * 1000, crit = 20, crit_damage = 10, armor_ignore = 20, pdamage = 20).wrap(core.BuffSkillWrapper)
         EpicAdventure = core.BuffSkill("에픽 어드벤처", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
@@ -90,7 +89,7 @@ class JobGenerator(ck.JobGenerator):
         ChargedArrow = core.DamageSkill("차지드 애로우", 0, 750 + vEhc.getV(1,1)*30, 10+1, cooltime = -1, modifier = PASSIVE_MODIFIER).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         ChargedArrowHold = core.SummonSkill("차지드 애로우(더미)", 0, 10000, 0, 0, 9999999, cooltime = -1).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) # TODO: 공격 주기에 쿨감 적용해야 함
         #Summon Skills
-        Freezer = core.SummonSkill("프리저", 0, 1710, 390 if distance <= 280 else 0, 1, 220 * 1000).setV(vEhc, 3, 3, False).wrap(core.SummonSkillWrapper) # 이볼브 종료시 자동소환되므로 딜레이 0, 사거리 280보다 멀면 공격안함
+        Freezer = core.SummonSkill("프리저", 0, 1710, 390 if DISTANCE <= 280 else 0, 1, 220 * 1000).setV(vEhc, 3, 3, False).wrap(core.SummonSkillWrapper) # 이볼브 종료시 자동소환되므로 딜레이 0, 사거리 280보다 멀면 공격안함
         Evolve = adventurer.EvolveWrapper(vEhc, 5, 5, Freezer)
         
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)

--- a/dpmModule/kernel/core.py
+++ b/dpmModule/kernel/core.py
@@ -1213,6 +1213,11 @@ class AbstractSkillWrapper(GraphElement):
         '''
         self.constraint.append(constraint)
         
+    def set_disabled(self):
+        '''주어진 요소를 실행 불가 상태로 만듭니다.
+        '''
+        raise NotImplementedError
+        
     def set_disabled_and_time_left(self, time):
         '''주어진 요소를 실행 불가 상태로 만들고, ``time`` 이후에 실행가능하도록 합니다.
 
@@ -1262,7 +1267,10 @@ class AbstractSkillWrapper(GraphElement):
             실행될 경우, 해당 ``GraphElement`` 의 잔여 시간을 제어하는 ``TaskHolder`` 
 
         '''
-        if type_ == 'set_disabled_and_time_left':
+        if type_ == 'set_disabled':
+            _name = ("사용 종료")
+            task = Task(self, self.set_disabled)
+        elif type_ == 'set_disabled_and_time_left':
             if time == -1:
                 _name = ("사용 불가")
             else:
@@ -1416,6 +1424,10 @@ class BuffSkillWrapper(AbstractSkillWrapper):
         mdf = self.get_modifier()
         return ResultObject(0, mdf, 0, 0, sname = self.skill.name, spec = self.skill.spec, kwargs = {"remain" : time})
         
+    def set_disabled(self):
+        self.timeLeft = 0
+        return self._disabledResultobjectCache
+        
     def set_disabled_and_time_left(self, time):
         self.timeLeft = 0
         self.cooltimeLeft = time
@@ -1558,6 +1570,11 @@ class SummonSkillWrapper(AbstractSkillWrapper):
         for sk, _ in self._runtime_modifier_list:
             li.append([self, sk, "modifier"])
         return li
+        
+    def set_disabled(self):
+        self.timeLeft = 0
+        self.tick = 0
+        return ResultObject(0, CharacterModifier(), 0, 0, sname = self.skill.name, spec = 'graph control')
         
     def set_disabled_and_time_left(self, time):
         self.cooltimeLeft = time


### PR DESCRIPTION
* 이볼브를 공용 EvolveWrapper를 사용하도록 리팩토링
* 프리저/피닉스의 공격주기는 1710ms로 확인됨 (클라, 인게임 모두 확인함)
* 레이븐의 공격주기는 1800ms로 확인됨 (마찬가지)
* 레이븐의 타수가 1인데 4로 적혀있던것 수정
* 패스파인더 레이븐 템페스트 도중 이볼브 사용불가, 레이븐 템페스트가 이볼브 잡아먹게 수정
* 패스파인더 이볼브도 칠때마다 렐릭 게이지 채워줌
* 레이븐 템페스트가 사용 가능하면 이볼브를 쓰지 않는 규칙 추가
* SkillWrapper에 set_disabled 메소드 추가 (쿨타임 바꾸지 않으면서 종료만)

fix #465 