### PR TITLE
feat: filter elements with ensure()

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -217,6 +217,7 @@ class JobGenerator:
         initialize_global_properties()
 
         base_element, all_elements = self.generate(vEhc, chtr, options)
+        ensured_elements = [el for el in all_elements if el.ensure(chtr)]
 
         GlobalOperation.assign_storage()
         GlobalOperation.attach_namespace()
@@ -227,7 +228,7 @@ class JobGenerator:
 
         collection = GlobalOperation.export_collection()
 
-        graph = policy.StorageLinkedGraph(base_element, collection.get_storage(), accessible_elements=all_elements)
+        graph = policy.StorageLinkedGraph(base_element, collection.get_storage(), accessible_elements=ensured_elements)
         graph.build(chtr)
 
         return graph

--- a/dpmModule/jobs/archmageFb.py
+++ b/dpmModule/jobs/archmageFb.py
@@ -204,11 +204,11 @@ class JobGenerator(ck.JobGenerator):
         OverloadMana = overload_mana_builder.get_buff()
 
         return (Paralyze, 
-                [Infinity, Meditation, EpicAdventure, OverloadMana.ensure(vEhc,1,5),
+                [Infinity, Meditation, EpicAdventure, OverloadMana,
                 globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), globalSkill.useful_wind_booster(),
                 globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
-                [DotPunisher.ensure(vEhc,0,0), PoisonChain, Meteor, MegidoFlame, FlameHeize, MistEruption, PoisonNova.ensure(vEhc,2,1), MirrorBreak, MirrorSpider] +\
-                [Ifritt, FireAura, FuryOfIfritt.ensure(vEhc,3,2),
-                    SlimeVirus, ParalyzeDOT, MistDOT, PoisonBreathDOT, IfrittDot, HeizeFlameDOT, TeleportMasteryDOT, MegidoFlameDOT, DotPunisherDOT.ensure(vEhc,0,0), PoisonNovaDOT.ensure(vEhc,2,1), PoisonChainToxic] +\
+                [DotPunisher, PoisonChain, Meteor, MegidoFlame, FlameHeize, MistEruption, PoisonNova, MirrorBreak, MirrorSpider] +\
+                [Ifritt, FireAura, FuryOfIfritt,
+                    SlimeVirus, ParalyzeDOT, MistDOT, PoisonBreathDOT, IfrittDot, HeizeFlameDOT, TeleportMasteryDOT, MegidoFlameDOT, DotPunisherDOT, PoisonNovaDOT, PoisonChainToxic] +\
                 [UnstableMemorize] +\
                 [Paralyze])

--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -1,3 +1,4 @@
+from dpmModule.character.characterKernel import AbstractCharacter
 from ..kernel import core
 import math
 
@@ -45,14 +46,28 @@ def useful_advanced_bless(slevel = 1):
     UsefulAdvancedBless = core.BuffSkill("쓸만한 어드밴스드 블레스", 600, usefulSkillRemain(slevel), rem = False, att = 20).wrap(core.BuffSkillWrapper)
     return UsefulAdvancedBless
 
-def SpiderInMirrorBuilder(enhancer, skill_importance, enhance_importance, break_modifier=core.CharacterModifier(), spider_modifier=core.CharacterModifier()):
-    MirrorBreak = core.DamageSkill(
-        "스파이더 인 미러(공간 붕괴)", 720, 450+18*enhancer.getV(skill_importance, enhance_importance), 15, cooltime = 250*1000, red = True, modifier=break_modifier
-    ).wrap(core.DamageSkillWrapper)
+class MirrorBreakWrapper(core.DamageSkillWrapper):
+    def __init__(self, vEhc, num1, num2, modifier) -> None:
+        super(MirrorBreakWrapper, self).__init__(
+            core.DamageSkill("스파이더 인 미러(공간 붕괴)", 720, 450+18*vEhc.getV(num1, num2), 15, cooltime = 250*1000, red = True, modifier=modifier)
+        )
+
+    def ensure(self, chtr: AbstractCharacter) -> bool:
+        return chtr.level >= 235
+
+class MirrorSpiderWrapper(core.SummonSkillWrapper):
     # 5번 연속 공격 후 종료, 재돌입 대기시간 3초
-    MirrorSpider = core.SummonSkill(
-        "스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+7*enhancer.getV(skill_importance, enhance_importance), 8*5, 15*1000, cooltime = -1, modifier=spider_modifier
-    ).wrap(core.SummonSkillWrapper)
+    def __init__(self, vEhc, num1, num2, modifier) -> None:
+        super(MirrorSpiderWrapper, self).__init__(
+            core.SummonSkill("스파이더 인 미러(거울 속의 거미)", 0, 3000, 175+7*vEhc.getV(num1, num2), 8*5, 15*1000, cooltime = -1, modifier=modifier)
+        )
+
+    def ensure(self, chtr: AbstractCharacter) -> bool:
+        return chtr.level >= 235
+
+def SpiderInMirrorBuilder(enhancer, skill_importance, enhance_importance, break_modifier=core.CharacterModifier(), spider_modifier=core.CharacterModifier()):
+    MirrorBreak = MirrorBreakWrapper(enhancer, skill_importance, enhance_importance, break_modifier)
+    MirrorSpider = MirrorSpiderWrapper(enhancer, skill_importance, enhance_importance, spider_modifier)
     MirrorBreak.onAfter(MirrorSpider.controller(3000))
     return MirrorBreak, MirrorSpider
 

--- a/dpmModule/jobs/mercedes.py
+++ b/dpmModule/jobs/mercedes.py
@@ -235,7 +235,7 @@ class JobGenerator(ck.JobGenerator):
     
         return(BasicAttack,
                 [globalSkill.maple_heros(chtr.level, combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), 
-                    Booster, ElvishBlessing, AncientSpirit, HerosOath, Sylphidia.ignore(), RoyalKnights,
+                    Booster, ElvishBlessing, AncientSpirit, HerosOath, RoyalKnights,
                     CriticalReinforce, UnicornSpikeBuff, RegendrySpearBuff, LightningEdgeBuff, ElementalGhost,
                     globalSkill.MapleHeroes2Wrapper(vEhc, 0, 0, chtr.level, self.combat), globalSkill.soul_contract()] +\
                 [RoyalKnightsAttack, ElementalGhostSpirit,UnicornSpike, RegendrySpear, WrathOfEllil, IrkilaBreathInit] +\

--- a/dpmModule/kernel/core/graph_element.py
+++ b/dpmModule/kernel/core/graph_element.py
@@ -7,7 +7,7 @@ from .modifier import CharacterModifier
 from .result_object import ResultObject
 
 if TYPE_CHECKING:
-    from ..abstract import AbstractVEnhancer
+    from ..abstract import AbstractCharacter
     from .callback import Callback
     from .modifier import SkillModifier
 
@@ -235,32 +235,14 @@ class GraphElement:
     def onJustAfters(self, ellist: List[GraphElement]) -> None:
         self._justAfter += ellist
 
-    def ignore(self) -> None:
-        return None
-
-    # TODO: Not used method.
-    def ensure_condition(self, cond: Callable[[], bool]) -> Optional[GraphElement]:
-        if cond():
-            return self
-        else:
-            return None
-
-    def ensure(self, ehc: AbstractVEnhancer, index_1: int, index_2: int) -> Optional[GraphElement]:
-        """주어진 ``ehc`` 의 코어 강화가 존재하지 않는다면, ``None`` 을 반환하여 실행되지 못하도록 막습니다.
+    def ensure(self, chtr: AbstractCharacter) -> bool:
+        """주어진 ``chtr``를 참조해 스킬의 사용 가능 여부를 판정합니다.
 
         Parameters
         ----------
-        ehc: AbstractVEnhancer
-        index_1 : int
-            ``ehc`` 가 첫번째 인자로 받게 될 index
-        index_2 : int
-            ``ehc`` 가 두번째 인자로 받게 될 index
-
+        chtr: AbstractCharacter
         """
-        if ehc.getV(index_1, index_2) > 0:
-            return self
-        else:
-            return None
+        return True
 
     def create_callbacks(self, **kwargs) -> List[Callback]:
         raise NotImplementedError


### PR DESCRIPTION
SpiderInMirror, SeedRing, Genesis Skill must be instantiated,
but may not be included in the graph build depending on chtr.
This patch adds the feature to determine
whether a skill is included in the graph based on chtr.

resolve #557 