### PR TITLE
fix: get_weapon_base_att()

### DIFF
--- a/dpmModule/character/characterKernel.py
+++ b/dpmModule/character/characterKernel.py
@@ -167,7 +167,8 @@ class GearedCharacter(AbstractCharacter):
             self.add_gear_modifier(gear_dict[key])
 
     def get_weapon_base_att(self) -> int:
-        return self.gear_list["weapon"].base_stat[GearPropType.att]
+        weapon_base_stat = self.gear_list["weapon"].base_stat
+        return max(weapon_base_stat[GearPropType.att], weapon_base_stat[GearPropType.matt])
 
     def get_starforce_count(self) -> int:
         count = 0


### PR DESCRIPTION
* get_weapon_base_att() was always returning weapon att
* it should return max(att, matt) because
Illium's magic curcuit references weapon matt