### PR TITLE
fix multiple jobs

### DIFF
--- a/dpmModule/jobs/angelicbuster.py
+++ b/dpmModule/jobs/angelicbuster.py
@@ -164,14 +164,27 @@ class JobGenerator(ck.JobGenerator):
         
         SuperNova.onTick(SoulSeeker)
         #SuperNova.onConstraint(core.ConstraintElement("익절트와 함께", SoulExult, SoulExult.is_active))
-        
-    
-        return (Trinity_1,
-                [Booster, SoulGaze, LuckyDice, FinalContract,
-                    SoulExult, SoulContract, Overdrive,
-                    FinaturaFettucciaBuff, SpotLightBuff, MascortFamilier, NovaGoddessBless,
-                    globalSkill.maple_heros(chtr.level, name = "노바의 용사", combat_level=self.combat), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(), globalSkill.useful_wind_booster()] +\
-                [FinaturaFettuccia, EnergyBurst, MirrorBreak, MirrorSpider] +\
-                [SuperNova, MascortFamilierAttack, ShinyBubbleBreath, SpotLight, TrinityFusionInit, Phanteon] +\
-                [] +\
-                [Trinity_1])
+
+        return (
+            Trinity_1,
+            [
+                globalSkill.maple_heros(chtr.level, name = "노바의 용사", combat_level=self.combat),
+                globalSkill.useful_sharp_eyes(),
+                globalSkill.useful_combat_orders(),
+                globalSkill.useful_wind_booster(),
+                Booster,
+                SoulGaze,
+                LuckyDice,
+                NovaGoddessBless,
+                MascortFamilier,
+                FinalContract,
+                SoulExult,
+                Overdrive,
+                SoulContract,
+                FinaturaFettucciaBuff,
+                SpotLightBuff,
+            ] +
+            [FinaturaFettuccia, EnergyBurst, MirrorBreak, MirrorSpider] +
+            [SuperNova, MascortFamilierAttack, ShinyBubbleBreath, SpotLight, TrinityFusionInit, Phanteon] +
+            [Trinity_1]
+        )

--- a/dpmModule/jobs/captain.py
+++ b/dpmModule/jobs/captain.py
@@ -2,6 +2,7 @@ from ..kernel import core
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
+from ..execution.rules import ConditionRule, ReservationRule, RuleSet, ConcurrentRunRule
 from . import globalSkill
 from .jobbranch import pirates
 from .jobclass import adventurer
@@ -23,6 +24,14 @@ class JobGenerator(ck.JobGenerator):
 
     def get_modifier_optimization_hint(self):
         return core.CharacterModifier(pdamage=28, armor_ignore=22)
+
+    def get_ruleset(self):
+        ruleset = RuleSet()
+        ruleset.add_rule(ConditionRule('노틸러스', '노틸러스 어썰트', lambda sk: sk.is_cooltime_left(8000, 1)), RuleSet.BASE)
+        ruleset.add_rule(ConditionRule('소울 컨트랙트', '노틸러스 어썰트', lambda sk: sk.is_usable() or sk.is_cooltime_left(70000, 1)), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('노틸러스 어썰트', '소울 컨트랙트'), RuleSet.BASE)
+
+        return ruleset
 
     def get_passive_skill_list(
         self, vEhc, chtr: ck.AbstractCharacter, options: Dict[str, Any]
@@ -464,15 +473,15 @@ class JobGenerator(ck.JobGenerator):
             )
 
         # 노틸러스 어썰트
