### PR TITLE
KMST 1.2.115 (재업)

### DIFF
--- a/dpmModule/jobs/globalSkill.py
+++ b/dpmModule/jobs/globalSkill.py
@@ -43,7 +43,7 @@ def useful_advanced_bless(slevel=1):
 
 class MirrorBreakWrapper(core.DamageSkillWrapper):
     def __init__(self, vEhc, num1, num2, modifier) -> None:
-        skill = core.DamageSkill("스파이더 인 미러(공간 붕괴)", 720, 450+18*vEhc.getV(num1, num2), 15, cooltime=250*1000, red=True, modifier=modifier)
+        skill = core.DamageSkill("스파이더 인 미러(공간 붕괴)", 720, 450+18*vEhc.getV(num1, num2), 15, cooltime=250*1000, red=True, modifier=modifier).isV(vEhc, num1, num2)
         super(MirrorBreakWrapper, self).__init__(skill)
 
     def ensure(self, chtr: AbstractCharacter) -> bool:
@@ -55,7 +55,7 @@ class MirrorSpiderWrapper(core.SummonSkillWrapper):
     def __init__(self, vEhc, num1, num2, modifier) -> None:
         self.delays = [900, 850, 750, 650, 5730]  # 400001039.summonedSequenceAttack에서 가져온 딜레이, 5회째 공격 후 눈 감고뜨는 시간 5730ms
         self.hit_count = 0
-        skill = core.SummonSkill("스파이더 인 미러(거울 속의 거미)", 0, 900, 175+7*vEhc.getV(num1, num2), 8, 50*1000, cooltime=-1, modifier=modifier)
+        skill = core.SummonSkill("스파이더 인 미러(거울 속의 거미)", 0, 900, 175+7*vEhc.getV(num1, num2), 8, 50*1000, cooltime=-1, modifier=modifier).isV(vEhc, num1, num2)
         super(MirrorSpiderWrapper, self).__init__(skill)
 
     def _useTick(self) -> core.ResultObject:
@@ -105,6 +105,29 @@ class AeonianRiseWrapper(core.DamageSkillWrapper):
 
 def GenesisSkillBuilder():
     return TandadianRuinWrapper(), AeonianRiseWrapper()
+
+
+class MitraFlameWrapper(core.DamageSkillWrapper):
+    def __init__(self, vEhc, num1, num2, modifier) -> None:
+        skill = core.DamageSkill("크레스트 오브 더 솔라(미트라의 불꽃)", 870, 750+30*vEhc.getV(num1, num2), 12, cooltime=250*1000, red=True, modifier=modifier).isV(vEhc, num1, num2)
+        super(MitraFlameWrapper, self).__init__(skill)
+
+    def ensure(self, chtr: AbstractCharacter) -> bool:
+        return chtr.level >= 265
+
+class FlamePatternWrapper(core.SummonSkillWrapper):
+    def __init__(self, vEhc, num1, num2, modifier) -> None:
+        skill = core.SummonSkill("크레스트 오브 더 솔라(불꽃의 문양)", 0, 2100, 275+11*vEhc.getV(num1, num2), 6, 51*1000, cooltime=-1, modifier=modifier).isV(vEhc, num1, num2)
+        super(MirrorSpiderWrapper, self).__init__(skill)
+
+    def ensure(self, chtr: AbstractCharacter) -> bool:
+        return chtr.level >= 265
+
+def CrestOfTheSolarBuilder(enhancer, skill_importance, enhance_importance, modifier=core.CharacterModifier()):
+    MitraFlame = MitraFlameWrapper(enhancer, skill_importance, enhance_importance, modifier)
+    FlamePattern = FlamePatternWrapper(enhancer, skill_importance, enhance_importance, modifier)
+    MitraFlame.onAfter(FlamePattern)
+    return MitraFlame, FlamePattern
 
 
 # 미완성 코드

--- a/dpmModule/jobs/kain.py
+++ b/dpmModule/jobs/kain.py
@@ -955,7 +955,7 @@ class JobGenerator(ck.JobGenerator):
         # 발현 스킬의 쿨타임 있는 파이널 어택처럼 취급
         for sk, count in [
             (StrikeArrowRelease, 1),
-            (ScatteringShotRelease, 2 * 2),  # 기본 2개지만, 원거리에서는 쿨타임이 돌면서 2번 생김
+            (ScatteringShotRelease, 2),
             (ShaftBreakReleaseExplode, 6),
             (FallingDustRelease, 8),
             (SneakySnipingRelease, 8),


### PR DESCRIPTION
#728 작업 중 rebase를 잘못하는 바람에 엉망이 돼버려서 새 브랜치로 다시 올립니다.

변경사항
---
* 크레스트 오브 더 솔라 추가 (단일 몬스터 상대 기준)
* ~~제로의 초월자 륀느의 기원으로 발동하는 추가 타격이 오라 웨폰으로 인한 오라 파동에는 발동되지 않게 됩니다.~~ 이미 적용중
* 보우마스터의 아머피어싱에 현행 로직과 동일하게 자신이 직접 공격하는 스킬에만 발동된다는 스킬 설명이 추가됩니다. - 확인중
* [발현] 스캐터링 샷으로 정해진 개수보다 많이 생성될 수 있는 현상이 수정됩니다.
* 데몬어벤져 시드링: 본섭 패치후 #727 에 추가할 예정