### PR TITLE
fix: 배틀메이지 마스터 오브 데스

### DIFF
--- a/dpmModule/jobs/battlemage.py
+++ b/dpmModule/jobs/battlemage.py
@@ -192,8 +192,7 @@ class JobGenerator(ck.JobGenerator):
         DarkGenesisFinalAttack.onAfter(ReduceDeath)
         DarkGenesis.onAfter(ReduceDeath)
         ReaperScythe.onAfter(ReduceDeath)
-        BlackMagicAlter.onTick(ReduceDeath)
-        GrimReaper.onTick(ReduceDeath)
+        DarkLightning.onAfter(ReduceDeath)
         Death.add_runtime_modifier(MasterOfDeath, lambda sk: core.CharacterModifier(pdamage_indep = 50 * sk.is_active()))
         
         # 배틀킹 바


### PR DESCRIPTION
* 블랙 매직 알터, 그림 리퍼의 공격이 물리 속성인것 반영
* 다크 라이트닝이 암흑 속성인것 반영
* 암흑 속성 공격이 마스터 오브 데스 도중 데스의 쿨타임을 감소시킴

fix #494 