### PR TITLE
fix: 크리티컬 리인포스, 윈드브레이커

### DIFF
--- a/dpmModule/jobs/bowmaster.py
+++ b/dpmModule/jobs/bowmaster.py
@@ -178,7 +178,7 @@ class JobGenerator(ck.JobGenerator):
         ######   Skill Wrapper   ######
         GrittyGust.onAfter(GrittyGustDOT)
             
-        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 22.5) #Maybe need to sync
+        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 25 + ceil(self.combat/2))
 
         ArrowOfStorm.onAfter(AdvancedQuibberAttack)
         ArrowOfStorm.onAfter(AdvancedFinalAttack)

--- a/dpmModule/jobs/pathfinder.py
+++ b/dpmModule/jobs/pathfinder.py
@@ -203,7 +203,7 @@ class JobGenerator(ck.JobGenerator):
         # 5차
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 3, 3)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
-        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 1, 1, 20)
+        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 1, 1, 20+ceil(self.combat/2))
         
         Evolve = adventurer.EvolveWrapper(vEhc, 5, 5, Raven)
         UltimateBlast = core.DamageSkill("얼티밋 블래스트", LINK_DELAY + 1350, 400+20*vEhc.getV(2,2), 15*5, cooltime = 120*1000, red=True, 

--- a/dpmModule/jobs/sniper.py
+++ b/dpmModule/jobs/sniper.py
@@ -107,7 +107,7 @@ class JobGenerator(ck.JobGenerator):
         
         ######   Skill Wrapper   ######
         
-        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 20+20) # 샤프 아이즈 20 + 불스아이 20. 불스아이를 항상 크리인에 맞춰쓰므로 가동률 고려 X
+        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 20 + 20 + ceil(self.combat/2)) # 샤프 아이즈 20 + 불스아이 20. 불스아이를 항상 크리인에 맞춰쓰므로 가동률 고려 X
     
         SplitArrowOption = core.OptionalElement(SplitArrowBuff.is_active, SplitArrow, name = "스플릿 애로우 여부 확인")
         Snipping.onAfter(SplitArrowOption)

--- a/dpmModule/jobs/wildhunter.py
+++ b/dpmModule/jobs/wildhunter.py
@@ -159,7 +159,7 @@ class JobGenerator(ck.JobGenerator):
         #5th
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 4, 4)
         RegistanceLineInfantry = resistance.ResistanceLineInfantryWrapper(vEhc, 3, 3)
