### PR TITLE
캐릭터카드 SSS급 반영

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -337,7 +337,7 @@ class JobGenerator:
         log_buffed_character(chtr)
 
         # 유니온 공격대원
-        unionCard = Card.get_card(self.jobtype, ulevel, True)
+        unionCard = Card.get_card(self.jobname, self.jobtype, ulevel, chtr.level, True)
         log_modifier(unionCard, "union card")
         chtr.apply_modifiers([unionCard])
         log_buffed_character(chtr)
@@ -627,6 +627,7 @@ class Card:
     1/2/3/4/5
     크리율 : 2
 
+    TODO: 소환수 지속시간 증가 추가
     4/6/8/10/12
     소환수 : 1
 
@@ -665,6 +666,48 @@ class Card:
              [ExMDF(stat_main_fixed=i, stat_sub_fixed=i) for i in [5, 10, 20, 40, 50]],
              [ExMDF(pcooltime_reduce=i) for i in [2, 3, 4, 5, 6]],
              [ExMDF(buff_rem=i) for i in [5, 10, 15, 20, 25]]]
+    unoinCardList = {"아크메이지불/독" : "mp_rate",
+        "아크메이지썬/콜" : "int",
+        "일리움" : "int",
+        "히어로" : "str",
+        "팔라딘" : "str",
+        "신궁" : "crit",
+        "윈드브레이커" : "dex",
+        "소울마스터" : "hp",
+        "바이퍼" : "str",
+        "플레임위자드" : "int",
+        "메르세데스" : "pcooltime_reduce",
+        "루미너스" : "int",
+        "비숍" : "int",
+        "배틀메이지" : "int",
+        "메카닉" : "buff_rem",
+        "데몬슬레이어" : None,
+        "다크나이트" : "hp_rate",
+        "와일드헌터" : "pdamage",
+        "섀도어" : "luk",
+        "캐논슈터" : "str",
+        "미하일" : "hp",
+        "듀얼블레이드" : "luk",
+        "카이저" : "str",
+        "캡틴" : "summon_rem",
+        "엔젤릭버스터" : "dex",
+        "팬텀" : None,
+        "나이트로드" : "crit",
+        "은월" : "crit_damage",
+        "나이트워커" : "luk",
+        "스트라이커" : "str",
+        "에반" : None,
+        "보우마스터" : "dex",
+        "제로" : None,
+        "키네시스" : "int",
+        "패스파인더" : "dex",
+        "카데나" : "luk",
+        "아크" : "str",
+        "블래스터" : "armor_ignore",
+        "아란" : None,
+        "아델" : "str",
+        "호영" : "luk"
+    }
 
     priority = {
         "str": {
@@ -699,10 +742,11 @@ class Card:
 
     # TODO define Character Cards
     @staticmethod
-    def get_card(jobtype: str, ulevel: int, maplem: bool = True) -> ExMDF:
+    def get_card(jobname: str, jobtype: str, ulevel: int, mylevel: int = 240, maplem: bool = True) -> ExMDF:
         """get_card : 캐릭터카드 효과를 리턴합니다.
         리턴 형태 : Modifier
         """
+
         if jobtype not in ["str", "dex", "int", "luk"]:
             raise TypeError("jobtype must str, dex, int or luk, get:" + str(jobtype))
         retmdf = ExMDF()
@@ -727,6 +771,24 @@ class Card:
 
         if maplem:
             retmdf += Card.CList[3][2]
+        
+        if mylevel >= 250:
+            # 250레벨 이상일 경우 본캐 캐릭터카드를 SSS로 교체
+            main_card = Card.unoinCardList[jobname]
+            if main_card in ["str", "dex", "int", "luk"]:
+                retmdf += Card.CList[0][4] - Card.CList[0][3]
+            if main_card == "crit":
+                retmdf += Card.CList[2][4] - Card.CList[2][3]
+            if main_card == "crit_damage":
+                retmdf += Card.CList[4][4] - Card.CList[4][3]
+            if main_card == "armor_ignore":
+                retmdf += Card.CList[6][4] - Card.CList[6][3]
+            if main_card == "pdamage":
+                retmdf += Card.CList[7][4] - Card.CList[7][3]
+            if main_card == "pcooltime_reduce":
+                retmdf += Card.CList[9][4] - Card.CList[9][3]
+            if main_card == "buff_rem":
+                retmdf += Card.CList[10][4] - Card.CList[10][3]
         return retmdf
 
 

--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -358,7 +358,7 @@ class JobGenerator:
 
         # 유니온 점령
         refMDF = get_reference_modifier(chtr)
-        union = Union.get_union(refMDF, ulevel, buffrem=self.buffrem, critical_reinforce=self._use_critical_reinforce)
+        union = Union.get_union(refMDF, chtr.level, ulevel, buffrem=self.buffrem, critical_reinforce=self._use_critical_reinforce)
         log_modifier(union, "union")
         chtr.apply_modifiers([union])
         log_buffed_character(chtr)
@@ -421,14 +421,14 @@ class Union:
 
     # TODO :: -1을 리턴하지 않도록,
     @staticmethod
-    def get_union_object(mdf: ExMDF, ulevel: int, buffrem: Tuple[int, int], asIndex: bool = False, slot=None) -> 'Union':
-        mdf, buffrem = Union.get_union(mdf, ulevel, buffrem=buffrem, asIndex=asIndex, slot=slot)
+    def get_union_object(mdf: ExMDF, mylevel: int, ulevel: int, buffrem: Tuple[int, int], asIndex: bool = False, slot=None) -> 'Union':
+        mdf, buffrem = Union.get_union(mdf, mylevel, ulevel, buffrem=buffrem, asIndex=asIndex, slot=slot)
         return Union(mdf, buffrem, -1, ulevel)
 
     @staticmethod
-    def get_union(mdf: ExMDF, ulevel: int, buffrem: Tuple[int, int], asIndex: bool = False,
+    def get_union(mdf: ExMDF, mylevel: int, ulevel: int, buffrem: Tuple[int, int], asIndex: bool = False,
                   slot=None, critical_reinforce: bool = False) -> UnionType[ExMDF, List[int]]:
-        """get_union(mdf, ulevel, buffrem, asIndex=False, slot=None, critical_reinforce=False) : return optimized ExMDF value.
+        """get_union(mdf, mylevel, ulevel, buffrem, asIndex=False, slot=None, critical_reinforce=False) : return optimized ExMDF value.
         return value : (ExMDF, buffremain) tuple.
         """
         if slot is None:
@@ -436,6 +436,8 @@ class Union:
         else:
             slots = slot
         maxvalue = Union.maxSlot[min((ulevel - 2000) // 1000, 4)]
+        if mylevel >= 250:
+            maxvalue += 1
 
         buffrem_min, buffrem_max = buffrem
 

--- a/dpmModule/util/optimizer.py
+++ b/dpmModule/util/optimizer.py
@@ -42,7 +42,7 @@ def get_optimal_hyper_from_bare(spec, level):
     newHyper = HyperStat.get_hyper_object(ref, level)
     return newHyper
 
-def get_optimal_hyper_union(spec, job, otherspec, hyper, union):
+def get_optimal_hyper_union(spec, level, job, otherspec, hyper, union):
     '''최적화된 하이퍼 / 유니온 값을 계산해서 리턴합니다.
     입력값 : CharacterModifier들
     출력값 : [hyper, union]
@@ -56,7 +56,7 @@ def get_optimal_hyper_union(spec, job, otherspec, hyper, union):
     newHyper = HyperStat.get_hyper_object(ref, hyper.level)
     ref += newHyper.mdf
     
-    newUnion = Union.get_union_object(ref, -1, buffrem = buffremFlag, slot = union.slots)
+    newUnion = Union.get_union_object(ref, level, -1, buffrem = buffremFlag, slot = union.slots)
     
     return {"hyper" : newHyper, "union" : newUnion }
 


### PR DESCRIPTION
커널 편집은 사실상 이게 처음이라 맞게 했는지 모르겠습니다.

캐릭터 240레벨, 유니온 6000레벨: 변화 없음
캐릭터 250레벨, 유니온 6000레벨: 전직업 소폭 증가 (다크나이트 제외)

[master_250.txt](https://github.com/oleneyl/maplestory_dpm_calc/files/5622560/master_250.txt)
[modified_250.txt](https://github.com/oleneyl/maplestory_dpm_calc/files/5622561/modified_250.txt)

