### PR TITLE
KMS 1.2.340

### DIFF
--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -188,7 +188,7 @@ class JobGenerator(ck.JobGenerator):
             lambda order: max(order.get_stack() * 0.8 - 1, 0)
         )
 
-        Marker = core.DamageSkill('마커', 690, 1000, 3*2, cooltime=60*1000, modifier=core.CharacterModifier(pdamage_indep=300)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) # 최종뎀 300% 증가, 임의위치 조각 5개, 1히트, 결정 5개, 생성/파쇄 각각 공격, 클라공속 900ms
+        Marker = core.DamageSkill('마커', 690, 500, 6*2, cooltime=60*1000, modifier=core.CharacterModifier(pdamage_indep=300)).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper) # 최종뎀 300% 증가, 임의위치 조각 5개, 1히트, 결정 5개, 생성/파쇄 각각 공격, 클라공속 900ms
         Scool = core.DamageSkill('스콜', 690, 1000, 12, cooltime=180*1000).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper) #바인드. 클라공속 900ms
         WraithOfGod = core.BuffSkill("레이스 오브 갓", 0, 60*1000, pdamage = 10, cooltime = 120 * 1000).wrap(core.BuffSkillWrapper)
 

--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -124,7 +124,7 @@ class JobGenerator(ck.JobGenerator):
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         NovaGoddessBless = nova.NovaGoddessBlessWrapper(vEhc, 0, 0)
     
-        EnergyBurst = core.DamageSkill("에너지 버스트", 900, (600+20*vEhc.getV(4,4)) * 3, 12, red = True, cooltime = 120 * 1000).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
+        EnergyBurst = core.DamageSkill("에너지 버스트", 900, (450+18*vEhc.getV(4,4)) * 3, 15, red = True, cooltime = 120 * 1000).isV(vEhc,4,4).wrap(core.DamageSkillWrapper)
         
         SpotLight = core.SummonSkill("스포트라이트", 990, 800, 400+16*vEhc.getV(0,0), 3 * SPOTLIGHTHIT, 30000, cooltime = 120 * 1000, red=True).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
         SpotLightBuff = core.BuffSkill("스포트라이트(버프)", 0, 30000, cooltime = -1, crit = (10+int(0.2*vEhc.getV(0,0)))*SPOTLIGHTHIT,

--- a/dpmModule/jobs/aran.py
+++ b/dpmModule/jobs/aran.py
@@ -125,7 +125,7 @@ class JobGenerator(ck.JobGenerator):
         AdrenalineBeyonderWave = core.DamageSkill("비욘더(파동)", 0, 400, 5).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
 
         BoostEndHuntersTargetingHolder = core.DamageSkill("부스트 엔드-헌터즈 타겟팅(홀더)", BOOST_END_HUNTERS_TARGETING_DELAY, 0, 0, cooltime=-1).wrap(core.DamageSkillWrapper)
-        BoostEndHuntersTargeting = core.DamageSkill("부스트 엔드-헌터즈 타겟팅", 0, 1500 + 15 * self.combat + (20 + passive_level), 15, cooltime=-1).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
+        BoostEndHuntersTargeting = core.DamageSkill("부스트 엔드-헌터즈 타겟팅", 0, 1070 + 10 * self.combat + (20 + passive_level), 15, cooltime=-1).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)
 
         AdrenalineGenerator = core.BuffSkill("아드레날린 제네레이터", ADRENALINE_GENERATOR_DELAY, 0, cooltime=240*1000).wrap(core.BuffSkillWrapper)
         MahaRegion = core.SummonSkill("마하의 영역", 600, 1000, 500, 3, 10*1000, cooltime=150*1000).wrap(core.SummonSkillWrapper) # 게더링캐쳐 캔슬 : 1680 -> 600
@@ -159,7 +159,7 @@ class JobGenerator(ck.JobGenerator):
         Combo.set_name_style("콤보 %d만큼 증가")
 
         # 헌터즈 타게팅
-        BoostEndHuntersTargetingHolder.onAfter(core.RepeatElement(BoostEndHuntersTargeting, 5))
+        BoostEndHuntersTargetingHolder.onAfter(core.RepeatElement(BoostEndHuntersTargeting, 7))
 
         # 인스톨 마하
         InstallMaha.onAfter(InstallMahaBlizzard)

