### PR TITLE
제로 신콤보 추가

### DIFF
--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -14,6 +14,9 @@ from typing import Any, Dict
 항상 베타 스탯 적용: 파워 스텀프 충격파
 
 https://github.com/Monolith11/memo/wiki/Zero-Skill-Mechanics
+
+딜사이클 자료
+http://www.inven.co.kr/board/maple/2294/204582
 '''
 
 
@@ -353,9 +356,9 @@ class JobGenerator(ck.JobGenerator):
                          GigaCrash, JumpingCrash, WindStrikeTAG, AdvancedEarthBreak, AdvancedStormBreakTAG]
         elif BETA_DEALCYCLE == "turning_upper":  # 터닝어퍼
             BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind, AdvancedRollingAssulterTAG,
-                         FrontSlash, ThrowingWeapon, UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
                          TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind, AdvancedRollingAssulterTAG,
-                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp]
+                         UpperSlash, AdvancedPowerStomp]
         else:
             raise ValueError(BETA_DEALCYCLE)
 

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -99,6 +99,9 @@ class JobGenerator(ck.JobGenerator):
         elif BETA_DEALCYCLE == "advanced_earth_break":
             WHEELWIND_DELAY = 750
             WHEELWIND_HIT = 5
+        elif BETA_DEALCYCLE == "turning_upper":
+            WHEELWIND_DELAY = 60
+            WHEELWIND_HIT = 1
         else:
             raise ValueError(BETA_DEALCYCLE)
 
@@ -332,6 +335,11 @@ class JobGenerator(ck.JobGenerator):
             # 국콤
             AlphaCombo = [SetAlpha, WindCutter, GigaCrashTAG, WindStrike, JumpingCrashTAG, AdvancedStormBreak, AdvancedEarthBreakTAG,
                           AdvancedRollingCurve, TurningDriveTAG, AdvancedRollingAssulter]
+        elif ALPHA_DEALCYCLE == "moon_pierce_shadow_wind":
+            # 윈커-윈스-스톰-문스-피어싱-쉐스-문스-윈커
+            AlphaCombo = [SetAlpha, WindCutter, GigaCrashTAG, WindStrike, JumpingCrashTAG, AdvancedStormBreak, AdvancedEarthBreakTAG,
+                          MoonStrikeLink, UpperSlashTAG, PierceStrikeLink, AdvancedPowerStompTAG, ShadowStrike,
+                          MoonStrikeLink, UpperSlashTAG, WindCutter]
         else:
             raise ValueError(ALPHA_DEALCYCLE)
 
@@ -343,6 +351,11 @@ class JobGenerator(ck.JobGenerator):
         elif BETA_DEALCYCLE == "advanced_earth_break":  # 국콤
             BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind, AdvancedRollingAssulterTAG,
                          GigaCrash, JumpingCrash, WindStrikeTAG, AdvancedEarthBreak, AdvancedStormBreakTAG]
+        elif BETA_DEALCYCLE == "turning_upper":  # 터닝어퍼
+            BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind, AdvancedRollingAssulterTAG,
+                         FrontSlash, ThrowingWeapon, UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind, AdvancedRollingAssulterTAG,
+                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp]
         else:
             raise ValueError(BETA_DEALCYCLE)
 

--- a/statistics/preset.py
+++ b/statistics/preset.py
@@ -370,12 +370,22 @@ presets = [
     Preset(
         id="zero",
         job="제로",
+        description="터닝스로잉",
+        options={
+            "alpha_dealcycle": "moon_pierce_shadow_wind",
+            "beta_dealcycle": "turning_upper",
+        },
+        alt=0,
+    ),
+    Preset(
+        id="zero_moon_pierce_shadow",
+        job="제로",
         description="문피쉐",
         options={
             "alpha_dealcycle": "moon_pierce_shadow",
             "beta_dealcycle": "advanced_power_stomp",
         },
-        alt=0,
+        alt=1,
     ),
     Preset(
         id="zero_advanced_power_stomp",
@@ -385,7 +395,7 @@ presets = [
             "alpha_dealcycle": "advanced_storm_break_pierce",
             "beta_dealcycle": "advanced_power_stomp",
         },
-        alt=1,
+        alt=2,
     ),
     Preset(
         id="kinesis",


### PR DESCRIPTION
알파 스킬 | 어시스트
-- | --
윈드 커터 | 기가 크래시
윈드 스트라이크 | 점핑 크래시
스톰 브레이크 | 어스 브레이크
문 스트라이크 | 어퍼 슬래시
피어스 쓰러스트 | 파워 스텀프
쉐도우 스트라이크 |  
문 스트라이크 | 어퍼 슬래시
윈드 커터 |  

베타 스킬 | 어시스트
-- | --
터닝 드라이브 | 롤링커브
휠 윈드 | 롤링어썰터
프론트 슬래시 |  
스로잉 웨폰 |  
어퍼 슬래시 | 문스트라이크
파워 스텀프 | 피어쓰스러스트
터닝 드라이브 | 롤링커브
휠 윈드 | 롤링어썰터
어퍼 슬래시 | 문스트라이크
파워 스텀프 |  

제 손으로 신콤보 영상들의 딜사이클을 도저히 따라할 수가 없어 영상을 기반으로 올립니다.

제가 실수했을 가능성도 있으므로 리뷰 필요합니다.