### PR TITLE
제로 신규 딜사이클 제안

### DIFF
--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -88,9 +88,26 @@ class JobGenerator(ck.JobGenerator):
 
         어파스 기준
         '''
-        ALPHA_DEALCYCLE = options.get('alpha_dealcycle', 'moon_pierce_shadow')
-        BETA_DEALCYCLE = options.get('beta_dealcycle', 'wheel_throw_stomp_wheel_stomp')
+        ### 스로잉 12회 기준
+        ### 스문스문윈 / 휠스휠어스 
 
+        ### 스로잉 5회 기준
+        ### 스문스문윈 / 휠어스휠어 ??? 왜 5회도 스문스문윈이 더 쌔지???
+
+        # spin_moon_wind
+        # moon_pierce_shadow
+        # storm_moon_pierce_shadow_wind
+        ALPHA_DEALCYCLE = options.get('alpha_dealcycle', 'spin_moon_wind')
+        # "wheel_throw_wheel_throw_stomp":  # 휠스휠스어
+        # "wheel_throw_wheel_stomp_throw":  # 휠스휠어스
+        # "wheel_stomp_wheel_stomp_throw":  # 휠어휠어스
+        # "wheel_throw_stomp_wheel_throw":  # 휠스어휠스 기본
+        # "wheel_stomp_throw_wheel_stomp":  # 휠어스휠어
+        # "wheel_stomp_throw_wheel_throw":  # 휠어스휠스
+        # "wheel_throw_stomp_wheel_stomp":  # 휠스어휠어
+        BETA_DEALCYCLE = options.get('beta_dealcycle', 'wheel_stomp_throw_wheel_stomp')
+
+        # 스로잉 횟수 5회 / 12회 
         THROWINGHIT = 5
 
         #### 마스터리 ####
@@ -185,6 +202,8 @@ class JobGenerator(ck.JobGenerator):
 
         ThrowingWeapon = core.SummonSkill("어드밴스드 스로잉 웨폰", 480, 300, 550+5*self.combat, 2, THROWINGHIT*300, cooltime=-1, modifier=extra_damage(6)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
         ThrowingWeaponLast = core.SummonSkill("어드밴스드 스로잉 웨폰(마무리)", 30, 300, 550+5*self.combat, 2, THROWINGHIT*300, cooltime=-1, modifier=extra_damage(6)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
+        ThrowingWeaponTAG = core.SummonSkill("어드밴스드 스로잉 웨폰(태그)", 0, 300, 550+5*self.combat, 2, THROWINGHIT*300, cooltime=-1, modifier=extra_damage(6)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
+        ThrowingWeaponTAG2 = core.SummonSkill("어드밴스드 스로잉 웨폰(태그2)", 0, 300, 550 + 5 * self.combat, 2, THROWINGHIT * 300, cooltime=-1, modifier=extra_damage(6)).setV(vEhc, 1, 2, False).wrap(core.SummonSkillWrapper)
 
         TurningDrive = core.DamageSkill("터닝 드라이브", 360, 260, 6, modifier=extra_damage(6)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         TurningDriveTAG = core.DamageSkill("터닝 드라이브(태그)", 0, 260, 6, modifier=extra_damage(6)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
@@ -305,23 +324,98 @@ class JobGenerator(ck.JobGenerator):
 
         BetaState.controller(1)  # 베타로 시작
 
-        ### 딜사이클 생성
-        if ALPHA_DEALCYCLE == "moon_pierce_shadow":
-            AlphaCombo = [SetAlpha, MoonStrikeLink, UpperSlashTAG, PierceStrikeLink, AdvancedPowerStompTAG, ShadowStrike,
-                          MoonStrikeLink, UpperSlashTAG, PierceStrikeLink, AdvancedPowerStompTAG, ShadowStrike,
-                          MoonStrikeLink, UpperSlashTAG, PierceStrikeLink, AdvancedPowerStompTAG, ShadowStrike,
+        ### 딜사이클 생성 (쿨뚝 요구 x)
+        ### 신규 딜 사이클 = 스문스문윈
+        ### 플래시 어썰터 - 프론트 슬래시
+        ### 스핀 커터 - 스로잉 웨폰
+        ### 문 스트라이크 - 어퍼 슬래시
+        ### 피어스 스트라이크 - 어드밴스드 파워 스텀프
+        ### 플래시 어썰터 - 프론트 슬래시
+        ### 스핀 커터 - 스로잉 웨폰
+        ### 문 스트라이크 - 어퍼 슬래시
+        ### 피어스 스트라이크 - 어드밴스드 파워 스텀프
+        ### 윈드 커터 - X
+
+        ### 기존 dpm 기준 딜사이클 문피쉐
+        ### 문피쉐 - 문피쉐 - 문피쉐 - 윈커
+
+        ### 요즘 실전에서 많이 사용하는 콤보
+        ### 윈커 윈스 스톰브 - 문피쉐 - 문 - 윈커
+        if ALPHA_DEALCYCLE == "spin_moon_wind":
+            AlphaCombo = [SetAlpha, FlashAssault, FrontSlashTAG,
+                          AdvancedSpinCutter, ThrowingWeaponTAG,
+                          MoonStrikeLink, UpperSlashTAG,
+                          PierceStrike, AdvancedPowerStompTAG,
+                          FlashAssault, FrontSlashTAG,
+                          AdvancedSpinCutter, ThrowingWeaponTAG2,
+                          MoonStrikeLink, UpperSlashTAG,
+                          PierceStrike, AdvancedPowerStomp,
                           WindCutterLast]
+        elif ALPHA_DEALCYCLE == "moon_pierce_shadow":
+            AlphaCombo = [SetAlpha, MoonStrikeLink, UpperSlashTAG, 
+                          PierceStrikeLink, AdvancedPowerStompTAG, 
+                          ShadowStrike, MoonStrikeLink, UpperSlashTAG, 
+                          PierceStrikeLink, AdvancedPowerStompTAG, 
+                          ShadowStrike, MoonStrikeLink, UpperSlashTAG, 
+                          PierceStrikeLink, AdvancedPowerStompTAG, 
+                          ShadowStrike, WindCutterLast]
+        elif ALPHA_DEALCYCLE == "storm_moon_pierce_shadow_wind":
+            AlphaCombo = [SetAlpha, WindCutter, GigaCrashTAG, WindStrike, JumpingCrashTAG, AdvancedStormBreak, AdvancedEarthBreakTAG,
+                          MoonStrikeLink, UpperSlashTAG, PierceStrikeLink, AdvancedPowerStompTAG, ShadowStrike,
+                          MoonStrikeLink, UpperSlashTAG, WindCutterLast]
         else:
             raise ValueError(ALPHA_DEALCYCLE)
 
-        if BETA_DEALCYCLE == "wheel_throw_stomp_wheel_throw":  # 휠스어휠스
+        ### 기본 : 휠xx휠x 에서 두번째 휠 태그로 롤썰터 나감 
+        ### 확인 : 휠xx휠x 에서 두번째 휠 태그로 롤썰터 잘 안나감 빡빡함
+        ### 휠x휠xx가 실전에서는 더 유용하나 쿨뚝 없을시 한 사이클마다 60ms 손해
+        ### 휠윈드 직후 스로잉 사용시 태그로 플썰터 안나감
+        ### 휠윈드 직후 어파스 사용시 경직이 심함
+        
+        # 휠x휠xx
+        if BETA_DEALCYCLE == "wheel_throw_wheel_throw_stomp":  # 휠스휠스어
             BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG,
-                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
-                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG, FrontSlash, ThrowingWeaponLast]
+                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, 
+                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG, 
+                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, 
+                         UpperSlash, AdvancedPowerStompLast]
+        elif BETA_DEALCYCLE == "wheel_throw_wheel_stomp_throw":  # 휠스휠어스
+            BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG,
+                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, 
+                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG, 
+                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         FrontSlash, ThrowingWeaponLast]
+        elif BETA_DEALCYCLE == "wheel_stomp_wheel_stomp_throw":  # 휠어휠어스
+            BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG,
+                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG,
+                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         FrontSlash, ThrowingWeaponLast]
+        # 휠xx휠x
+        elif BETA_DEALCYCLE == "wheel_throw_stomp_wheel_throw":  # 휠스어휠스 기본
+            BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG,
+                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, 
+                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG, 
+                         FrontSlash, ThrowingWeaponLast]
+        elif BETA_DEALCYCLE == "wheel_stomp_throw_wheel_stomp":  # 휠어스휠어
+            BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG,
+                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         FrontSlash, FlashAssaultTAG, ThrowingWeapon, AdvancedSpinCutterTAG, 
+                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG, 
+                         UpperSlash, AdvancedPowerStompLast]
+        elif BETA_DEALCYCLE == "wheel_stomp_throw_wheel_throw":  # 휠어스휠스
+            BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG,
+                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         FrontSlash, FlashAssaultTAG, ThrowingWeapon, AdvancedSpinCutterTAG, 
+                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG, 
+                         FrontSlash, ThrowingWeaponLast]
         elif BETA_DEALCYCLE == "wheel_throw_stomp_wheel_stomp":  # 휠스어휠어
             BetaCombo = [SetBeta, TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG,
-                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
-                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG, UpperSlash, AdvancedPowerStompLast]
+                         FrontSlash, ThrowingWeapon, AdvancedSpinCutterTAG, 
+                         UpperSlash, MoonStrikeTAG, AdvancedPowerStomp, PierceStrikeTAG,
+                         TurningDrive, AdvancedRollingCurveTAG, AdvancedWheelWind1, AdvancedRollingAssulterTAG, 
+                         UpperSlash, AdvancedPowerStompLast]
         else:
             raise ValueError(BETA_DEALCYCLE)
 
@@ -392,6 +486,6 @@ class JobGenerator(ck.JobGenerator):
                 SoulContract] +
                [TwinBladeOfTime, ShadowFlashAlpha, ShadowFlashBeta, MirrorBreak, MirrorSpider] +
                [AdvancedStormBreakSummon, AdvancedStormBreakElectric, AdvancedEarthBreakElectric,
-                WindCutterSummon, WindCutterLastSummon, ThrowingWeapon, ThrowingWeaponLast] +
+                WindCutterSummon, WindCutterLastSummon, ThrowingWeapon, ThrowingWeaponLast, ThrowingWeaponTAG, ThrowingWeaponTAG2] +
                [EgoWeaponAlpha, EgoWeaponBeta] +
                [ComboHolder])

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -88,14 +88,14 @@ class JobGenerator(ck.JobGenerator):
 
         어파스 기준
         '''