--- a/dpmModule/jobs/archmageFb.py
+++ b/dpmModule/jobs/archmageFb.py
@@ -111,7 +111,7 @@ class JobGenerator(ck.JobGenerator):
         
         # Summoning Skills
         Ifritt = core.SummonSkill("이프리트", 600, 3030, 150+2*self.combat, 3, (260+5*self.combat)*1000).setV(vEhc, 6, 2, False).wrap(core.SummonSkillWrapper)
-        FireAura = core.SummonSkill("파이어 오라", 0, 3000, 400, 2, 999999999).setV(vEhc, 4, 2, True).wrap(core.SummonSkillWrapper)
+        FireAura = core.SummonSkill("파이어 오라", 0, 3000, 400, 2, 999999999, modifier = core.CharacterModifier(pdamage = -50)).setV(vEhc, 4, 2, True).wrap(core.SummonSkillWrapper)
         FuryOfIfritt = core.SummonSkill("퓨리 오브 이프리트", 360, 6000/25, 200+8*vEhc.getV(3,2), 6, 6*1000-1, cooltime = 75000, red = True).isV(vEhc,2,1).wrap(core.SummonSkillWrapper)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         

--- a/dpmModule/jobs/cannonshooter.py
+++ b/dpmModule/jobs/cannonshooter.py
@@ -55,7 +55,7 @@ class JobGenerator(ck.JobGenerator):
         버스터-서포트-다수기-롤캐
         '''
         COCOBALLHIT = 27
-        ICBMHIT = 4
+        ICBMHIT = 6
         passive_level = chtr.get_base_modifier().passive_level + self.combat
         
         #Buff skills
@@ -95,7 +95,7 @@ class JobGenerator(ck.JobGenerator):
         BFGCannonball = core.SummonSkill("빅 휴즈 기간틱 캐논볼", 600, 210, (450+15*vEhc.getV(0,0)) * 0.45, 4 * 3, 210*COCOBALLHIT, cooltime = 25000).isV(vEhc,0,0).wrap(core.SummonSkillWrapper)
 
 
-        ICBM = core.DamageSkill("ICBM", 1140, (1200+48*vEhc.getV(1,1)) * 0.45, 5*ICBMHIT * 3, cooltime = 30000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
+        ICBM = core.DamageSkill("ICBM", 1140, (800+32*vEhc.getV(1,1)) * 0.45, 5*ICBMHIT * 3, cooltime = 30000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)
         ICBMDOT = core.SummonSkill("ICBM(장판)", 0, 15000/27, (500+20*vEhc.getV(1,1)) * 0.45, 1 * 3, 15000, cooltime = -1).isV(vEhc,1,1).wrap(core.SummonSkillWrapper) #27타
     
         SpecialMonkeyEscort_Canon = core.SummonSkill("스페셜 몽키 에스코트", 780, int(45000 / 97), 300+12*vEhc.getV(2,2), 4, (30+int(0.5*vEhc.getV(2,2)))*1000 - 1500, cooltime = 120000, red=True).isV(vEhc,2,2).wrap(core.SummonSkillWrapper)

--- a/dpmModule/jobs/hoyoung.py
+++ b/dpmModule/jobs/hoyoung.py
@@ -167,7 +167,7 @@ class JobGenerator(ck.JobGenerator):
         
         # 벞지 & 소환수 지속시간 둘다 적용
         Talisman_Clone = core.BuffSkill("환영 분신부", 900, 200*1000, rem=True).wrap(PausableBuffSkillWrapper)
-        Talisman_Clone_Attack = core.DamageSkill("환영 분신부(공격)", 0, 60 + 120 + 220 + 5*passive_level, 4 * 3, cooltime = 1500).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        Talisman_Clone_Attack = core.DamageSkill("환영 분신부(공격)", 0, 60 + 60 + 110 + 2*passive_level, 4 * 3, cooltime = 1500).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         Talisman_Clone_Attack_Opt = core.OptionalElement(lambda : Talisman_Clone.is_active() and Talisman_Clone_Attack.is_available(), Talisman_Clone_Attack)
         Talisman_Clone_Attack.protect_from_running()
 
@@ -230,7 +230,7 @@ class JobGenerator(ck.JobGenerator):
         # 환영 분신부를 대체하는 스킬 (알고리즘 구현 필요)
         # 환영 분신부 지속중에만 사용가능, 발동 중에는 환영 분신부의 지속시간이 감소하지 않음
         Clone_Rampage = core.BuffSkill("선기 : 극대 분신난무", 900, 30*1000, cooltime = 200*1000, red=True).wrap(core.BuffSkillWrapper)
-        Clone_Rampage_Attack = core.DamageSkill("선기 : 극대 분신난무(공격)", 0, 60 + 120 + 220 + 5*passive_level + 200 + vEhc.getV(0, 0) * 8, 4 * 12, cooltime = 1500).setV(vEhc, 0, 2, True).isV(vEhc, 0, 0).wrap(core.DamageSkillWrapper)
+        Clone_Rampage_Attack = core.DamageSkill("선기 : 극대 분신난무(공격)", 0, 60 + 60 + 110 + 2*passive_level + 200 + vEhc.getV(0, 0) * 8, 4 * 12, cooltime = 1500).setV(vEhc, 0, 2, True).isV(vEhc, 0, 0).wrap(core.DamageSkillWrapper)
 
         Clone_Rampage_Attack_Opt = core.OptionalElement(lambda : Clone_Rampage.is_active() and Clone_Rampage_Attack.is_available(), Clone_Rampage_Attack)
         Clone_Rampage_Attack.protect_from_running()

--- a/dpmModule/jobs/hoyoung.py
+++ b/dpmModule/jobs/hoyoung.py
@@ -167,7 +167,7 @@ class JobGenerator(ck.JobGenerator):
         
         # 벞지 & 소환수 지속시간 둘다 적용
         Talisman_Clone = core.BuffSkill("환영 분신부", 900, 200*1000, rem=True).wrap(PausableBuffSkillWrapper)
-        Talisman_Clone_Attack = core.DamageSkill("환영 분신부(공격)", 0, 460 + 5*passive_level, 2 * 3, cooltime = 1500).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
+        Talisman_Clone_Attack = core.DamageSkill("환영 분신부(공격)", 0, 60 + 120 + 220 + 5*passive_level, 4 * 3, cooltime = 1500).setV(vEhc, 0, 2, True).wrap(core.DamageSkillWrapper)
         Talisman_Clone_Attack_Opt = core.OptionalElement(lambda : Talisman_Clone.is_active() and Talisman_Clone_Attack.is_available(), Talisman_Clone_Attack)
         Talisman_Clone_Attack.protect_from_running()
 
@@ -230,7 +230,7 @@ class JobGenerator(ck.JobGenerator):
         # 환영 분신부를 대체하는 스킬 (알고리즘 구현 필요)
         # 환영 분신부 지속중에만 사용가능, 발동 중에는 환영 분신부의 지속시간이 감소하지 않음
         Clone_Rampage = core.BuffSkill("선기 : 극대 분신난무", 900, 30*1000, cooltime = 200*1000, red=True).wrap(core.BuffSkillWrapper)
-        Clone_Rampage_Attack = core.DamageSkill("선기 : 극대 분신난무(공격)", 0, 460 + 5*passive_level + 400 + vEhc.getV(0, 0) * 16, 2 * 12, cooltime = 1500).setV(vEhc, 0, 2, True).isV(vEhc, 0, 0).wrap(core.DamageSkillWrapper)
+        Clone_Rampage_Attack = core.DamageSkill("선기 : 극대 분신난무(공격)", 0, 60 + 120 + 220 + 5*passive_level + 200 + vEhc.getV(0, 0) * 8, 4 * 12, cooltime = 1500).setV(vEhc, 0, 2, True).isV(vEhc, 0, 0).wrap(core.DamageSkillWrapper)
 
         Clone_Rampage_Attack_Opt = core.OptionalElement(lambda : Clone_Rampage.is_active() and Clone_Rampage_Attack.is_available(), Clone_Rampage_Attack)
         Clone_Rampage_Attack.protect_from_running()

--- a/dpmModule/jobs/ilium.py
+++ b/dpmModule/jobs/ilium.py
@@ -212,7 +212,7 @@ class JobGenerator(ck.JobGenerator):
         #5차 스킬들
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         FloraGoddessBless = flora.FloraGoddessBlessWrapper(vEhc, 0, 0, jobutils.get_weapon_att("건틀렛"))
-        GramHolder = GramHolderWrapper(core.SummonSkill("그람홀더", 210, 3000, 1000+25*vEhc.getV(4,3), 6, 40000, cooltime = 180000).isV(vEhc,4,3))
+        GramHolder = GramHolderWrapper(core.SummonSkill("그람홀더", 210, 3000, 500+20*vEhc.getV(4,3), 12, 40000, cooltime = 180000).isV(vEhc,4,3))
         
         MagicCircuitFullDrive = core.BuffSkill("매직 서킷 풀드라이브", 720, (30+vEhc.getV(3,2))*1000, pdamage = (20 + vEhc.getV(3,2)), cooltime = 200*1000).isV(vEhc,3,2).wrap(core.BuffSkillWrapper)
         MagicCircuitFullDriveStorm = core.SummonSkill("매직 서킷 풀드라이브(마력 폭풍)", 0, 4000, 500+20*vEhc.getV(3,2), 3, (30+vEhc.getV(3,2))*1000, cooltime = -1).wrap(core.SummonSkillWrapper)

--- a/dpmModule/jobs/shadower.py
+++ b/dpmModule/jobs/shadower.py
@@ -118,7 +118,7 @@ class JobGenerator(ck.JobGenerator):
         ReadyToDie = thieves.ReadyToDieWrapper(vEhc, 2, 2)
         MirrorBreak, MirrorSpider = globalSkill.SpiderInMirrorBuilder(vEhc, 0, 0)
         
-        Eviscerate = core.DamageSkill("절개", 570, 1900+76*vEhc.getV(0,0), 7, modifier = core.CharacterModifier(crit=100, armor_ignore=100), cooltime = 14000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 720ms - 150ms(암살 2타연계)
+        Eviscerate = core.DamageSkill("절개", 570, 475+19*vEhc.getV(0,0), 7*4, modifier = core.CharacterModifier(crit=100, armor_ignore=100), cooltime = 14000, red=True).isV(vEhc,0,0).wrap(core.DamageSkillWrapper) # 720ms - 150ms(암살 2타연계)
 		
 		# 1.2.324 패치 적용
         SonicBlow = core.DamageSkill("소닉 블로우", 900, 0, 0, cooltime = 80 * 1000, red=True).isV(vEhc,1,1).wrap(core.DamageSkillWrapper)


### PR DESCRIPTION
* 아크메이지(불, 독)의 엘리먼트 앰플리피케이션에 현행 로직과 동일하게 파이어 오라에는 적용되지 않는다는 설명이 추가됩니다.
  * 앰플이 패시브로 적용되어 있어 파이어 오라에서 앰플 상승치를 뺐습니다.
* 섀도어의 암살에서 연계한 절개가 25레벨 기준 공격 발생 횟수가 1회에서 4회로 증가되고 데미지가 3800%에서 950%로 감소됩니다.
* 캐논슈터의 ICBM가 25레벨 기준 공격 발생 횟수가 4회에서 6회로 증가되고 데미지가 2400%에서 1600%로 감소됩니다. 준비 동작의 무적 시간이 공격 속도에 영향을 받는 현상, 사용 즉시 맵을 이동할 경우 이동한 맵에 오염 지역이 생성되는 현상이 수정됩니다.
* 아란의 부스트 엔드-헌터즈 타겟팅이 마스터 기준 공격 발생 횟수가 5회에서 7회로 증가되고 데미지가 1500%에서 1070%로 감소됩니다. 사용 중 맵을 이동할 경우 가끔 클라이언트가 종료되는 현상, MP가 공격 발생 횟수에 비례해 소모되는 현상, 다른 캐릭터에게 폴암 이펙트 위치가 다르게 보이는 현상, 최대 HP가 가장 높은 적을 우선 공격하지 않는 현상이 수정됩니다.
* 엔젤릭버스터의 에너지 버스터가 25레벨 기준 공격 횟수가 12회에서 15회로 증가되고 데미지가 1100%에서 900%로 감소됩니다.
* 아델의 마커 공격 횟수가 3회에서 6회로 증가되고 데미지가 1000%에서 500%로 감소됩니다.
* 일리움의 그람홀더가 25레벨 기준 공격 횟수가 6회에서 12회로 증가되고 데미지가 2000%에서 1000%로 감소됩니다.
  * 본섭 기준 `1000+40n%`인데 코드상에는 `1000+25n%`로 돼있네요. 
* 호영의 환영분신부가 마스터 기준 공격 횟수가 2회에서 4회로 증가되고 데미지가 120%에서 60%로 감소됩니다.
* 호영의 선기 : 극대 분신난무의 환영분신부 데미지 증가량이 25레벨 기준 800%p에서 400%p로 감소되고 자쿰 혹은 우르스를 공격했을 때 가끔 이미지가 비정상적으로 보이는 현상이 수정됩니다.