-        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 1, 1, 20)
+        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 1, 1, 20 + ceil(self.combat/2))
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
     
         JaguerStorm = core.BuffSkill("재규어 스톰", 840, 40*1000, cooltime = (150-vEhc.getV(0,0))*1000, red=True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -45,6 +45,10 @@ class JobGenerator(ck.JobGenerator):
         코강 순서:
         천노-윔-브링어
 
+        하이퍼:
+        트라이플링 윔-리인포스, 인핸스, 더블찬스
+        천공의 노래-리인포스, 보스 킬러
+
         하울링게일 58회, 볼텍스 스피어 17회 타격
         
         트라이플링 윔 평균치로 계산
@@ -62,7 +66,10 @@ class JobGenerator(ck.JobGenerator):
         
         StormBringerDummy = core.BuffSkill("스톰 브링어(버프)", 0, 200 * 1000).wrap(core.BuffSkillWrapper)  #딜레이 계산 필요
         # 하이퍼: 데미지 증가, 확률 10% 증가, 타수 증가
-        TriflingWhim = core.DamageSkill("트라이플링 윔", 0, (290 + passive_level*3) * 0.8 + (390 + passive_level*3) * 0.2, 2 * (0.5 + 0.1), modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        whim_proc = (50 + 10 + passive_level//2) * 0.01
+        advanced_proc = (20 + passive_level//3) * 0.01
+        TriflingWhim = core.DamageSkill("트라이플링 윔", 0,
+            (290 + passive_level*3) * (1 - advanced_proc) + (390 + passive_level*3) * advanced_proc, 2 * whim_proc, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         StormBringer = core.DamageSkill("스톰 브링어", 0, 500, 0.3).setV(vEhc, 2, 2, True).wrap(core.DamageSkillWrapper)
     
         # 핀포인트 피어스
@@ -71,7 +78,7 @@ class JobGenerator(ck.JobGenerator):
 
         #Damage Skills
         # 하이퍼: 데미지 증가, 보스 데미지 증가
-        target_pdamage = ((120 + self.combat // 2) / 100) ** (4 + additional_target) * 100 - 100 # 코강렙 20이상 가정. 툴팁은 u(x/2)로 되어있으나 실제 동작은 d(x/2)로 버림처리됨.
+        target_pdamage = ((120 + self.combat // 2) / 100) ** (4 + additional_target) * 100 - 100 # 코강렙 20이상 가정.
         SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + self.combat*3, 1, modifier = core.CharacterModifier(pdamage = target_pdamage + 20, boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
         CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 600, 120 * 5, 450 + 18*vEhc.getV(0,0), 5, 120 * (40 + vEhc.getV(0,0)), cooltime = 30 * 1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
@@ -83,16 +90,20 @@ class JobGenerator(ck.JobGenerator):
         GuidedArrow = bowmen.GuidedArrowWrapper(vEhc, 5, 5)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0) # TODO: 윔 발생여부 확인할것
         HowlingGail = core.SummonSkill("하울링 게일", 630, 150, 250 + 10*vEhc.getV(1, 1), 3, 150*58-1, cooltime = 20 * 1000).isV(vEhc, 1, 1).wrap(core.SummonSkillWrapper) #58타
-        WindWall = core.SummonSkill("윈드 월", 720, 2000, (550 + vEhc.getV(2, 2)*22) / 2, 5 * 3 , 45 * 1000, cooltime = 90 * 1000, red=True).isV(vEhc, 2, 2).wrap(core.SummonSkillWrapper)
+        WindWall = core.SummonSkill("윈드 월", 720, 2000, 550 + vEhc.getV(2, 2)*22, 5, 45 * 1000, cooltime = 90 * 1000, red=True).isV(vEhc, 2, 2).wrap(core.SummonSkillWrapper)
+        WindWallExceed = core.SummonSkill("윈드 월(초과)", 720, 2000, (550 + vEhc.getV(2, 2)*22) / 2, 5 * 2 , 45 * 1000, cooltime=-1).isV(vEhc, 2, 2).wrap(core.SummonSkillWrapper)
         VortexSphere = core.SummonSkill("볼텍스 스피어", 720, 180, 400+16*vEhc.getV(0,0), 6, 180*17-1, cooltime=35000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper) # 17타
         
         ######   Skill Wrapper   #####
         
-        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 55) #Maybe need to sync
+        CriticalReinforce = bowmen.CriticalReinforceWrapper(vEhc, chtr, 3, 3, 10 + 25+passive_level//2 + 20+ceil(self.combat/2)) # 실프스 에이드 + 알바트로스 맥시멈 + 샤프 아이즈
+
+        WindWall.onAfter(WindWallExceed)
     
         #Damage
         SongOfHeaven.onAfters([TriflingWhim, StormBringer])
         PinPointPierce.onAfters([PinPointPierceDebuff, TriflingWhim, StormBringer])
+        MirrorBreak.onAfters([TriflingWhim, StormBringer])
         #Summon
         CygnusPalanks.onTicks([core.RepeatElement(TriflingWhim, 5), core.RepeatElement(StormBringer, 5)])
         HowlingGail.onTicks([TriflingWhim, StormBringer])
@@ -106,6 +117,6 @@ class JobGenerator(ck.JobGenerator):
                     PinPointPierceDebuff,
                     globalSkill.soul_contract()] +\
                 [Mercilesswind]+\
-                [GuidedArrow, HowlingGail, VortexSphere, WindWall, MercilesswindDOT, CygnusPalanks, PinPointPierce, MirrorBreak, MirrorSpider]+\
+                [GuidedArrow, HowlingGail, VortexSphere, WindWall, WindWallExceed, MercilesswindDOT, CygnusPalanks, PinPointPierce, MirrorBreak, MirrorSpider]+\
                 []+\
                 [SongOfHeaven])


### PR DESCRIPTION
* 크리티컬 리인포스의 크뎀 증가량에 샤프 아이즈의 컴뱃으로 증가한 크확이 빠진것 수정
  * 샤프 아이즈 하이퍼가 잘못 적용된것도 수정
* 윈브 윈드월 공격 중 1개는 100%로 들어가는것 반영
* 윈브 윔 사출확률 계산에 패시브 레벨 고려하도록 함
  * 지금 패시브 어빌을 안쓰므로 dpm에 영향은 없음
* 윈브 스인미 1타에 윔, 스톰브링어 터지는것 반영