-        NautilusAssult.onAfter(NautilusAssult_2)
-        NautilusAssult.onAfter(
+        NautilusAssult.onEventEnd(NautilusAssult_2)
+        NautilusAssult.onJustAfter(
             core.OptionalElement(
                 partial(Nautilus.is_cooltime_left, 8000, -1),
                 Nautilus.controller(8000),
                 name="노틸러스 쿨타임 8초",
             )
         )
-        Nautilus.onAfter(
+        Nautilus.onJustAfter(
             core.OptionalElement(
                 partial(NautilusAssult.is_cooltime_left, 8000, -1),
                 NautilusAssult.controller(8000),

--- a/dpmModule/jobs/hero.py
+++ b/dpmModule/jobs/hero.py
@@ -2,7 +2,7 @@ from ..kernel import core
 from ..character import characterKernel as ck
 from functools import partial
 from ..status.ability import Ability_tool
-from ..execution.rules import ReservationRule, RuleSet, InactiveRule
+from ..execution.rules import ConcurrentRunRule, ReservationRule, RuleSet, InactiveRule
 from . import globalSkill
 from .jobbranch import warriors
 from math import ceil
@@ -69,8 +69,8 @@ class JobGenerator(ck.JobGenerator):
         ruleset.add_rule(InactiveRule('콤보 데스폴트', '콤보 인스팅트'), RuleSet.BASE)
         ruleset.add_rule(InactiveRule('레이지 업라이징', '콤보 인스팅트'), RuleSet.BASE)
         ruleset.add_rule(ReservationRule('메이플월드 여신의 축복', '콤보 인스팅트'), RuleSet.BASE)
+        ruleset.add_rule(ConcurrentRunRule('소울 컨트랙트', '소드 오브 버닝 소울'), RuleSet.BASE)
         return ruleset
-
 
     def get_passive_skill_list(self, vEhc, chtr : ck.AbstractCharacter, options: Dict[str, Any]):
         passive_level = chtr.get_base_modifier().passive_level + self.combat

--- a/dpmModule/jobs/mechanic.py
+++ b/dpmModule/jobs/mechanic.py
@@ -141,8 +141,8 @@ class JobGenerator(ck.JobGenerator):
 
         #마그네틱 필드는 로봇 마스터리, 하이퍼를 제외한 소환수 지속시간 영향을 받지 않음. 설치 완료 후부터 쿨타임이 돔.
         MagneticFieldInstall = core.DamageSkill("마그네틱 필드(설치)", 630, 0, 0, cooltime=-1).wrap(core.DamageSkillWrapper)
-        MagneticField = core.SummonSkill("마그네틱 필드", 0, 990, 200, 1, 60*1000*(0.4+passive_level*0.01)+10, cooltime = 160*0.75*1000, red=True, modifier = ROBOT_MASTERY).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
-        MagneticFieldBuff = core.BuffSkill("마그네틱 필드(버프)", 0, 60*1000*(0.4+passive_level*0.01)+10, cooltime = -1, pdamage = ROBOT_BUFF).wrap(core.BuffSkillWrapper)
+        MagneticField = core.SummonSkill("마그네틱 필드", 0, 990, 200, 1, 60*1000*ROBOT_SUMMON_REMAIN+10000, cooltime = 160*0.75*1000, red=True, modifier = ROBOT_MASTERY).setV(vEhc, 3, 2, False).wrap(core.SummonSkillWrapper)
+        MagneticFieldBuff = core.BuffSkill("마그네틱 필드(버프)", 0, 60*1000*ROBOT_SUMMON_REMAIN+10000, cooltime = -1, pdamage = ROBOT_BUFF).wrap(core.BuffSkillWrapper)
         
         SupportWaver = core.SummonSkill("서포트 웨이버", 630, 80000*ROBOT_SUMMON_REMAIN, 0, 0, 80*1000*ROBOT_SUMMON_REMAIN).wrap(core.SummonSkillWrapper)
         SupportWaverBuff = core.BuffSkill("서포트 웨이버(버프)", 0, 80*1000*ROBOT_SUMMON_REMAIN, pdamage_indep=10+5+math.ceil(passive_level/3), pdamage = ROBOT_BUFF, cooltime = -1, armor_ignore=10).wrap(core.BuffSkillWrapper)

--- a/dpmModule/jobs/paladin.py
+++ b/dpmModule/jobs/paladin.py
@@ -22,7 +22,7 @@ class JobGenerator(ck.JobGenerator):
         def use_soul_contract(soul_contract, grand_cross, holy_unity):
             if holy_unity.is_not_active():
                 return False
-            if grand_cross.is_usable() and holy_unity.is_time_left(7000, 1):
+            if grand_cross.is_usable() and holy_unity.is_time_left(9000, 1):  # 억지로 맞췄는데... 그크 직전에 정확히 쓰도록 해줄 방법이?
                 return True
             return False
 


### PR DESCRIPTION
fix(angelicbuster): buff priority

fix(captain): NautilusAssult scheduling
* ensure SoulContracy sync
* prevent Nautilus disturbing NautilusAssult cooltime
* NautilusAssult_2 appears when NautilusAssult is ended

fix(hero): SoulContract usage
* ensure sync with SwordlOfBurningSoul and ComboInstinct
fix(mechanic): MagneticField remain time

fix(paladin): SoulContract stability
* when synchronizing SoulContract and GrandCross,
avoid the occasional use of only A