-        ### 스로잉 12회 기준
-        ### 스문스문윈 / 휠스휠어스 
+        ### 스로잉 12타 기준
+        ### 스문스문윈 / 휠어스휠스 
 
-        ### 스로잉 5회 기준
-        ### 스문스문윈 / 휠어스휠어 ??? 왜 5회도 스문스문윈이 더 쌔지???
+        ### 스로잉 5타 기준
+        ### 스문스문윈 / 휠어스휠어
 
         # spin_moon_wind
-        # moon_pierce_shadow
+        # moon_pierce_shadow # 기본
         # storm_moon_pierce_shadow_wind
         ALPHA_DEALCYCLE = options.get('alpha_dealcycle', 'spin_moon_wind')
         # "wheel_throw_wheel_throw_stomp":  # 휠스휠스어

--- a/dpmModule/jobs/zero.py
+++ b/dpmModule/jobs/zero.py
@@ -366,11 +366,9 @@ class JobGenerator(ck.JobGenerator):
         else:
             raise ValueError(ALPHA_DEALCYCLE)
 
-        ### 기본 : 휠xx휠x 에서 두번째 휠 태그로 롤썰터 나감 
-        ### 확인 : 휠xx휠x 에서 두번째 휠 태그로 롤썰터 잘 안나감 빡빡함
+        ### 기본 : 휠xx휠x 에서 두번째 휠 태그로 롤썰터 빡빡하게 나감
         ### 휠x휠xx가 실전에서는 더 유용하나 쿨뚝 없을시 한 사이클마다 60ms 손해
         ### 휠윈드 직후 스로잉 사용시 태그로 플썰터 안나감
