### PR TITLE
GenesisSkillBuilder: chtr 인자가 필요없음

### DIFF
--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -103,8 +103,8 @@ class AeonianRiseWrapper(core.DamageSkillWrapper):
         return False
 
 
-def GenesisSkillBuilder(chtr: AbstractCharacter):
-    return TandadianRuinWrapper(chtr), AeonianRiseWrapper(chtr)
+def GenesisSkillBuilder():
+    return TandadianRuinWrapper(), AeonianRiseWrapper()
 
 
 # 미완성 코드


### PR DESCRIPTION
`ensure()` 함수는 어차피 `chtr`을 인자로 받으므로 Builder 단계에서 따로 보내줄 필요가 없습니다.

수정 후 스인미와 같은 방식으로 선언해주면 정상적으로 작동하는 것을 확인했습니다.