### PR TITLE
fix(zero): 알파 콤보 변경

### DIFF
--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -122,13 +122,9 @@ class JobGenerator(ck.JobGenerator):
         PierceStrike = core.DamageSkill("피어스 쓰러스트", 510, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         PierceStrikeTAG = core.DamageSkill("피어스 쓰러스트(태그)", 0, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
-        '''
-        미사용 스킬
-
-        TODO: 쉐스 검기 항상 알파스펙인지 확인할 것
-        ShadowStrike = core.DamageSkill("쉐도우 스트라이크", 510, 195, 8).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        ShadowStrike = core.DamageSkill("쉐도우 스트라이크", 240+90, 195, 8).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         ShadowStrikeAura = core.DamageSkill("쉐도우 스트라이크(오라)", 0, 310, 1).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
-        '''
+
         FlashAssault = core.DamageSkill("플래시 어썰터", 270, 165, 8).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
         FlashAssaultTAG = core.DamageSkill("플래시 어썰터(태그)", 0, 165, 8).setV(vEhc, 6, 2, False).wrap(core.DamageSkillWrapper)
 
@@ -244,6 +240,8 @@ class JobGenerator(ck.JobGenerator):
         ######   Skill Wrapper   ######
         ### 스킬 연결 ###
         ### 알파 ###
+        ShadowStrike.onAfter(ShadowStrikeAura)
+
         AdvancedSpinCutter.onAfter(AdvancedSpinCutterAura)
         AdvancedSpinCutterTAG.onAfter(AdvancedSpinCutterAuraTAG)
         
@@ -281,11 +279,21 @@ class JobGenerator(ck.JobGenerator):
         
         ### 어파스 생성
         # 윈커(0ms) - 윈스(420ms) - 스톰(900ms) - 문스(1590ms) - 피어싱(1920ms) - 문스(2430ms) - 피어싱(2760ms) - 3270ms
-        # 기가(0ms) -       점핑(690ms) -   어스(1260ms) - 어퍼 씹힘 -   어파스(2340ms)   어퍼, 어파스 씹힘  - 2970ms
-        AlphaCombo = [SetAlpha, WindCutter, GigaCrashTAG, WindStrike, JumpingCrashTAG, AdvancedStormBreak, AdvancedEarthBreakTAG,
+        # 기가(60ms) -       점핑(690ms) -   어스(1260ms) - 어퍼 씹힘 -   어파스(2340ms)   어퍼, 어파스 씹힘  - 2970ms
+        AlphaComboLegacy = [SetAlpha, WindCutter, GigaCrashTAG, WindStrike, JumpingCrashTAG, AdvancedStormBreak, AdvancedEarthBreakTAG,
                         MoonStrike, PierceStrike, MoonStrike, PierceStrike, AdvancedPowerStompTAG]
+
+        # 문스(0ms) - 피어스(330ms) - 쉐스(690ms) - 문스(1020ms) - 피어스(1350ms) - 쉐스(1710ms) - 문스(2040ms) - 피어스(2370ms) - 쉐스(2730ms) - 문스(3060ms) - 3390ms
+        # 어퍼(60ms) - 어파스(330ms) -      어퍼(900ms) -          어파스(1350ms) -            어퍼(1920ms)    - 어파스(2370ms)               - 2940ms -   3360ms
+        # 2940ms: 어파스 딜레이 종료
+        # 3360ms: 어파스 딜레이가 끝났어도 충격파 발생해야 태그 가능
+        AlphaCombo = [SetAlpha, MoonStrike, UpperSlashTAG, PierceStrike, AdvancedPowerStompTAG, ShadowStrike,
+                        MoonStrike, UpperSlashTAG, PierceStrike, AdvancedPowerStompTAG, ShadowStrike,
+                        MoonStrike, UpperSlashTAG, PierceStrike, AdvancedPowerStompTAG, ShadowStrike,
+                        MoonStrike]
+        
         # 터닝(0ms) - 휠윈(360ms) - 프런트(1260ms) - 스로잉(1710ms) - 어퍼(2190ms) - 어파스(2580ms) - 3150ms
-        # 롤커(0ms) -        롤어(1020ms) - 플래시 씹힘 - 스핀(1710ms) - 문스(2190ms)  -  2640ms
+        # 롤커(60ms) -        롤어(1020ms) - 플래시 씹힘 - 스핀(1710ms) - 문스(2190ms)  -  2640ms
         BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind, AdvancedRollingAssulterTAG,
                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, UpperSlash, MoonStrikeTAG, AdvancedPowerStomp]
         ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -119,7 +119,7 @@ class JobGenerator(ck.JobGenerator):
         MoonStrike = core.DamageSkill("문 스트라이크", 330, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         MoonStrikeTAG = core.DamageSkill("문 스트라이크(태그)", 0, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
-        PierceStrike = core.DamageSkill("피어스 쓰러스트", 360, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        PierceStrike = core.DamageSkill("피어스 쓰러스트", 510, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         PierceStrikeTAG = core.DamageSkill("피어스 쓰러스트(태그)", 0, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
         '''
@@ -280,15 +280,14 @@ class JobGenerator(ck.JobGenerator):
         BetaState.controller(1) # 베타로 시작
         
         ### 어파스 생성
-        # 윈커(0ms) - 윈스(420ms) - 스톰(900ms) - 문스(1590ms) - 피어싱(1920ms) - 문스(2280ms) - 피어싱(2610ms) - 2970ms -> 태그 쿨타임 대기 +130ms
-        # 기가(0ms) -       점핑(630ms) -     어스(1290ms) -    어스 후딜 도중 문스 사용, 어퍼 씹힘 -   어파스(2850ms)
-        TagCooltimeWait = core.DamageSkill("태그 쿨타임 대기(알파)", 130, 0, 0, cooltime=-1).wrap(core.DamageSkillWrapper)
+        # 윈커(0ms) - 윈스(420ms) - 스톰(900ms) - 문스(1590ms) - 피어싱(1920ms) - 문스(2430ms) - 피어싱(2760ms) - 3270ms
+        # 기가(0ms) -       점핑(690ms) -   어스(1260ms) - 어퍼 씹힘 -   어파스(2340ms)   어퍼, 어파스 씹힘  - 2970ms
         AlphaCombo = [SetAlpha, WindCutter, GigaCrashTAG, WindStrike, JumpingCrashTAG, AdvancedStormBreak, AdvancedEarthBreakTAG,
-                        MoonStrike, PierceStrike, MoonStrike, PierceStrike, AdvancedPowerStompTAG, TagCooltimeWait]
-        # 터닝(0ms) - 휠윈(360ms) - 프런트(1260ms) - 스로잉(1710ms) - 어퍼(2190ms) - 어파스(2580ms) - 3150ms -> 태그 쿨타임 대기 0ms
-        # 롤커(0ms) -         롤어(960ms) -  플래시 씹힘 -    스핀(1920ms) -  문스 씹힘 -  피어싱(2640ms)
+                        MoonStrike, PierceStrike, MoonStrike, PierceStrike, AdvancedPowerStompTAG]
+        # 터닝(0ms) - 휠윈(360ms) - 프런트(1260ms) - 스로잉(1710ms) - 어퍼(2190ms) - 어파스(2580ms) - 3150ms
+        # 롤커(0ms) -        롤어(1020ms) - 플래시 씹힘 - 스핀(1710ms) - 문스(2190ms)  -  2640ms
         BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind, AdvancedRollingAssulterTAG,
-                        FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, UpperSlash, AdvancedPowerStomp, PierceStrikeTAG]
+                        FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, UpperSlash, MoonStrikeTAG, AdvancedPowerStomp]
         ComboHolder = core.DamageSkill("어파스", 0,0,0).wrap(core.DamageSkillWrapper)
         for sk in AlphaCombo + BetaCombo:
             ComboHolder.onAfter(sk)

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -116,10 +116,12 @@ class JobGenerator(ck.JobGenerator):
         extra_dmg = lambda x, y : (core.CharacterModifier(pdamage = (x - 1 + int(y))*8))
 
         #### 알파 ####
-        MoonStrike = core.DamageSkill("문 스트라이크", 330, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        MoonStrike = core.DamageSkill("문 스트라이크", 390, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
+        MoonStrikeLink = core.DamageSkill("문 스트라이크(연계)", 330, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         MoonStrikeTAG = core.DamageSkill("문 스트라이크(태그)", 0, 120, 6).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
         
         PierceStrike = core.DamageSkill("피어스 쓰러스트", 510, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
+        PierceStrikeLink = core.DamageSkill("피어스 쓰러스트(연계)", 360, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         PierceStrikeTAG = core.DamageSkill("피어스 쓰러스트(태그)", 0, 170, 6).setV(vEhc, 0, 3, False).wrap(core.DamageSkillWrapper)
         
         ShadowStrike = core.DamageSkill("쉐도우 스트라이크", 240+90, 195, 8).setV(vEhc, 5, 3, False).wrap(core.DamageSkillWrapper)
@@ -281,15 +283,15 @@ class JobGenerator(ck.JobGenerator):
         # 윈커(0ms) - 윈스(420ms) - 스톰(900ms) - 문스(1590ms) - 피어싱(1920ms) - 문스(2430ms) - 피어싱(2760ms) - 3270ms
         # 기가(60ms) -       점핑(690ms) -   어스(1260ms) - 어퍼 씹힘 -   어파스(2340ms)   어퍼, 어파스 씹힘  - 2970ms
         AlphaComboLegacy = [SetAlpha, WindCutter, GigaCrashTAG, WindStrike, JumpingCrashTAG, AdvancedStormBreak, AdvancedEarthBreakTAG,
-                        MoonStrike, PierceStrike, MoonStrike, PierceStrike, AdvancedPowerStompTAG]
+                        MoonStrikeLink, PierceStrike, MoonStrikeLink, PierceStrike, AdvancedPowerStompTAG]
 
-        # 문스(0ms) - 피어스(330ms) - 쉐스(690ms) - 문스(1020ms) - 피어스(1350ms) - 쉐스(1710ms) - 문스(2040ms) - 피어스(2370ms) - 쉐스(2730ms) - 문스(3060ms) - 3390ms
+        # 문스(0ms) - 피어스(330ms) - 쉐스(690ms) - 문스(1020ms) - 피어스(1350ms) - 쉐스(1710ms) - 문스(2040ms) - 피어스(2370ms) - 쉐스(2730ms) - 문스(3060ms) - 3450ms
         # 어퍼(60ms) - 어파스(330ms) -      어퍼(900ms) -          어파스(1350ms) -            어퍼(1920ms)    - 어파스(2370ms)               - 2940ms -   3360ms
         # 2940ms: 어파스 딜레이 종료
         # 3360ms: 어파스 딜레이가 끝났어도 충격파 발생해야 태그 가능
-        AlphaCombo = [SetAlpha, MoonStrike, UpperSlashTAG, PierceStrike, AdvancedPowerStompTAG, ShadowStrike,
-                        MoonStrike, UpperSlashTAG, PierceStrike, AdvancedPowerStompTAG, ShadowStrike,
-                        MoonStrike, UpperSlashTAG, PierceStrike, AdvancedPowerStompTAG, ShadowStrike,
+        AlphaCombo = [SetAlpha, MoonStrikeLink, UpperSlashTAG, PierceStrikeLink, AdvancedPowerStompTAG, ShadowStrike,
+                        MoonStrikeLink, UpperSlashTAG, PierceStrikeLink, AdvancedPowerStompTAG, ShadowStrike,
+                        MoonStrikeLink, UpperSlashTAG, PierceStrikeLink, AdvancedPowerStompTAG, ShadowStrike,
                         MoonStrike]
         
         # 터닝(0ms) - 휠윈(360ms) - 프런트(1260ms) - 스로잉(1710ms) - 어퍼(2190ms) - 어파스(2580ms) - 3150ms


### PR DESCRIPTION
* 쉐스로 이어지지 않는 피어스에는 skipActionFrame 적용되지 않음
* 새로 정리된 자료 기준으로 어파스 타임라인 재작성
* 알파 콤보를 어파스에서 (문스-피어스-쉐스)*3-문스 로 변경
  * dpm 4.7%정도 높음
  * 1.2.338 패치의 쉐스 변경으로 가능해짐
* MoonStrike, PierceStrike의 연계/비연계 딜레이 분리