### PR TITLE
팬텀 코드 가독성 개선, 스틸스킬 옵션 추가

### DIFF
--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -67,17 +67,17 @@ class JobGenerator(ck.JobGenerator):
         STEALSKILL = core.CharacterModifier(pdamage_indep = 100*((1.2 / 1.3)-1))
 
         # 1차
-        CardinalDischarge = core.DamageSkill("카디널 디스차지(탤팬1)", 210, 90, 4).setV(vEhc, 0, 7, True).wrap(core.DamageSkillWrapper)
+        CardinalDischarge = core.DamageSkill("카디널 디스차지(탤팬1)", 210, 90, 4, modifier = STEALSKILL).setV(vEhc, 0, 7, True).wrap(core.DamageSkillWrapper)
 
         # 2차
         # 힐+마오팬보다 분노가 허수아비딜은 잘나옴
         Fury = core.BuffSkill("분노(탤팬2)", 0, 180000, rem = True, att = 30).wrap(core.BuffSkillWrapper)
         Heal = core.BuffSkill("힐(탤팬2)", 450, 2*1000, cooltime=10*1000, pdamage_indep=10).wrap(core.BuffSkillWrapper)
-        CardinalBlast = core.DamageSkill("카디널 블래스트(탤팬2)", 240, 200, 4).setV(vEhc, 1, 5, False).wrap(core.DamageSkillWrapper) # 210~270ms 랜덤 (1.2.338 기준 측정), 최종뎀 단리적용
+        CardinalBlast = core.DamageSkill("카디널 블래스트(탤팬2)", 240, 200, 4, modifier = STEALSKILL).setV(vEhc, 1, 5, False).wrap(core.DamageSkillWrapper) # 210~270ms 랜덤 (1.2.338 기준 측정), 최종뎀 단리적용
 
         # 3차
         CrossoverChain = core.BuffSkill("크로스 오버 체인(탤팬3)", 0, 180000, rem = True, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
-        ArrowFlatter = core.SummonSkill("애로우 플래터(탤팬3)", 600, 210, 85, 1, 30 * 1000).setV(vEhc, 4, 3, False).wrap(core.SummonSkillWrapper) # 딜레이 모름
+        ArrowFlatter = core.SummonSkill("애로우 플래터(탤팬3)", 600, 210, 85, 1, 30 * 1000, modifier = STEALSKILL).setV(vEhc, 4, 3, False).wrap(core.SummonSkillWrapper) # 딜레이 모름
         
         # 4차
         FinalCut = core.DamageSkill("파이널 컷(탤팬4)", 450, 2000 + 20 * self.combat, 1, modifier = STEALSKILL, cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -30,9 +30,7 @@ class JobGenerator(ck.JobGenerator):
     
         ReadyToDiePassive = thieves.ReadyToDiePassiveWrapper(vEhc, 3, 3)
 
-        return [
-                            HighDexterity, LuckMonopoly, LuckOfPhantomtheif, MoonLight, AcuteSence, CainExpert,
-                                ReadyToDiePassive]
+        return [HighDexterity, LuckMonopoly, LuckOfPhantomtheif, MoonLight, AcuteSence, CainExpert, ReadyToDiePassive]
                                 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter):
         passive_level = chtr.get_base_modifier().passive_level + self.combat
@@ -62,15 +60,34 @@ class JobGenerator(ck.JobGenerator):
         템페스트 오브 카드 사용하지 않음
         '''
         passive_level = chtr.get_base_modifier().passive_level + self.combat
+
+        ##### Steal skills #####
+
+        # 훔친 스킬은 공격력에 패널티가 있습니다.
         STEALSKILL = core.CharacterModifier(pdamage_indep = 100*((1.2 / 1.3)-1))
-        #Buff skills
-        TalentOfPhantomII = core.BuffSkill("분노(탤팬2)", 0, 180000, rem = True, att = 30).wrap(core.BuffSkillWrapper)
+
+        # 1차
+        CardinalDischarge = core.DamageSkill("카디널 디스차지(탤팬1)", 210, 90, 4).setV(vEhc, 0, 7, True).wrap(core.DamageSkillWrapper)
+
+        # 2차
         # 힐+마오팬보다 분노가 허수아비딜은 잘나옴
-        # TalentOfPhantomII = core.BuffSkill("힐(탤팬2)", 450, 2*1000, cooltime=10*1000, pdamage_indep=10).wrap(core.BuffSkillWrapper)
-        TalentOfPhantomIII = core.BuffSkill("크로스 오버 체인(탤팬3)", 0, 180000, rem = True, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
-        FinalCut = core.DamageSkill("탤런트 오브 팬텀시프 IV(파이널 컷)", 450, 2000 + 20 * self.combat, 1, modifier = STEALSKILL, cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
-        FinalCutBuff = core.BuffSkill("파이널 컷(버프, 탤팬4)", 0, 60000, cooltime = -1, rem = True, pdamage_indep = 40 + self.combat).wrap(core.BuffSkillWrapper)
-        BoolsEye = core.BuffSkill("불스아이(탤팬5)", 960, 30 * 1000, cooltime = 180 * 1000, crit = 20, crit_damage = 10, armor_ignore = 20, pdamage = 20).wrap(core.BuffSkillWrapper)
+        Fury = core.BuffSkill("분노(탤팬2)", 0, 180000, rem = True, att = 30).wrap(core.BuffSkillWrapper)
+        Heal = core.BuffSkill("힐(탤팬2)", 450, 2*1000, cooltime=10*1000, pdamage_indep=10).wrap(core.BuffSkillWrapper)
+        CardinalBlast = core.DamageSkill("카디널 블래스트(탤팬2)", 240, 200, 4).setV(vEhc, 1, 5, False).wrap(core.DamageSkillWrapper) # 210~270ms 랜덤 (1.2.338 기준 측정), 최종뎀 단리적용
+
+        # 3차
+        CrossoverChain = core.BuffSkill("크로스 오버 체인(탤팬3)", 0, 180000, rem = True, pdamage_indep = 20).wrap(core.BuffSkillWrapper)
+        ArrowFlatter = core.SummonSkill("애로우 플래터(탤팬3)", 600, 210, 85, 1, 30 * 1000).setV(vEhc, 4, 3, False).wrap(core.SummonSkillWrapper) # 딜레이 모름
+        
+        # 4차
+        FinalCut = core.DamageSkill("파이널 컷(탤팬4)", 450, 2000 + 20 * self.combat, 1, modifier = STEALSKILL, cooltime = 90000, red=True).setV(vEhc, 3, 2, True).wrap(core.DamageSkillWrapper)
+        FinalCutBuff = core.BuffSkill("파이널 컷(탤팬4)(버프)", 0, 60000, cooltime = -1, rem = True, pdamage_indep = 40 + self.combat).wrap(core.BuffSkillWrapper)
+        
+        # 하이퍼
+        BoolsEye = core.BuffSkill("불스아이(탤팬H)", 960, 30 * 1000, cooltime = 180 * 1000, crit = 20, crit_damage = 10, armor_ignore = 20, pdamage = 20).wrap(core.BuffSkillWrapper)
+        Preparation = core.BuffSkill("프리퍼레이션(탤팬H)", 900, 30 * 1000, cooltime = 120 * 1000, att = 50, boss_pdamage = 20).wrap(core.BuffSkillWrapper)
+
+        #Buff skills
     
         JudgementBuff = core.BuffSkill("저지먼트(버프)", 0, 999999999, crit = 0).wrap(core.BuffSkillWrapper)    #확률성 크리티컬
         
@@ -154,7 +171,7 @@ class JobGenerator(ck.JobGenerator):
         
         return(BasicAttackWrapper,
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
-                    TalentOfPhantomII, TalentOfPhantomIII, FinalCutBuff, globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), BoolsEye,
+                    Fury, CrossoverChain, FinalCutBuff, globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), BoolsEye,
                     JudgementBuff, Booster, PrieredAria, HerosOath, ReadyToDie, JokerBuff,
                     globalSkill.soul_contract()] +\
                 [FinalCut, JokerInit, MarkOfPhantom, LiftBreak, BlackJackFinal] +\

--- a/dpmModule/jobs/phantom.py
+++ b/dpmModule/jobs/phantom.py
@@ -87,6 +87,8 @@ class JobGenerator(ck.JobGenerator):
         BoolsEye = core.BuffSkill("불스아이(탤팬H)", 960, 30 * 1000, cooltime = 180 * 1000, crit = 20, crit_damage = 10, armor_ignore = 20, pdamage = 20).wrap(core.BuffSkillWrapper)
         Preparation = core.BuffSkill("프리퍼레이션(탤팬H)", 900, 30 * 1000, cooltime = 120 * 1000, att = 50, boss_pdamage = 20).wrap(core.BuffSkillWrapper)
 
+        ##### Phantom skills #####
+
         #Buff skills
     
         JudgementBuff = core.BuffSkill("저지먼트(버프)", 0, 999999999, crit = 0).wrap(core.BuffSkillWrapper)    #확률성 크리티컬
@@ -168,6 +170,16 @@ class JobGenerator(ck.JobGenerator):
         MileAiguillesInit.protect_from_running()
         
         #이들 정보교환 부분을 굳이 Task exchange로 표현할 필요가 있을까?
+
+        CardinalBlast.onAfter(CarteNoir)
+        CardinalDischarge.onAfter(CarteNoir)
+
+        CardinalBlast.onAfter(CardinalDischarge)
+        
+        '''
+        얼드: BasicAttackWrapper
+        블디: CardinalBlast
+        '''
         
         return(BasicAttackWrapper,
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),


### PR DESCRIPTION
1. 패시브 스킬 리턴문의 불필요한 공백을 제거했습니다.
2. 추후에 사용될 가능성이 있는 스틸 스킬들을 미리 등록했습니다. 변수명을 원래 이름으로 변경했습니다.