### PR TITLE
제로 크리티컬 바인드, 무기 공격력 수정

### DIFF
--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -46,6 +46,7 @@ class JobGenerator(ck.JobGenerator):
         self.jobname = "제로"
         self.ability_list = Ability_tool.get_ability_set('boss_pdamage', 'crit', 'buff_rem')
         self.preEmptiveSkills = 2
+        self.combat = 0
 
     def get_ruleset(self):
         ruleset = RuleSet()
@@ -385,7 +386,7 @@ class JobGenerator(ck.JobGenerator):
         EgoWeaponBeta.protect_from_running()
 
         return(ComboHolder,
-               [globalSkill.maple_heros(chtr.level, name="륀느의 가호", combat_level=0), globalSkill.useful_sharp_eyes(), globalSkill.useful_combat_orders(),
+               [globalSkill.maple_heros(chtr.level, name="륀느의 가호", combat_level=0), globalSkill.useful_sharp_eyes(),
                 DivineForce, AlphaState, BetaState, DivineLeer, AuraWeaponBuff, AuraWeapon, RhinneBless,
                 DoubleTime, TimeDistortion, TimeHolding, LimitBreak, LimitBreakCDR, LimitBreakFinal, CriticalBind,
                 SoulContract] +

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -19,7 +19,7 @@ https://github.com/Monolith11/memo/wiki/Zero-Skill-Mechanics
 
 class CriticalBindWrapper(core.BuffSkillWrapper):
     def __init__(self, alphaState: core.BuffSkillWrapper, betaState: core.BuffSkillWrapper):
-        skill = core.BuffSkill("크리티컬 바인드", 0, 4000, cooltime=35000, crit=30, crit_damage=20)
+        skill = core.BuffSkill("크리티컬 바인드", 0, 4000, cooltime=35000+4000, crit=30, crit_damage=20, red=False)  # 지속시간 4초 + 저항시간 35초
         super(CriticalBindWrapper, self).__init__(skill)
         self.alphaState = alphaState
         self.betaState = betaState
@@ -94,11 +94,10 @@ class JobGenerator(ck.JobGenerator):
         THROWINGHIT = 5
 
         #### 마스터리 ####
-        # 베타 마스터리의 공격력 +4는 무기 기본 공격력 차이
-        # 제네시스 무기의 경우 +5로 변경 필요
+        # 베타 마스터리의 공격력 +5는 무기 기본 공격력 차이
 
         AlphaMDF = core.CharacterModifier(pdamage_indep=5, crit=40, att=40, armor_ignore=30, crit_damage=50) + core.CharacterModifier(pdamage_indep=34)
-        BetaMDF = core.CharacterModifier(pdamage_indep=5, crit=15, boss_pdamage=30, att=80+4) + core.CharacterModifier(pdamage_indep=49)
+        BetaMDF = core.CharacterModifier(pdamage_indep=5, crit=15, boss_pdamage=30, att=80+5) + core.CharacterModifier(pdamage_indep=49)
 
         AlphaState = core.BuffSkill("상태-알파", 0, 9999*10000, cooltime=-1,
                                     pdamage_indep=AlphaMDF.pdamage_indep,


### PR DESCRIPTION
* 크리티컬 바인드의 저항 시간이 효과 종료 후부터 돌기 시작합니다. 따라서 재발동 대기시간은 35초+4초=39초입니다.
* 알파와 베타의 무기 공격력 차이는 5입니다. 제가 예전에 4라고 적어놨었는데 실수가 있었던 것 같습니다.
* 딜사이클 변경 이후 컴뱃 오더스를 사용하지 않는 것이 딜 상승치가 더 높은 것이 확인되었습니다.