### PR TITLE
Wb phalanx

### DIFF
--- a/dpmModule/jobs/flamewizard.py
+++ b/dpmModule/jobs/flamewizard.py
@@ -73,7 +73,7 @@ class JobGenerator(ck.JobGenerator):
         #Full speed, No Combat Orders
         OrbitalFlame = core.DamageSkill("오비탈 플레임 IV", 210, 215 + self.combat, 3 * 2 * (210 / flamewizardDefaultSpeed), modifier = core.CharacterModifier(armor_ignore = 20)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         # BlazingExtinction = core.SummonSkill("블레이징 익스팅션", 1020, 2500, 310+2*self.combat, 3+1, 10000, cooltime=5000, modifier = core.CharacterModifier(pdamage = 20)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
-        CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 2, 1)
+        CygnusPhalanx = cygnus.PhalanxChargeWrapper(vEhc, 2, 1)
         BlazingOrbital = core.DamageSkill("블레이징 오비탈 플레임", 180, 330+13*vEhc.getV(0,0), 6 * blazingOrbitalHit, cooltime = 5000, red = True, modifier = core.CharacterModifier(armor_ignore = 50)).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)    #4타 가정
         
         DragonSlaveTick = core.DamageSkill("드래곤 슬레이브", 280, 500, 6).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)#x7
@@ -130,7 +130,7 @@ class JobGenerator(ck.JobGenerator):
         # Overload Mana
         overload_mana_builder = magicians.OverloadManaBuilder(vEhc, 1, 2)
         for sk in [OrbitalFlame, InfernoRize, DragonSlaveTick, DragonSlaveEnd, InfinityFlameCircleTick, SavageFlame_2, SavageFlame_3, SavageFlame_4,
-                    SalamanderMischeif, CygnusPalanks]:
+                    SalamanderMischeif, CygnusPhalanx]:
             overload_mana_builder.add_skill(sk)
         OverloadMana = overload_mana_builder.get_buff()
         
@@ -138,7 +138,7 @@ class JobGenerator(ck.JobGenerator):
                 [globalSkill.maple_heros(chtr.level, name = "시그너스 나이츠", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
                      cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level), WordOfFire, FiresOfCreation, BurningRegion, GloryOfGuardians, OverloadMana, Flame, SalamanderMischeifBuff,
                     globalSkill.soul_contract()] +\
-                [SalamanderMischeif, CygnusPalanks, BlazingOrbital, DragonSlaveInit, SavageFlame, InfinityFlameCircleInit, 
+                [SalamanderMischeif, CygnusPhalanx, BlazingOrbital, DragonSlaveInit, SavageFlame, InfinityFlameCircleInit, 
                     InfernoRize, MirrorBreak, MirrorSpider] +\
                 [IgnitionDOT] +\
                 [] +\

--- a/dpmModule/jobs/michael.py
+++ b/dpmModule/jobs/michael.py
@@ -95,7 +95,7 @@ class JobGenerator(ck.JobGenerator):
         QueenOfTomorrow = core.BuffSkill("퀸 오브 투모로우", 0, 60000, cooltime = 120000, pdamage = 10).wrap(core.BuffSkillWrapper)
     
         # 5th
-        CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 3, 3)
+        CygnusPhalanx = cygnus.PhalanxChargeWrapper(vEhc, 3, 3)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         RoIias = core.BuffSkill("로 아이아스", 840, (75+3*vEhc.getV(0,0))*1000, cooltime = 300*1000, red = True, pdamage_indep = 5 + (35+3*(vEhc.getV(0,0)//4))//2).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
         ClauSolis = core.DamageSkill("클라우 솔라스", 690, 700+28*vEhc.getV(4,4), 7, cooltime = 12000, red = True).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)    #로얄가드 버프지속시간 6초 증가. 100% 암흑 5초
@@ -151,6 +151,6 @@ class JobGenerator(ck.JobGenerator):
                     GuardOfLight, LoyalGuardBuff, SoulAttack, Booster, Invigorate, SacredCube, cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level),
                     DeadlyChargeBuff, QueenOfTomorrow, AuraWeaponBuff, AuraWeapon, RoIias, SwordOfSoullight, LightOfCourage, LightOfCourageSummon, LightOfCourageFinal,
                     globalSkill.soul_contract()] +\
-                [CygnusPalanks, LoyalGuard_5, ShiningCross, DeadlyCharge, ClauSolis, MirrorBreak, MirrorSpider] +\
+                [CygnusPhalanx, LoyalGuard_5, ShiningCross, DeadlyCharge, ClauSolis, MirrorBreak, MirrorSpider] +\
                 [ShiningCrossInstall, ClauSolisSummon] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/nightwalker.py
+++ b/dpmModule/jobs/nightwalker.py
@@ -134,7 +134,7 @@ class JobGenerator(ck.JobGenerator):
 
         GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
