### PR TITLE
재사용 대기시간 계산방식 변경 (샘플)

### DIFF
--- a/dpmModule/kernel/core/skill.py
+++ b/dpmModule/kernel/core/skill.py
@@ -92,11 +92,11 @@ class AbstractSkill(EvaluativeGraphElement):
         }
         return my_json
 
-    def wrap(self, wrapper: Type[T], name: str = None) -> T:
+    def wrap(self, wrapper: Type[T], name: str = None, unique_reduce: int = 0, reusable: bool = False) -> T:
         if name is None:
-            return wrapper(self)
+            return wrapper(self, unique_reduce=unique_reduce, reusable=reusable)
         else:
-            return wrapper(self, name=name)
+            return wrapper(self, unique_reduce=unique_reduce, reusable=reusable, name=name)
 
     def isV(self, enhancer: BasicVEnhancer, use_index: int, upgrade_index: int):
         """Speed hack"""


### PR DESCRIPTION
피니투라 페투치아
----
쿨타임 40000ms, 딜레이 1020ms, 하이퍼로 25% 감소 가능

* 현행 DPM
  * 쿨감모 0초: 40000 * (1 - 0.25) * (1 - 0.05) = 28500
  * 쿨감모 4초: 40000 * (1 - 0.25) * (1 - 0.05) - 4000 = 24500
* 실제 DPM
  * 쿨감모 0초: 40000 * (1 - 0.05 - 0.25) = 28000
  * 쿨감모 4초: 40000 * (1 - 0.05 - 0.25) - 4000 = 24000
* 실제 DPM + 재사용 20%
  * 쿨감모 0초: 0.8 * 28000 + 0.2 * 1020 = 22604
  * 쿨감모 4초: 0.8 * 24000 + 0.2 * 1020 = 19404
