### PR TITLE
fix-auraweapon: 방무 및 최종뎀 오류 수정

### DIFF
--- a/dpmModule/jobs/jobbranch/warriors.py
+++ b/dpmModule/jobs/jobbranch/warriors.py
@@ -1,4 +1,5 @@
 from ...kernel import core
+from math import ceil
 
 
 class AuraWeaponBuilder:
@@ -17,9 +18,9 @@ class AuraWeaponBuilder:
                 remain=(80 + 2 * enhancer.getV(skill_importance, enhance_importance)) * 1000,
                 cooltime=180 * 1000,
                 red=True,
-                armor_ignore=15,
+                armor_ignore=10+enhancer.getV(skill_importance, enhance_importance)//5,
                 pdamage_indep=(
-                    enhancer.getV(skill_importance, enhance_importance) // 5
+                    ceil(enhancer.getV(skill_importance, enhance_importance) / 5)
                 ),
             )
             .isV(enhancer, skill_importance, enhance_importance)


### PR DESCRIPTION
* 방무가 15%로 고정돼있던 것을 클라이언트 값에 맞게 수정했습니다. (`10+d(x/5)`)
* 최종 데미지가 소수점 버림으로 되어있던 것을 소수점 올림으로 수정했습니다. (`u(x/5)`)