### PR TITLE
Ark fix2

### DIFF
--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -309,7 +309,7 @@ class JobGenerator(ck.JobGenerator):
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("너클")
         Overdrive = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
-        MirrorSpider, MirrorBreak = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
+        MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         FloraGoddessBless = flora.FloraGoddessBlessWrapper(vEhc, 0, 0, WEAPON_ATT)
     
         MemoryOfSource = core.DamageSkill("근원의 기억", 990, 0, 0, cooltime = 200 * 1000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
@@ -413,6 +413,7 @@ class JobGenerator(ck.JobGenerator):
             CrawlingFear_Link, EndlessPainTick, EndlessPainEnd, EndlessPainEnd_Link, ForeverHungryBeast]:
             skill.onAfter(UpcomingDeath_Connected)
         MagicCircuitFullDriveStorm.onAfter(core.OptionalElement(SpecterState.is_active, UpcomingDeath_Connected))
+        MirrorBreak.onAfter(core.OptionalElement(SpecterState.is_active, UpcomingDeath_Connected))
         
         # 5차 - 새어나오는 악몽 / 흉몽 연계
         EndlessNightmare_Link.onAfter(core.OptionalElement(DeviousNightmare.is_available, DeviousNightmare))

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -235,6 +235,8 @@ class JobGenerator(ck.JobGenerator):
         AbyssSpell = core.SummonSkill("어비스 스펠", 0, 300*0.75, 70 + 2*self.combat, 2, 3000, cooltime = -1).setV(vEhc, 6, 2, False).wrap(core.SummonSkillWrapper)
         AbyssBuff = core.BuffSkill("어비스 버프", 0, 60*1000, cooltime = -1, rem=True, pdamage = 20 + self.combat//2, boss_pdamage = 30 + self.combat, armor_ignore = 20 + self.combat//2).wrap(core.BuffSkillWrapper)
 
+        HUMAN_SKILLS_MCF = [EndlessNightmare_Link, PlainChargeDrive, PlainChargeDrive_Link, ScarletChargeDrive, ScarletChargeDrive_Link, UnstoppableImpulse_Link,
+            GustChargeDrive_Link, AbyssChargeDrive_Link, PlainSpell, ScarletSpell, GustSpell, AbyssSpell]
         
         ##### 스펙터 상태일 때 #####
         UpcomingDeath = core.DamageSkill("다가오는 죽음", 0, 450 + 3*passive_level, 2, cooltime = -1).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
@@ -267,6 +269,9 @@ class JobGenerator(ck.JobGenerator):
         
         Impulse_Connected = MultipleDamageSkillWrapper(core.DamageSkill("충동/본능 연결", 0, 0, 0, cooltime = 6000, red=True, modifier=BattleArtsHyper).setV(vEhc, 7, 2, False), 2, 1500)
 
+        SPECTER_SKILLS_MCF = [ReturningHate, EndlessBadDream, EndlessBadDream_Link, UncurableHurt_Link, TenaciousInstinct_Link, UnfulfilledHunger, UnfulfilledHunger_Link,
+            CrawlingFear, CrawlingFear_Link, UncontrollableChaos, UncontrollableChaos_Link, RaptRestriction, RaptRestrictionSummon, RaptRestrictionEnd]
+            
         # 하이퍼
         ChargeSpellAmplification = core.BuffSkill("차지 스펠 앰플리피케이션", 720, 60000, att = 30, crit = 20, pdamage = 20, armor_ignore = 20, boss_pdamage = 30, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
         
@@ -301,18 +306,6 @@ class JobGenerator(ck.JobGenerator):
         ForeverHungryBeastInit = core.DamageSkill("영원히 굶주리는 짐승(개시)", 540, 0, 0, cooltime=120*1000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         ForeverHungryBeastTrigger = core.DamageSkill("영원히 굶주리는 짐승(등장)", 0, 0, 0, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         ForeverHungryBeast = core.DamageSkill("영원히 굶주리는 짐승", 0, 400+16*vEhc.getV(0,0), 12, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 20회 반복
-
-        magic_curcuit_full_drive_builder = flora.MagicCircuitFullDriveBuilder(vEhc, 4, 3)
-        for skill in [
-            PlainChargeDrive, PlainChargeDrive_Link, EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, UnstoppableImpulse_Link,
-            PlainSpell, ScarletSpell, GustSpell, AbyssSpell, ReturningHate, # UpcomingDeath
-            EndlessBadDream, EndlessBadDream_Link, UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, TenaciousInstinct_Link,
-            CrawlingFear_Link, RaptRestriction, RaptRestrictionSummon, RaptRestrictionEnd, EndlessPainTick, EndlessPainEnd_Link, 
-            MemoryOfSourceTick, MemoryOfSourceEnd, DeviousNightmare, DeviousDream, ForeverHungryBeast, MirrorBreak
-            ]:
-            magic_curcuit_full_drive_builder.add_trigger(skill)
-        MagicCircuitFullDrive, ManaStorm = magic_curcuit_full_drive_builder.get_skill()
-
 
         ### Skill Wrapper ###
 
@@ -370,13 +363,20 @@ class JobGenerator(ck.JobGenerator):
         AdditionalConsumption = core.OptionalElement(MemoryOfSourceBuff.is_not_active, SpecterState.advancedController())
         EndlessPainEnd.onJustAfter(AdditionalConsumption)
 
+        magic_curcuit_full_drive_builder = flora.MagicCircuitFullDriveBuilder(vEhc, 4, 3)
+        for sk in (HUMAN_SKILLS_MCF + SPECTER_SKILLS_MCF +
+            [EndlessPainTick, EndlessPainEnd, EndlessPainEnd_Link, MemoryOfSourceTick, MemoryOfSourceEnd, 
+            DeviousNightmare, DeviousDream, ForeverHungryBeast, MirrorBreak]):
+            magic_curcuit_full_drive_builder.add_trigger(sk)
+        MagicCircuitFullDrive, MagicCircuitFullDriveStorm = magic_curcuit_full_drive_builder.get_skill()
+
         # 스펙터 상태 파이널어택류 연계
         for skill in [EndlessBadDream, EndlessBadDream_Link, DeviousDream,
             UnfulfilledHunger, UncontrollableChaos, 
             UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, TenaciousInstinct_Link,
             CrawlingFear_Link, EndlessPainTick, EndlessPainEnd, EndlessPainEnd_Link, ForeverHungryBeast]:
             skill.onAfter(UpcomingDeath_Connected)
-        ManaStorm.onAfter(core.OptionalElement(SpecterState.is_active, UpcomingDeath_Connected))
+        MagicCircuitFullDriveStorm.onAfter(core.OptionalElement(SpecterState.is_active, UpcomingDeath_Connected))
         
         # 5차 - 새어나오는 악몽 / 흉몽 연계
         EndlessNightmare_Link.onAfter(core.OptionalElement(DeviousNightmare.is_available, DeviousNightmare))
@@ -499,5 +499,5 @@ class JobGenerator(ck.JobGenerator):
                     EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, 
                     UncurableHurt_Link, UnfulfilledHunger_Link, Impulse_Connected, UncontrollableChaos_Link, 
                     AbyssSpell, RaptRestrictionSummon, DeviousNightmare, DeviousDream, MirrorBreak, MirrorSpider] +\
-                [ManaStorm] +\
+                [MagicCircuitFullDriveStorm] +\
                 [PlainAttack])

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -3,12 +3,12 @@ from ..kernel.core import VSkillModifier as V
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from ..execution.rules import RuleSet, MutualRule, ConcurrentRunRule
+from ..execution.rules import RuleSet, ConcurrentRunRule, ConditionRule
 from . import globalSkill
 from .jobbranch import pirates
 from .jobclass import flora
 from . import jobutils
-from math import ceil, floor
+from math import ceil
 
 # TODO: core쪽으로 옮길 것, .wrap()과 함께 사용 가능하게 할 것
 class MultipleDamageSkillWrapper(core.DamageSkillWrapper):
@@ -58,17 +58,18 @@ class DeviousWrapper(core.DamageSkillWrapper):
         self.reduceDict = set()
         return super(DeviousWrapper, self)._use(skill_modifier)
 
-class SpectorWrapper(core.BuffSkillWrapper):
+class SpecterWrapper(core.BuffSkillWrapper):
     def __init__(self, memoryBuff, endlessBuff):
         skill = core.BuffSkill("스펙터 상태", 0, 9999999, att = 30, cooltime = -1)
-        self.gauge = 500
+        self.gauge = 900
         self.memoryBuff = memoryBuff
         self.endlessBuff = endlessBuff
         self.schedule = None
         self.cooldown = 0
         self.lockdown = 0
-        super(SpectorWrapper, self).__init__(skill)
+        super(SpecterWrapper, self).__init__(skill)
         self.onoff = False
+        self.stopwatch = 0
 
     def is_active(self):
         return self.onoff
@@ -82,6 +83,7 @@ class SpectorWrapper(core.BuffSkillWrapper):
         """
         self.cooldown -= time
         self.lockdown -= time
+        self.stopwatch += time
         if self.onoff:
             if self.memoryBuff.is_not_active() and self.endlessBuff.is_not_active():
                 self.gauge = max(self.gauge - 23 * time / 1020, 0)
@@ -90,20 +92,38 @@ class SpectorWrapper(core.BuffSkillWrapper):
                 self.gauge = min(self.gauge + 13 * 1.1 * time / 1020, 1000) # 하이퍼 엑스트라 힐링 적용
 
         if self.gauge <= 0:
-            self.onoff = False
-            self.lockdown = 20000
-            raise ValueError("The Gauge is exhausted. Fix schedule.") # 게이지 고갈시 에러 발생. 고갈을 허용하고 싶으면 제거.
+            self.setExhausted()
         else:
-            onoff = self.schedule(self.gauge)
+            onoff = self.schedule(self.gauge, self.stopwatch)
             if self.onoff != onoff and self.cooldown <= 0:
                 self.onoff = onoff
+                self.stopwatch = 0
                 self.cooldown = 3000
+
+    def setExhausted(self):
+        self.onoff = False
+        self.gauge = 0
+        self.cooldown = 20000
+        self.lockdown = 20000
+        raise ValueError("The Gauge is exhausted. Fix schedule.") # 게이지 고갈시 에러 발생. 고갈을 허용하고 싶으면 제거.
+
+    def advanced(self):
+        self.gauge -= 48
+        if self.gauge <= 0:
+            self.setExhausted()
+        return core.ResultObject(0, core.CharacterModifier(), 0, 0, '잠식-어드밴스드 효과 적용', spec = 'graph control')
+
+    def advancedController(self):
+        task = core.Task(self, self.advanced)
+        return core.TaskHolder(task, name = "정신력 추가 소모")  
 
     def registerSchedule(self, schedule):
         self.schedule = schedule
 
     def setOnoff(self, onoff):
-        self.onoff = onoff
+        if self.onoff != onoff:
+            self.onoff = onoff
+            self.stopwatch = 0
         return self._result_object_cache
     
     def onoffController(self, onoff):
@@ -127,9 +147,12 @@ class JobGenerator(ck.JobGenerator):
 
     def get_ruleset(self):
         ruleset = RuleSet()
-        ruleset.add_rule(ConcurrentRunRule('근원의 기억', '차지 스펠 앰플리피케이션'), RuleSet.BASE)
-        ruleset.add_rule(MutualRule('인피니티 스펠', '근원의 기억'), RuleSet.BASE)
-        ruleset.add_rule(ConcurrentRunRule('매직 서킷 풀드라이브', '인피니티 스펠'), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule('근원의 기억', '인피니티 스펠', lambda x:x.is_cooltime_left(10750, -1)), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('인피니티 스펠', '근원의 기억(버프)'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('매직 서킷 풀드라이브(버프)', '인피니티 스펠'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule("그란디스 여신의 축복(레프)","매직 서킷 풀드라이브(버프)"), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule('영원히 굶주리는 짐승(개시)', '인피니티 스펠', lambda x:x.is_cooltime_left(100000, 1)), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule('끝없는 고통', '인피니티 스펠', lambda x:x.is_cooltime_left(50000, 1)), RuleSet.BASE)
 
         return ruleset
 
@@ -163,13 +186,13 @@ class JobGenerator(ck.JobGenerator):
         연계 시 플레인 차지드라이브 540 → 240ms, 끝나지 않는 흉몽 540 → 180ms
         각각 +30ms 적용해 270ms, 210ms로 적용됨
 
-        스펠 불릿 수동 사용
+        스펠 불릿 자동 사용
         
         하이퍼 : 배틀아츠-리인포스, 보스킬러, 이그노어 가드 / 엑스트라 힐링, 인핸스
         
         5차 중요도 순서
         
-        인피니티스펠 -  근원 - 새어나오는 악몽/흉몽 - 로디드 - 매서풀
+        인피니티스펠 -  영굶짐 - 새악흉 - 근원 - 로디드 - 매서풀
         
         5차 강화 
         
@@ -180,7 +203,6 @@ class JobGenerator(ck.JobGenerator):
         passive_level = chtr.get_base_modifier().passive_level + self.combat
         LINK_DELAY = 30
         BattleArtsHyper = core.CharacterModifier(pdamage=20, boss_pdamage=20, armor_ignore=20)  # 하이퍼 - 배틀아츠 modifier
-        SpellBullet = core.CharacterModifier(pdamage=20)
 
 
         # Buff skills
@@ -193,29 +215,29 @@ class JobGenerator(ck.JobGenerator):
         
         PlainChargeDrive = core.DamageSkill('플레인 차지드라이브', 540, 610 + 3*passive_level, 3, modifier=BattleArtsHyper).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         PlainChargeDrive_Link = core.DamageSkill('플레인 차지드라이브(연계)', 240+LINK_DELAY, 610 + 3*passive_level, 3, modifier=BattleArtsHyper).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
-        PlainSpell = core.DamageSkill("플레인 스펠", 0, 370 + 3*passive_level, 2, modifier=SpellBullet).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        PlainSpell = core.DamageSkill("플레인 스펠", 0, 370 + 3*passive_level, 2).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         PlainBuff = core.BuffSkill("플레인 버프", 0, 60 * 1000, cooltime = -1).wrap(core.BuffSkillWrapper)  # dpm에 영향을 주지 않아 미사용
         
         ScarletChargeDrive = core.DamageSkill("스칼렛 차지드라이브", 540, 350 + 3*passive_level, 3, cooltime = 3000, red=True, modifier=BattleArtsHyper).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         ScarletChargeDrive_Link = core.DamageSkill("스칼렛 차지드라이브(연계)", 510, 350 + 3*passive_level, 3, cooltime = 3000, red=True, modifier=BattleArtsHyper).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         ScarletChargeDrive_After = core.DamageSkill("스칼렛 차지드라이브(후속타)", 0, 350 + 3*passive_level, 3, modifier=BattleArtsHyper).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
-        ScarletSpell = core.DamageSkill("스칼렛 스펠", 0, 220 + passive_level, 5, modifier=SpellBullet).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
+        ScarletSpell = core.DamageSkill("스칼렛 스펠", 0, 220 + passive_level, 5).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         ScarletBuff = core.BuffSkill("스칼렛 버프", 0, 60 * 1000, cooltime = -1, rem=True, att = 30, crit = 20).wrap(core.BuffSkillWrapper)
         
         UnstoppableImpulse_Link = core.DamageSkill("멈출 수 없는 충동(연계)", 540, 435 + 3*passive_level, 5, cooltime = -1, modifier=BattleArtsHyper).setV(vEhc, 7, 2, False).wrap(core.DamageSkillWrapper)
 
         GustChargeDrive_Link = core.DamageSkill("거스트 차지드라이브(연계)", 450, 400 + 3*passive_level, 6, cooltime = 5000, red=True, modifier=BattleArtsHyper).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
-        GustSpell = core.DamageSkill('거스트 스펠', 0, 230 + passive_level, 4, modifier=SpellBullet).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
+        GustSpell = core.DamageSkill('거스트 스펠', 0, 230 + passive_level, 4).setV(vEhc, 5, 2, False).wrap(core.DamageSkillWrapper)
         GustBuff = core.BuffSkill("거스트 버프", 0, 60*1000, cooltime = -1).wrap(core.BuffSkillWrapper) # dpm에 영향을 주지 않아 미사용        
         
         AbyssChargeDrive_Link = core.DamageSkill("어비스 차지드라이브(연계)", 630, 340 + 3*self.combat, 4, cooltime = 9000, red=True, modifier=BattleArtsHyper).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         AbyssChargeDrive_After = core.DamageSkill("어비스 차지드라이브(후속타)", 0, 410 + 3*self.combat, 6, modifier=BattleArtsHyper).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
-        AbyssSpell = core.SummonSkill("어비스 스펠", 0, 300*0.75, 70 + 2*self.combat, 2, 3000, cooltime = -1, modifier=SpellBullet).setV(vEhc, 6, 2, False).wrap(core.SummonSkillWrapper)
-        AbyssBuff = core.BuffSkill("어비스 버프", 0, 60*1000, cooltime = -1, rem=True, pdamage = 20 + floor(self.combat/2), boss_pdamage = 30 + self.combat, armor_ignore = 20 + floor(self.combat/2)).wrap(core.BuffSkillWrapper)
+        AbyssSpell = core.SummonSkill("어비스 스펠", 0, 300*0.75, 70 + 2*self.combat, 2, 3000, cooltime = -1).setV(vEhc, 6, 2, False).wrap(core.SummonSkillWrapper)
+        AbyssBuff = core.BuffSkill("어비스 버프", 0, 60*1000, cooltime = -1, rem=True, pdamage = 20 + self.combat//2, boss_pdamage = 30 + self.combat, armor_ignore = 20 + self.combat//2).wrap(core.BuffSkillWrapper)
 
         
         ##### 스펙터 상태일 때 #####
-        UpcomingDeath = core.DamageSkill("다가오는 죽음", 0, 450 + 3*passive_level, 2).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        UpcomingDeath = core.DamageSkill("다가오는 죽음", 0, 450 + 3*passive_level, 2, cooltime = -1).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         ReturningHateStack = core.StackSkillWrapper(core.BuffSkill("돌아오는 증오(스택)", 0, 99999999), 12)
         ReturningHate = core.StackDamageSkillWrapper(
             core.DamageSkill("돌아오는 증오", 0, 320 + 3*passive_level, 6, cooltime=12000, red=True).setV(vEhc, 0, 2, True),
@@ -240,7 +262,7 @@ class JobGenerator(ck.JobGenerator):
         UncontrollableChaos_Link = core.DamageSkill("걷잡을 수 없는 혼돈(연계)", 720, 440 + 3*self.combat, 12, cooltime = 9000, red=True, modifier=BattleArtsHyper).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
 
         RaptRestriction = core.DamageSkill("황홀한 구속", 690, 600 + 10*self.combat, 6, cooltime = 180 * 1000, red=True, modifier=BattleArtsHyper).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
-        RaptRestrictionSummon = core.SummonSkill("황홀한 구속(소환)", 0, 450, 400 + 10*self.combat, 3, 9000, cooltime = -1, modifier=BattleArtsHyper).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)  #임의주기 300ms, DPM 미사용.
+        RaptRestrictionSummon = core.SummonSkill("황홀한 구속(소환)", 0, 450, 400 + 10*self.combat, 3, 9000, cooltime = -1, modifier=BattleArtsHyper).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
         RaptRestrictionEnd = core.DamageSkill("황홀한 구속(종결)", 0, 1000 + 10*self.combat, 8, cooltime = -1, modifier=BattleArtsHyper).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
         
         Impulse_Connected = MultipleDamageSkillWrapper(core.DamageSkill("충동/본능 연결", 0, 0, 0, cooltime = 6000, red=True, modifier=BattleArtsHyper).setV(vEhc, 7, 2, False), 2, 1500)
@@ -263,12 +285,9 @@ class JobGenerator(ck.JobGenerator):
         #TODO: 템셋을 읽어서 무기별로 다른 수치 적용하도록 만들어야 함.
         WEAPON_ATT = jobutils.get_weapon_att("너클")
         Overdrive = pirates.OverdriveWrapper(vEhc, 5, 5, WEAPON_ATT)
-        MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
+        MirrorSpider, MirrorBreak = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         FloraGoddessBless = flora.FloraGoddessBlessWrapper(vEhc, 0, 0, WEAPON_ATT)
     
-        MagicCircuitFullDrive = core.BuffSkill("매직 서킷 풀드라이브", 720, (30+vEhc.getV(4,3))*1000, pdamage = (20 + vEhc.getV(4,3)), cooltime = 200*1000, red=True).isV(vEhc,4,3).wrap(core.BuffSkillWrapper)
-        MagicCircuitFullDriveStorm = core.DamageSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 500+20*vEhc.getV(4,3), 3, cooltime=4000).wrap(core.DamageSkillWrapper)
-                
         MemoryOfSource = core.DamageSkill("근원의 기억", 0, 0, 0, cooltime = 200 * 1000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         MemoryOfSourceTick = core.DamageSkill("근원의 기억(틱)", 250, 400 + 16 * vEhc.getV(1,1), 6).wrap(core.DamageSkillWrapper)    # 43타
         MemoryOfSourceEnd = core.DamageSkill("근원의 기억(종결)", 0, 1200 + 48 * vEhc.getV(1,1), 12 * 6).wrap(core.DamageSkillWrapper)
@@ -283,16 +302,28 @@ class JobGenerator(ck.JobGenerator):
         ForeverHungryBeastTrigger = core.DamageSkill("영원히 굶주리는 짐승(등장)", 0, 0, 0, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper)
         ForeverHungryBeast = core.DamageSkill("영원히 굶주리는 짐승", 0, 400+16*vEhc.getV(0,0), 12, cooltime=-1).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 20회 반복
 
+        magic_curcuit_full_drive_builder = flora.MagicCircuitFullDriveBuilder(vEhc, 4, 3)
+        for skill in [
+            PlainChargeDrive, PlainChargeDrive_Link, EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, UnstoppableImpulse_Link,
+            PlainSpell, ScarletSpell, GustSpell, AbyssSpell, ReturningHate, # UpcomingDeath
+            EndlessBadDream, EndlessBadDream_Link, UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, TenaciousInstinct_Link,
+            CrawlingFear_Link, RaptRestriction, RaptRestrictionSummon, RaptRestrictionEnd, EndlessPainTick, EndlessPainEnd_Link, 
+            MemoryOfSourceTick, MemoryOfSourceEnd, DeviousNightmare, DeviousDream, ForeverHungryBeast, MirrorBreak
+            ]:
+            magic_curcuit_full_drive_builder.add_trigger(skill)
+        MagicCircuitFullDrive, ManaStorm = magic_curcuit_full_drive_builder.get_skill()
+
+
         ### Skill Wrapper ###
 
-        SpectorState = SpectorWrapper(MemoryOfSourceBuff, EndlessPainBuff)
+        SpecterState = SpecterWrapper(MemoryOfSourceBuff, EndlessPainBuff)
         
         # 기본 연결 설정(스펙터)
         for skill in [UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, TenaciousInstinct_Link]:
             skill.onBefore(EndlessBadDream_Link)
         # 흉몽(스펙터)과 플레인(레프)에서도 연계 가능한 스킬
         for skill in [CrawlingFear_Link, RaptRestriction, EndlessPain, MemoryOfSource]:
-            skill.onBefore(core.OptionalElement(SpectorState.is_active, EndlessBadDream_Link, PlainChargeDrive_Link))
+            skill.onBefore(core.OptionalElement(SpecterState.is_active, EndlessBadDream_Link, PlainChargeDrive_Link))
   
         # 보스 1:1 시 공격 1회 당 다가오는 죽음 1개 생성, 인피니티 스펠 상태 시 강화레벨에 따라 총 3 ~ 4개 생성
         UpcomingDeath_Connected = core.OptionalElement(InfinitySpell.is_active, core.RepeatElement(UpcomingDeath, 3 + vEhc.getV(0,0) // 25), UpcomingDeath)
@@ -323,21 +354,21 @@ class JobGenerator(ck.JobGenerator):
         AbyssChargeDrive_Link.onAfter(AbyssSpell)
         AbyssChargeDrive_Link.onAfter(AbyssChargeDrive_After)
         
-        Impulse_Connected.onAfter(core.OptionalElement(SpectorState.is_active, TenaciousInstinct_Link, UnstoppableImpulse_Link))
+        Impulse_Connected.onAfter(core.OptionalElement(SpecterState.is_active, TenaciousInstinct_Link, UnstoppableImpulse_Link))
 
-        RaptRestriction.onConstraint(core.ConstraintElement("게이지 150 이상", SpectorState, partial(SpectorState.judge, 150, 1)))
-        RaptRestriction.onAfter(SpectorState.onoffController(True))
+        RaptRestriction.onConstraint(core.ConstraintElement("게이지 150 이상", SpecterState, partial(SpecterState.judge, 150, 1)))
+        RaptRestriction.onAfter(SpecterState.onoffController(True))
         RaptRestriction.onAfter(RaptRestrictionSummon)
         RaptRestriction.onAfter(RaptRestrictionEnd.controller(9000))
         
-        EndlessPainRepeat = core.RepeatElement(EndlessPainTick, 15) # TODO: 사용 직후 게이지 1틱 감소
+        EndlessPainRepeat = core.RepeatElement(EndlessPainTick, 15)
         EndlessPainRepeat.onAfter(core.RepeatElement(EndlessPainEnd_Link, 5))
-        EndlessPain.onConstraint(core.ConstraintElement("게이지 150 이상", SpectorState, partial(SpectorState.judge, 150, 1)))
-        EndlessPain.onAfter(SpectorState.onoffController(True))
+        EndlessPain.onConstraint(core.ConstraintElement("게이지 150 이상", SpecterState, partial(SpecterState.judge, 150, 1)))
+        EndlessPain.onAfter(SpecterState.onoffController(True))
         EndlessPain.onAfter(EndlessPainBuff)
         EndlessPain.onAfter(EndlessPainRepeat)
-        
-        MagicCircuitFullDriveStorm.onConstraint(core.ConstraintElement('매서풀 발동조건', MagicCircuitFullDrive, MagicCircuitFullDrive.is_active)) # TODO: flora.py에 있는 빌더 사용해야 함. 트리거하는 스킬 모두 등록해야함 (매우많음)
+        AdditionalConsumption = core.OptionalElement(MemoryOfSourceBuff.is_not_active, SpecterState.advancedController())
+        EndlessPainEnd.onJustAfter(AdditionalConsumption)
 
         # 스펙터 상태 파이널어택류 연계
         for skill in [EndlessBadDream, EndlessBadDream_Link, DeviousDream,
@@ -345,7 +376,7 @@ class JobGenerator(ck.JobGenerator):
             UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, TenaciousInstinct_Link,
             CrawlingFear_Link, EndlessPainTick, EndlessPainEnd, EndlessPainEnd_Link, ForeverHungryBeast]:
             skill.onAfter(UpcomingDeath_Connected)
-        MagicCircuitFullDriveStorm.onAfter(core.OptionalElement(SpectorState.is_active, UpcomingDeath_Connected))
+        ManaStorm.onAfter(core.OptionalElement(SpecterState.is_active, UpcomingDeath_Connected))
         
         # 5차 - 새어나오는 악몽 / 흉몽 연계
         EndlessNightmare_Link.onAfter(core.OptionalElement(DeviousNightmare.is_available, DeviousNightmare))
@@ -366,77 +397,107 @@ class JobGenerator(ck.JobGenerator):
                 skill.onAfter(DeviousDream.reduceCooltime(1000, _id))
 
         # 5차 - 영원히 굶주리는 짐승
-        ForeverHungryBeastInit.onAfter(ForeverHungryBeastTrigger.controller(9000)) # 9초 후 등장 TODO: 기본 9600+1740ms에 스펙터 스킬 적중시마다 시간 줄어들도록 할것
+        ForeverHungryBeastInit.onConstraint(core.ConstraintElement("게이지 250 이상", SpecterState, partial(SpecterState.judge, 250, 1)))
+        ForeverHungryBeastInit.onAfter(SpecterState.onoffController(True))
+        ForeverHungryBeastInit.onAfter(ForeverHungryBeastTrigger.controller(6000)) # 6초 후 등장 TODO: 기본 9600+1740ms에 스펙터 스킬 적중시마다 시간 줄어들도록 할것
         ForeverHungryBeastTrigger.onAfter(core.RepeatElement(ForeverHungryBeast, 20))\
         
         # 기본 공격 : 540ms 중립스킬
         PlainAttack = core.DamageSkill("기본 공격", 0, 0, 0).wrap(core.DamageSkillWrapper)
-        PlainAttack.onAfter(core.OptionalElement(SpectorState.is_active, EndlessBadDream, PlainChargeDrive))
+        PlainAttack.onAfter(core.OptionalElement(SpecterState.is_active, EndlessBadDream, PlainChargeDrive))
         
         # Constraint 추가하기 : 레프 모드
         for skill in [PlainChargeDrive, PlainChargeDrive_Link, ScarletChargeDrive, ScarletChargeDrive_Link,
                 EndlessNightmare_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, UnstoppableImpulse_Link]:
-            skill.onConstraint(core.ConstraintElement("레프 모드", SpectorState, SpectorState.is_not_active))
+            skill.onConstraint(core.ConstraintElement("레프 모드", SpecterState, SpecterState.is_not_active))
         
         # Constraint 추가하기 : 스펙터 모드
         for skill in [EndlessBadDream, UnfulfilledHunger, UncontrollableChaos, ReturningHate,
                 EndlessBadDream_Link, UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, TenaciousInstinct_Link]:
-            skill.onConstraint(core.ConstraintElement("스펙터 모드", SpectorState, SpectorState.is_active))
+            skill.onConstraint(core.ConstraintElement("스펙터 모드", SpecterState, SpecterState.is_active))
 
-        CrawlingFear.onConstraint(core.ConstraintElement("게이지 150 이상", SpectorState, partial(SpectorState.judge, 150, 1)))
-        CrawlingFear_Link.onConstraint(core.ConstraintElement("게이지 150 이상", SpectorState, partial(SpectorState.judge, 150, 1)))
-        CrawlingFear.onAfter(SpectorState.onoffController(True))
-        CrawlingFear_Link.onAfter(SpectorState.onoffController(True)) # TODO: 사용 직후 게이지 1틱 감소
+        CrawlingFear.onConstraint(core.ConstraintElement("게이지 150 이상", SpecterState, partial(SpecterState.judge, 150, 1)))
+        CrawlingFear_Link.onConstraint(core.ConstraintElement("게이지 150 이상", SpecterState, partial(SpecterState.judge, 150, 1)))
+        CrawlingFear.onAfter(SpecterState.onoffController(True))
+        CrawlingFear_Link.onAfter(SpecterState.onoffController(True))
+        CrawlingFear.onJustAfter(AdditionalConsumption)
+        CrawlingFear_Link.onJustAfter(AdditionalConsumption)
 
         MemoryOfSourceRepeat = core.RepeatElement(MemoryOfSourceTick, 43)
         MemoryOfSourceRepeat.onAfter(MemoryOfSourceEnd)
-        MemoryOfSource.onAfter(SpectorState.onoffController(True))
+        MemoryOfSource.onAfter(SpecterState.onoffController(True))
         MemoryOfSource.onAfter(MemoryOfSourceBuff)
         MemoryOfSource.onAfter(MemoryOfSourceRepeat)
 
-        def schedule(gauge):
+        def schedule(gauge, stopwatch):
             """
             스펙터 <-> 레프 상태 스케쥴링을 담당합니다.
             True를 리턴하면 스펙터, False를 리턴하면 레프 상태로 변환합니다.
             """
-            if gauge < 150:
+            if MemoryOfSourceBuff.is_active():
+                return True
+            if ForeverHungryBeastInit.is_available() and gauge < 300:
                 return False
-
+            if ForeverHungryBeastTrigger.is_cooltime_left(6001, -1):
+                return True
+            if ChargeSpellAmplification.is_available() and ChargeSpellAmplification.is_not_active():
+                return False
             if AbyssBuff.is_not_active() and AbyssChargeDrive_Link.is_available():
                 return False
             if ScarletBuff.is_not_active() and ScarletChargeDrive_Link.is_available():
                 return False
 
-            if MemoryOfSourceBuff.is_active():
-                return True
+            # 인피니티 스펠 지속 중일 때 게이지 소모를 우선
             if InfinitySpell.is_active():
+                if gauge <= 200:
+                    return False
+                elif gauge <= 400:
+                    if SpecterState.is_active() and stopwatch >= 4680:  # 스펙터 연계 최장시간 4680ms
+                        return False
+                else:
+                    if SpecterState.is_active() and stopwatch >= 10590:
+                        return False
                 return True
+            # 인피니티 스펠 지속 중이 아닐 때 게이지 회복을 우선
+            else:   
+                if gauge > 900:
+                    return True
+                elif gauge > 800:
+                    if SpecterState.is_not_active() and stopwatch >= 10350: # 레프 연계 최장시간 10350ms
+                        return True
+                else:
+                    if SpecterState.is_not_active() and stopwatch >= 17850:
+                        return True
+                return False
 
-            if gauge > 500:
-                return True
-            
-            return False
-
-        SpectorState.registerSchedule(schedule)
+        SpecterState.registerSchedule(schedule)
 
         ScarletBuff.set_disabled_and_time_left(0) # 스칼렛/어비스 버프가 있는 채로 딜 시작하는 것을 가정함.
         AbyssBuff.set_disabled_and_time_left(0)
 
         DeviousNightmare.protect_from_running()
         DeviousDream.protect_from_running()
+
+        # 인피니티 스펠 지속 중일 때 악몽과 충동의 사용을 제한함
+        EndlessNightmare_Link.onConstraint(core.ConstraintElement("악몽 사용제한", InfinitySpell, 
+            lambda: InfinitySpell.is_not_active() or DeviousNightmare.is_available()))
+        Impulse_Connected.onConstraint(core.ConstraintElement("충동 사용제한", InfinitySpell, 
+            lambda: InfinitySpell.is_not_active() or SpecterState.is_active()))
+
+        # 스펠 불릿 5칸 채울 시(인피니티 스펠) 효과
+        for spell in [PlainSpell, ScarletSpell, GustSpell, AbyssSpell]:
+            spell.add_runtime_modifier(InfinitySpell, lambda sk: core.CharacterModifier(pdamage = 20*sk.is_active()))
         
         return(PlainAttack, 
-                [ContactCaravan, ScarletBuff, AbyssBuff, SpectorState, Booster,
-                    ChargeSpellAmplification, WraithOfGod,
-                    LuckyDice, Overdrive,
-                    MagicCircuitFullDrive, MemoryOfSourceBuff, EndlessPainBuff,
-                    InfinitySpell, FloraGoddessBless,
-                    globalSkill.maple_heros(chtr.level, name = "레프의 용사", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), globalSkill.soul_contract()
-                    ] +\
-                [ForeverHungryBeastInit, ForeverHungryBeastTrigger, EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, 
-                    CrawlingFear_Link, MemoryOfSource, EndlessPain, RaptRestriction, ReturningHate, Impulse_Connected,
-                    UncurableHurt_Link, UnfulfilledHunger_Link, UncontrollableChaos_Link, 
-                    AbyssSpell, RaptRestrictionSummon, RaptRestrictionEnd, DeviousNightmare, DeviousDream, MirrorBreak, MirrorSpider
-                    ] +\
-                [MagicCircuitFullDriveStorm] +\
+                [globalSkill.maple_heros(chtr.level, name = "레프의 용사", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
+                    ContactCaravan, Booster, LuckyDice, ScarletBuff, AbyssBuff, SpecterState, 
+                    ChargeSpellAmplification, WraithOfGod, InfinitySpell, MagicCircuitFullDrive, FloraGoddessBless, Overdrive, 
+                    MemoryOfSourceBuff, EndlessPainBuff,
+                    globalSkill.soul_contract()] +\
+                [MemoryOfSource, RaptRestriction, RaptRestrictionEnd, UpcomingDeath, ReturningHate,
+                    ForeverHungryBeastInit, ForeverHungryBeastTrigger, CrawlingFear_Link, EndlessPain, 
+                    EndlessNightmare_Link, ScarletChargeDrive_Link, GustChargeDrive_Link, AbyssChargeDrive_Link, 
+                    UncurableHurt_Link, UnfulfilledHunger_Link, Impulse_Connected, UncontrollableChaos_Link, 
+                    AbyssSpell, RaptRestrictionSummon, DeviousNightmare, DeviousDream, MirrorBreak, MirrorSpider] +\
+                [ManaStorm] +\
                 [PlainAttack])

--- a/dpmModule/jobs/ark.py
+++ b/dpmModule/jobs/ark.py
@@ -363,6 +363,7 @@ class JobGenerator(ck.JobGenerator):
         ScarletChargeDrive.onAfter(ScarletSpell)
         ScarletChargeDrive_Link.onAfter(ScarletSpell)      
         ScarletChargeDrive.onAfter(ScarletChargeDrive_After)
+        ScarletChargeDrive_Link.onAfter(ScarletChargeDrive_After)
 
         GustChargeDrive_Link.onAfter(GustSpell)
         

--- a/dpmModule/jobs/jobclass/flora.py
+++ b/dpmModule/jobs/jobclass/flora.py
@@ -10,10 +10,10 @@ def FloraGoddessBlessWrapper(vEhc, num1, num2, WEAPON_ATT):
     FloraGoddessBless = core.BuffSkill("그란디스 여신의 축복(레프)", 480, 40*1000, att = 10 + 3 * vEhc.getV(num1, num2) + 1.5 * WEAPON_ATT, cooltime = 240*1000, red=True).isV(vEhc, num1, num2).wrap(core.BuffSkillWrapper)
     return FloraGoddessBless
 
+# 마나 최대치 유지 가정, 비율에 따라 수치가 어떻게 변동되는지 확인 필요
+# 마력 폭풍 발생 시 데미지 증가량 갱신 미적용중
 class MagicCircuitFullDriveBuilder():
     def __init__(self, vEhc, num1, num2, mana = 100):
-        # 마나 최대치 유지 가정, 비율에 따라 수치가 어떻게 변동되는지 확인 필요
-        # 마력 폭풍 발생 시 데미지 증가량 갱신 미적용중
         self.MANA = mana
         self.MagicCircuitFullDriveBuff = core.BuffSkill("매직 서킷 풀드라이브(버프)", 540, (30+vEhc.getV(num1, num2))*1000, cooltime=200*1000, red=True, pdamage=(20+vEhc.getV(num1, num2)) * (self.MANA/100)).wrap(core.BuffSkillWrapper)
         self.ManaStorm = core.DamageSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 500+20*vEhc.getV(num1, num2), 3, cooltime = 4000).wrap(core.DamageSkillWrapper)
@@ -25,10 +25,3 @@ class MagicCircuitFullDriveBuilder():
 
     def get_skill(self):
         return self.MagicCircuitFullDriveBuff, self.ManaStorm
-
-'''
-매직 서킷 풀드라이브
-최대 MP의 15% 소비, 55초[(스킬 레벨+30)초] 동안 현재 MP의 비율에 따라 데미지 최대 45%[(스킬 레벨+20)%]까지 증가, 마력 폭풍 발생 시 데미지 증가량 갱신
-공격 스킬 사용 시 4초마다 MP를 150 추가 소모하고 최대 6명의 적을 1000%의[(스킬 레벨*20+500)%의 데미지] 데미지로 3번 공격하는 마력 폭풍 발생
-재사용 대기시간 200초
-'''


### PR DESCRIPTION
#439 와 그 외 이것저것 수정안입니다.


1. 매직 서킷 풀드라이브 수정
    - #415의 코드를 가져왔습니다
    - 다른 공격스킬과 발동시간이 겹치는 사출기들도 나중에 사출기의 생성-타격 사이의 딜레이가 반영된다면 결과가 달라질 것 같아서 일단은 포함시켜놓았는데, 죽음은 매서풀과 서로를 참조하게 돼서 빠진 상태입니다.

2. 근원의 기억 딜레이 수정

3. generate가 리턴할 리스트 순서 임시로 조정

4. 기어 다니는 공포, 끝없는 고통 사용 시 게이지 추가 소모 반영
    - 근원버프가 없는 상태에서 사용 시 게이지 -48(약 2틱), 잠식-어드밴스드 적용 오류로 추정

5. 스펠 불릿 modifier 변경
    - 스펠 불릿 자동사용을 가정하여 인피 때에만 스펠에 뎀20을 적용

6. 인피니티 스펠 지속 중에 일부 연계스킬 제한
    - 레프 모드에서 충동 사용금지, 스펙터 모드의 본능은 사용됨
    - 끝나지 않는 악몽은 새어 나오는 악몽을 같이 사용할 수 있을 때에만 사용가능

7. schedule 조정
    - 비연계시간을 줄이기 위해 변신을 바꾼 후 너무 오래 그 상태를 유지하면 다른 상태로 잠깐씩 변경
    - 영굶짐 발동대기시간 동안 스펙터 상태를 유지할 수 있도록 조정
    - 인피on때 스펙터를 오래 유지해서 100쯤까지 내려가고, 인피off때 레프를 오래 유지해서 8~900까지 올라감

8. rule 조정
    - 스킬들을 차지앰플(하이퍼스킬)에 맞추지 않음
    - 인피가 곧 돌아온다면 그때까지 고통과 영굶짐을 아낌
    - 그축이 다른 규칙걸린 스킬보다 미리 사용되는 것을 방지

- spector → specter