### PR TITLE
fix luminous, create_auxilary_attack()

### DIFF
--- a/dpmModule/jobs/jobutils.py
+++ b/dpmModule/jobs/jobutils.py
@@ -20,6 +20,8 @@ def create_auxilary_attack(skill_wrapper: core.DamageSkillWrapper, ratio=1, name
         modifier=original_skill._static_skill_modifier,
     ).wrap(core.DamageSkillWrapper)
 
+    copial_skill._runtime_modifier_list = skill_wrapper._runtime_modifier_list
+
     skill_wrapper.onJustAfter(copial_skill)
 
 

--- a/dpmModule/jobs/luminous.py
+++ b/dpmModule/jobs/luminous.py
@@ -97,13 +97,10 @@ class LightAndDarknessWrapper(core.DamageSkillWrapper):
         super(LightAndDarknessWrapper, self).__init__(skill)
         self.stack = 12
 
-    def _use(self, skill_modifier):
-        self.stack = 12
-        return super(LightAndDarknessWrapper, self)._use(skill_modifier)
-
     def reduceStack(self):
         self.stack -= 1
         if self.stack <= 0:
+            self.stack = 12
             self.cooltimeLeft = 0
         return core.ResultObject(0, core.CharacterModifier(), 0, 0, sname = '빛과 어둠의 세례 스택 증가', spec = 'graph control')
 


### PR DESCRIPTION
* fix(luminous): Light and Darkness stack
  * should reset stack on cooltime reset, not on skill use
  * does not affect dpm result
* fix: apply runtime_modifier to auxilary attack
  * reference original skill's `_runtime_modifier_list`
  * cannot copy `_runtime_modifier_list` because we don't know order between `create_auxilary_attack()` and `add_runtime_modifier()`