-        CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 4, 4)
+        CygnusPhalanx = cygnus.PhalanxChargeWrapper(vEhc, 4, 4)
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 3, 3)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
 
@@ -223,7 +223,7 @@ class JobGenerator(ck.JobGenerator):
                     ShadowElusion, ReadyToDie, Dominion, cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level),
                     GloryOfGuardians, ShadowSpear, ShadowServentExtend, ShadowBite, ShadowBiteBuff,
                     globalSkill.soul_contract()] +\
-                [RapidThrowInit, CygnusPalanks, MirrorBreak, MirrorSpider] +\
+                [RapidThrowInit, CygnusPhalanx, MirrorBreak, MirrorSpider] +\
                 [ElementalDarknessDOT, ShadowSpearLarge] +\
                 [] +\
                 [QuintupleThrow])

--- a/dpmModule/jobs/soulmaster.py
+++ b/dpmModule/jobs/soulmaster.py
@@ -74,7 +74,7 @@ class JobGenerator(ck.JobGenerator):
         #Damage Skills
         SpeedingDance = core.DamageSkill("댄스오브 문/스피딩 선셋", (360+270)/2, 400+4*self.combat, 4 * 2, modifier = core.CharacterModifier(pdamage = 20, boss_pdamage = 20, armor_ignore = 20) + FallingMoon).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
-        CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 4, 4)
+        CygnusPhalanx = cygnus.PhalanxChargeWrapper(vEhc, 4, 4)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         
         SelestialDanceInit = core.BuffSkill("셀레스티얼 댄스", 570, (40+vEhc.getV(0,0))*1000, cooltime = 150 * 1000, red = True).isV(vEhc,0,0).wrap(core.BuffSkillWrapper)
@@ -131,6 +131,6 @@ class JobGenerator(ck.JobGenerator):
                     NimbleFinger, TrueSight, SolunaTime, SoulForge, cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level),
                     GloryOfGuardians, AuraWeaponBuff, AuraWeapon, globalSkill.soul_contract(), SelestialDanceInit, Elision, ElisionBreak,
                     ] +\
-                [FlareSlash, CygnusPalanks, SolunaDivide] +\
+                [FlareSlash, CygnusPhalanx, SolunaDivide] +\
                 [SelestialDanceSummon, SoulEclipse, MirrorBreak, MirrorSpider] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/striker.py
+++ b/dpmModule/jobs/striker.py
@@ -115,7 +115,7 @@ class JobGenerator(ck.JobGenerator):
         
         GloryOfGuardians = core.BuffSkill("글로리 오브 가디언즈", 0, 60*1000, cooltime = 120 * 1000, pdamage = 10).wrap(core.BuffSkillWrapper)
         
-        CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 4, 4)
+        CygnusPhalanx = cygnus.PhalanxChargeWrapper(vEhc, 4, 4)
         LuckyDice = core.BuffSkill("로디드 다이스", 0, 180*1000, pdamage = 20).isV(vEhc,1,3).wrap(core.BuffSkillWrapper)
 
         #오버드라이브 (앱솔 가정)
@@ -163,7 +163,7 @@ class JobGenerator(ck.JobGenerator):
                         SpearLightningAttack, SpearLightningAttack_Lightning, SpearLightningAttack_Final, SpearLightningAttack_Final_Lightning]:
             skill.onAfter(LightningStack.stackController(1))
 
-        for skill in [ShinNoiHapLAttack, CygnusPalanks, NoiShinChanGeukAttack]:
+        for skill in [ShinNoiHapLAttack, CygnusPhalanx, NoiShinChanGeukAttack]:
             skill.onTick(LightningStack.stackController(1))
 
         GioaTan.onAfter(core.OptionalElement(SkyOpen.is_not_active, LightningStack.stackController(-2), name="천지개벽 체크"))
@@ -185,7 +185,7 @@ class JobGenerator(ck.JobGenerator):
                     LightningStack, Booster, ChookRoi, WindBooster, LuckyDice,
                     HurricaneBuff, GloryOfGuardians, SkyOpen, Overdrive, ShinNoiHapL, cygnus.CygnusBlessWrapper(vEhc, 0, 0, chtr.level),
                     globalSkill.soul_contract()] +\
