### PR TITLE
fix(xenon): supply stack, skill priority

### DIFF
--- a/dpmModule/jobs/xenon.py
+++ b/dpmModule/jobs/xenon.py
@@ -1,6 +1,6 @@
 from ..kernel import core
 from ..character import characterKernel as ck
-from ..execution.rules import RuleSet, ConcurrentRunRule, ConditionRule
+from ..execution.rules import DisableRule, RuleSet, ConcurrentRunRule, ConditionRule
 from ..status.ability import Ability_tool
 from . import globalSkill
 from .jobbranch import thieves, pirates
@@ -102,11 +102,12 @@ class JobGenerator(ck.JobGenerator):
     def get_ruleset(self):
         ruleset = RuleSet()
 
-        for skill in ['메가 스매셔(개시)', '소울 컨트랙트', '레디 투 다이', '오버 드라이브']:
-            ruleset.add_rule(ConcurrentRunRule(skill, '홀로그램 그래피티 : 융합'), RuleSet.BASE)
+        for skill in ["메가 스매셔(개시)", "소울 컨트랙트", "레디 투 다이", "오버 드라이브"]:
+            ruleset.add_rule(ConcurrentRunRule(skill, "홀로그램 그래피티 : 융합"), RuleSet.BASE)
 
         # TODO: 포톤 레이가 융합과 함께 사용되는 빈도를 늘릴 수 있음
-        ruleset.add_rule(ConditionRule('엑스트라 서플라이', '서플러스 서플라이', lambda sk : sk.stack < sk._max - 10), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule("엑스트라 서플라이", "서플러스 서플라이", lambda sk : sk.stack < sk._max - 10), RuleSet.BASE)
+        ruleset.add_rule(DisableRule("멜트다운 익스플로전"), RuleSet.BASE)
 
         return ruleset
 


### PR DESCRIPTION
* 스킬 사용 우선순위 수정
* 불필요한 스킬 제거
* 불필요한 protect_from_running 제거, cooltime=-1로 변경
* 불필요한 Rule 제거
* 하이퍼스탯 스탠스 5레벨 투자
* 오버로드 모드 도중 에너지 미감소 적용
* 오버로드 모드 도중 에너지 증가 주기 4초 -> 2초 되는것 적용
* 아마란스 제너레이터 사용시 초과분 에너지는 충전되지 않는것 적용
* 멜트다운 익스플로전 사용하지 않도록 Rule 추가