### PR TITLE
Kms 1.2.360 blaster

### DIFF
--- a/dpmModule/jobs/blaster.py
+++ b/dpmModule/jobs/blaster.py
@@ -116,7 +116,7 @@ class JobGenerator(ck.JobGenerator):
 
         DuckingDelay = core.DamageSkill("더킹 딜레이", DUCKING_DELAY, 0, 0, cooltime=-1).wrap(core.DamageSkillWrapper)
         
-        MagnumPunch = core.DamageSkill("매그넘 펀치", 180, 430 + 2*self.combat, 3, modifier = core.CharacterModifier(pdamage = 10, armor_ignore = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
+        MagnumPunch = core.DamageSkill("매그넘 펀치", 180, 75+90+105+205 + 3*self.combat, 3, modifier = core.CharacterModifier(pdamage = 10, armor_ignore = 20)).setV(vEhc, 1, 2, False).wrap(core.DamageSkillWrapper)
         MagnumPunch_Revolve = core.DamageSkill("리볼빙 캐논(매그넘 펀치)", 0, 180 + passive_level, 3).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
         Cylinder = core.StackSkillWrapper(core.BuffSkill("실린더 게이지", 0, 9999999), 6)
@@ -128,7 +128,7 @@ class JobGenerator(ck.JobGenerator):
         ReleaseFileBunker_C = core.DamageSkill("릴리즈 파일 벙커(C)", 0, 270 + passive_level, 6, modifier = core.CharacterModifier(pdamage = 15)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         ReleaseFileBunker_D = core.DamageSkill("릴리즈 파일 벙커(D)", 0, 320 + passive_level, 6, modifier = core.CharacterModifier(pdamage = 15)).setV(vEhc, 0, 2, False).wrap(core.DamageSkillWrapper)
         
-        DoublePang = core.DamageSkill("더블 팡", CANCEL_DELAY, 360 + 2*self.combat, 4, modifier = core.CharacterModifier(pdamage = 10, armor_ignore = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
+        DoublePang = core.DamageSkill("더블 팡", CANCEL_DELAY, 130+90+180 + 2*self.combat, 4, modifier = core.CharacterModifier(pdamage = 10, armor_ignore = 20)).setV(vEhc, 2, 2, False).wrap(core.DamageSkillWrapper)
         DoublePang_Revolve = core.DamageSkill("리볼빙 캐논(더블 팡)", 0, 180 + passive_level, 3).setV(vEhc, 4, 2, False).wrap(core.DamageSkillWrapper)
         
         HammerSmash = core.DamageSkill("해머 스매시", CANCEL_DELAY, 395 + 2*self.combat, 6, modifier = core.CharacterModifier(pdamage = 10, armor_ignore = 20)).setV(vEhc, 3, 2, False).wrap(core.DamageSkillWrapper)


### PR DESCRIPTION
■ 블래스터

- 인듀어런스 트레이닝 II

· 스탠스를 마스터 기준 60% 증가시키는 기능이 추가됩니다.

- 쇼크 웨이브 펀치

· 더블 팡의 데미지 증가량이 마스터 기준 140%p에서 180%p로 증가됩니다.

- 플래시 무브

· 매그넘 펀치의 데미지 증가량이 마스터 기준 160%p에서 205%p로 증가됩니다.

- 리볼빙 벙커

· 재사용 대기시간이 150초에서 120초로 감소됩니다.

· 적을 잡은 뒤 스킬을 한 번 더 입력하면, 적의 행동 불가 상태는 유지되며 캐릭터는 이동할 수 있게 수정됩니다.

----

리볼빙 벙커는 아직 구현하지 않았습니다.