-                [GioaTan, CygnusPalanks, NoiShinChanGeuk, SpearLightningAttackInit, MirrorBreak, MirrorSpider] +\
+                [GioaTan, CygnusPhalanx, NoiShinChanGeuk, SpearLightningAttackInit, MirrorBreak, MirrorSpider] +\
                 [ShinNoiHapLAttack, NoiShinChanGeukAttack] +\
                 [] +\
                 [BasicAttackWrapper])

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -81,7 +81,7 @@ class JobGenerator(ck.JobGenerator):
         target_pdamage = ((120 + self.combat // 2) / 100) ** (4 + additional_target) * 100 - 100 # 코강렙 20이상 가정.
         SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + self.combat*3, 1, modifier = core.CharacterModifier(pdamage = target_pdamage + 20, boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
-        CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 0, 0)
+        CygnusPhalanx = cygnus.PhalanxChargeWrapper(vEhc, 0, 0)
         
         Mercilesswind = core.DamageSkill("아이들 윔", 600, (500 + 20*vEhc.getV(4,4)) * 0.775, 10 * 3, cooltime = 10 * 1000, red=True).isV(vEhc,4,4).wrap(core.DamageSkillWrapper) #도트 데미지 9초간 초당 1000%
         MercilesswindDOT = core.DotSkill("아이들 윔(도트)", 0, 1000, 500 + 20*vEhc.getV(4,4), 1, 9000, cooltime = -1).wrap(core.SummonSkillWrapper)
@@ -105,7 +105,7 @@ class JobGenerator(ck.JobGenerator):
         PinPointPierce.onAfters([PinPointPierceDebuff, TriflingWhim, StormBringer])
         MirrorBreak.onAfters([TriflingWhim, StormBringer])
         #Summon
-        CygnusPalanks.onTicks([TriflingWhim, StormBringer])
+        CygnusPhalanx.onTicks([TriflingWhim, StormBringer])
         HowlingGail.onTicks([TriflingWhim, StormBringer])
         VortexSphere.onTicks([TriflingWhim, StormBringer])
 
@@ -117,6 +117,6 @@ class JobGenerator(ck.JobGenerator):
                     PinPointPierceDebuff,
                     globalSkill.soul_contract()] +\
                 [Mercilesswind]+\
-                [GuidedArrow, HowlingGail, VortexSphere, WindWall, WindWallExceed, MercilesswindDOT, CygnusPalanks, PinPointPierce, MirrorBreak, MirrorSpider]+\
+                [GuidedArrow, HowlingGail, VortexSphere, WindWall, WindWallExceed, MercilesswindDOT, CygnusPhalanx, PinPointPierce, MirrorBreak, MirrorSpider]+\
                 []+\
                 [SongOfHeaven])

--- a/dpmModule/jobs/windBreaker.py
+++ b/dpmModule/jobs/windBreaker.py
@@ -81,7 +81,7 @@ class JobGenerator(ck.JobGenerator):
         target_pdamage = ((120 + self.combat // 2) / 100) ** (4 + additional_target) * 100 - 100 # 코강렙 20이상 가정.
         SongOfHeaven = core.DamageSkill("천공의 노래", 120, 345 + self.combat*3, 1, modifier = core.CharacterModifier(pdamage = target_pdamage + 20, boss_pdamage = 30)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
-        CygnusPalanks = core.SummonSkill("시그너스 팔랑크스", 600, 120 * 5, 450 + 18*vEhc.getV(0,0), 5, 120 * (40 + vEhc.getV(0,0)), cooltime = 30 * 1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
+        CygnusPalanks = cygnus.PhalanxChargeWrapper(vEhc, 0, 0)
         
         Mercilesswind = core.DamageSkill("아이들 윔", 600, (500 + 20*vEhc.getV(4,4)) * 0.775, 10 * 3, cooltime = 10 * 1000, red=True).isV(vEhc,4,4).wrap(core.DamageSkillWrapper) #도트 데미지 9초간 초당 1000%
         MercilesswindDOT = core.DotSkill("아이들 윔(도트)", 0, 1000, 500 + 20*vEhc.getV(4,4), 1, 9000, cooltime = -1).wrap(core.SummonSkillWrapper)
@@ -105,7 +105,7 @@ class JobGenerator(ck.JobGenerator):
         PinPointPierce.onAfters([PinPointPierceDebuff, TriflingWhim, StormBringer])
         MirrorBreak.onAfters([TriflingWhim, StormBringer])
         #Summon
-        CygnusPalanks.onTicks([core.RepeatElement(TriflingWhim, 5), core.RepeatElement(StormBringer, 5)])
+        CygnusPalanks.onTicks([TriflingWhim, StormBringer])
         HowlingGail.onTicks([TriflingWhim, StormBringer])
         VortexSphere.onTicks([TriflingWhim, StormBringer])
 


### PR DESCRIPTION
```
Before
윈드브레이커 4630644109357.117 10.23809289932251초
After
윈드브레이커 4623937350989.113 10.796057224273682초

비교대상
나이트워커 5262358101723.929 14.780503511428833초
```

현재 윈브 팔랑크스는 5단위마다 계산되는데, 1단위로 바꿀 때 얼마나 느려질지 궁금해서 실험해본 결과 차이가 거의 없었습니다.

시간이 늘어나긴 했지만 수용 가능한 범위라고 판단되어 PR을 올립니다.

추가로 텍스트 Palanks를 Phalanx로 교체했습니다.