### PR TITLE
스파이럴오브 마나 딜레이 수정

### DIFF
--- a/dpmModule/jobs/evan.py
+++ b/dpmModule/jobs/evan.py
@@ -75,7 +75,7 @@ class SpiralOfManaWrapper(core.SummonSkillWrapper):
     def __init__(self, vEhc, num1, num2):
         self.penaltyTime = 0
         skill = core.SummonSkill(
-            "스파이럴 오브 마나", 360, 420, 235+vEhc.getV(num1,num2), 6, 7000, cooltime=5000-50*vEhc.getV(num1,num2), red=True
+            "스파이럴 오브 마나", 180+360, 420, 235+vEhc.getV(num1,num2), 6, 7000, cooltime=5000-50*vEhc.getV(num1,num2), red=True
         ).setV(vEhc, 0, 2, False).isV(vEhc, num1, num2)
         super(SpiralOfManaWrapper, self).__init__(skill)
 


### PR DESCRIPTION
다른 객체(패시브스킬)로써 스파이럴오브 마나를 코드작성 하였을때는 자체 딜레이가 360ms이고, 이를 발동하기 위해 서클오브 마나1타를 넣어야 하기에 서오마 1타 딜레이 180ms가 추가로 계산 되어야 합니다. 이는 스오마가 나온후 딜이 3%~7%(실전딜) 상승효과가 있는 딜사이클(스오마 작동시 서오어,서오썬을 사용하여 스오마 타수를 6타로 유지)하는 것으로 바뀌었기 때문입니다. 편의성을 위해 스오마 사용중에 서오마를 계속 같이 써주는 딜사이클도 어찌되었든 서오마가 발동한 후에 스오마가 구동되므로, 이러한 코드 상의 실제 스오마 딜레이는 360+180이 되어야 합니다.