### PR TITLE
fix: 무기 소울 크확 기준 변경

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -406,7 +406,7 @@ class JobGenerator:
 
         # 무기 소울
         refMDF = get_reference_modifier(chtr)
-        if refMDF.crit < 88:
+        if refMDF.crit <= 65:
             weapon_soul_modifier = ExMDF(crit=12, att=20)
         else:
             weapon_soul_modifier = ExMDF(patt=3, att=20)


### PR DESCRIPTION
* 링크스킬, 하이퍼스탯, 유니온배치 없는 기준 65% 이하일때 크확소울 사용
* 8000기준 전직업 dpm 하락 없는 것 확인됨

fix #518 