-        ### 휠윈드 직후 어파스 사용시 경직이 심함
         
         # 휠x휠xx
         if BETA_DEALCYCLE == "wheel_throw_wheel_throw_stomp":  # 휠스휠스어


### PR DESCRIPTION
## 제로 신규 딜사이클 (스문스문윈)
이 딜사이클은 수로 점수 향상을 위해 처음 고안되었습니다.
따라서 일부 제약된 조건이 있습니다.
```
1. 리스트레인트링 사용중 사용불가
2. 스로잉 풀히트에 가까운 조건 충족
```

처음 고안된 딜사이클은 스로잉 풀히트가 가능한 수로에 적용하고자 하였습니다.
하지만 스로잉 타수를 기존 딜사이클에 적용되던 5타로 줄였음에도 일부 딜 상승이 확인되었습니다.

딜 사이클은 다음과 같습니다.
- 알파
```
플래시 어썰터 - 스핀 커터 - 문 스트라이크 - 피어스 쓰러스트 - 플래시 어썰터 - 스핀커터 - 문 스트라이크 - 피어스 쓰러스트 - 윈드 커터
```
- 베타
```
터닝 드라이브 - 휠 윈드 - 어퍼 슬래시 - 어드밴스드 파워 스텀프 - 프론트 슬래시 - 어드밴스드 스로잉 웨폰 - 터닝 드라이브 - 휠 윈드 - 어퍼 슬래시 - 어드밴스드 파워 스텀프

터닝 드라이브 - 휠 윈드 - 어퍼 슬래시 - 어드밴스드 파워 스텀프 - 프론트 슬래시 - 어드밴스드 스로잉 웨폰 - 터닝 드라이브 - 휠 윈드 - 프론트 슬래시 - 어드밴스드 스로잉 웨폰
```

