### PR TITLE
아델 무기상수 수정

### DIFF
--- a/dpmModule/jobs/adele.py
+++ b/dpmModule/jobs/adele.py
@@ -124,7 +124,7 @@ class JobGenerator(ck.JobGenerator):
 
     def get_not_implied_skill_list(self, vEhc, chtr : ck.AbstractCharacter, options: Dict[str, Any]):
         passive_level = chtr.get_base_modifier().passive_level + self.combat
-        WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 34)
+        WeaponConstant = core.InformedCharacterModifier("무기상수",pdamage_indep = 30)
         Mastery = core.InformedCharacterModifier("숙련도", mastery=90+ceil(passive_level / 2))
 
         return [WeaponConstant, Mastery]


### PR DESCRIPTION
아델의 무기상수가 여태 1.34로 알려져 있었으나 나제불님님님께서 측정한 결과 1.30이 맞다고 합니다.

출처 https://blog.naver.com/oe135/222385428301