베타의 경우 딜 사이클 적용 시 고려해야할 점이 몇가지 있습니다.

1.  휠윈드 직후 스로잉 사용시 태그로 사용되고 있는 롤링어썰터의 알파 위치 문제로 사용되던 스킬이 캔슬되지 않아 다음 태그 동작인 플래시 어썰터가 사용되지 않음
2.  휠xx휠x 의 경우 딜레이 거의 없이 사용해야 두번째 휠윈드의 어시스트인 롤링 어썰트가 사용됨
3.  휠x휠xx 의 경우 두번째 휠 사용 전 쿨타임이 충분히 돌지 않아 약간의 딜레이가 발생함 (1초 이상의 쿨뚝 사용 시 해결가능)

<br>

### 결론

극딜이 아닌 평딜을 넣을때는 스문스문윈이 기존 콤보보다 스로잉 타수에 따라 다르지만 근소 우위에 있음을 확인함

- 이론상 최고의 딜 사이클
알파 : 문피쉐윈 / 스문스문윈 
베타 : 휠어스휠어 / 휠어스휠스

- 실전에 사용할 딜 사이클
알파 : 스톰브문피쉐윈 / 문피쉐윈 / 스문스문윈
베타 : 휠스휠스어 / 휠스휠어 / 휠어휠어스 등 휠x휠xx 의 콤보

<br>

### 정리된 dpm 수치

- 스로잉 5타 기준 여러 딜 사이클의 dpm 비교
https://docs.google.com/spreadsheets/d/e/2PACX-1vRXohFucI1qS98L9Li89cRaNeIs6sRiCiUDO1d3hfSVkiEwlsunPAfg2ZTBU8pTHCQgfYNVrAa8vIDe/pubhtml

- 스로잉 12타 기준 여러 딜 사이클의 dpm 비교
https://docs.google.com/spreadsheets/d/e/2PACX-1vQXqRcwz7QPXf0_B3NL1ITgsnz9dJZffP0oxQrE4MVfAmBni80_VKcCou_OwNb5eEsMO9XWAs0xc5eG/pubhtml